### PR TITLE
Loris kidnap option

### DIFF
--- a/events/giga_014_corrona_rebels.txt
+++ b/events/giga_014_corrona_rebels.txt
@@ -1583,6 +1583,58 @@ country_event = {
 	}
 
 	option = {
+		name = giga_flusionoperations.5000.d #Kidnap him - doesnt die so he cant be revived :kaisersmug:
+		custom_tooltip = "giga_flusionoperations.5000.d.tooltip"
+		allow = {
+			custom_tooltip = { 
+				fail_text = "loris_kidnap_condition"
+				hidden_trigger = {
+					event_target:flusion_primitives_country = {
+						check_variable = {
+							which = solak_resources
+							value >= 6
+						}
+						check_variable = {
+							which = zousa_res
+							value >= 2
+						}
+					}
+				}
+			}
+			custom_tooltip = { 
+				fail_text = "not_genocidal_loris"
+				hidden_trigger = {
+					has_valid_civic = civic_machine_terminator
+					has_valid_civic = civic_hive_devouring_swarm
+					has_valid_civic = civic_fanatic_purifiers
+				}
+			}
+		}
+		hidden_effect = {
+			decrease_solak_resources = yes
+			decrease_solak_resources = yes
+			decrease_solak_resources = yes
+			decrease_solak_resources = yes
+			decrease_solak_resources = yes
+			decrease_solak_resources = yes
+			event_target:flusion_primitives_country = {
+				set_variable = {
+					which = flusion_operation_odds
+					value = flusion_success_chance_total
+				}
+				change_variable = {
+					which = flusion_operation_odds
+					value = 35
+				}
+			}
+			set_global_flag = giga_kidnapping_loris
+			set_global_flag = flusion_special_resistance_operation_ongoing
+			set_country_flag = is_the_country_doing_flusion_op
+			run_flusion_resistance_operation_special = yes
+		}
+	}
+
+	option = {
 		name = giga_katrebels.2010.no #no
 		hidden_effect = {
 			remove_global_flag = flusion_resistance_operation_ongoing
@@ -1594,7 +1646,14 @@ country_event = {
 country_event = {
 	id = giga_flusionoperations.5001
 	title = "giga_flusionoperations.5001.name"
-	desc = "giga_flusionoperations.5001.desc"
+	desc = { 
+		trigger = { NOT = { has_global_flag = giga_kidnapping_loris} }
+		text = "giga_flusionoperations.5001.desc"
+	}
+	desc = { 
+		trigger = { has_global_flag = giga_kidnapping_loris }
+		text = "giga_flusion_operations_5001.desc.kidnap"
+	}
 	is_triggered_only = yes
 	picture = GFX_evt_surrender
 	show_sound = event_planetary_riot
@@ -1814,6 +1873,58 @@ country_event = {
 	option = {
 		name = "giga_flusionoperations.5007.a"
 		custom_tooltip = "giga_flusionoperations.5007.a.tooltip"
+	}
+}
+#Loris Kidnapped - YOU BOZOO THE KAYZOOO WILL COME AND SAVE MEEE (he won't care lol)
+country_event = {
+	id = giga_flusionoperations.5008
+	title = "giga_flusionoperations.5008.name"
+	desc = "giga_flusionoperations.5008.desc"
+	is_triggered_only = yes
+	picture = GFX_evt_cover_blown
+	show_sound = event_super_explosion
+
+	immediate = {
+		increase_katzen_wary = yes
+		increase_katzen_wary = yes
+		increase_katzen_wary = yes
+		update_total_flusion_res_value = yes
+	}
+
+	option = {
+		name = { 
+			trigger = { has_authority = auth_machine_intelligence has_valid_civic = civic_machine_assimilator }
+			text = "giga_flusionoperations.5008.assimilator"
+		}
+		name = "giga_flusionoperations.5008.a"
+		if = { 
+			limit = { NOT = { has_authority = auth_machine_intelligence has_valid_civic = civic_machine_assimilator } } 
+			custom_tooltip = "giga_flusionoperations.5008.a.tooltip" 
+		}
+		if = { 
+			limit = { has_authority = auth_machine_intelligence has_valid_civic = civic_machine_assimilator }
+			custom_tooltip = "giga_flusionoperations.5008.a.tooltip.assimilator" 
+			hidden_effect = { 
+				event_target:flusion_loris = {
+					add_trait = leader_trait_governor_cyborg
+				}
+			}
+		}
+		event_target:flusion_primitives_country = {
+			add_modifier = {
+				modifier = giga_loris_removed_modifier
+				days = -1
+			}
+		}
+		hidden_effect = {
+			event_target:flusion_loris = { unassign_leader = this set_owner = root }
+			remove_global_flag = flusion_special_resistance_operation_ongoing
+			remove_global_flag = flusion_resistance_operation_ongoing
+			remove_country_flag = is_the_country_doing_flusion_op
+			event_target:gigaflusion = { set_planet_flag = loris_removed }
+			set_global_flag = loris_removed #NOOOOOOOOOOOOOOOOOOOOO!!!!!!
+			set_global_flag = loris_kidnapped
+		}
 	}
 }
 
@@ -3146,6 +3257,13 @@ country_event = {
 				}
 				remove_global_flag = giga_blowing_up_loris
 				country_event = { id = giga_flusionoperations.5006 }
+			}
+			if = { #Loris is kidnapped 
+				limit = { 
+					has_global_flag = giga_kidnapping_loris
+				}
+				remove_global_flag = giga_kidnapping_loris
+				country_event = { id = giga_flusionoperations.5008 }
 			}
 		}
 	}

--- a/events/giga_014_corrona_rebels.txt
+++ b/events/giga_014_corrona_rebels.txt
@@ -1604,9 +1604,11 @@ country_event = {
 			custom_tooltip = { 
 				fail_text = "not_genocidal_loris"
 				hidden_trigger = {
-					has_valid_civic = civic_machine_terminator
-					has_valid_civic = civic_hive_devouring_swarm
-					has_valid_civic = civic_fanatic_purifiers
+					NOT = { 
+						has_valid_civic = civic_machine_terminator
+						has_valid_civic = civic_hive_devouring_swarm
+						has_valid_civic = civic_fanatic_purifiers
+					}	
 				}
 			}
 		}

--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -18718,9 +18718,16 @@
     giga_flusionoperations.5006.a:0 "Good riddance."
     giga_flusionoperations.5006.a.tooltip:0 "Yuo are Of Monster...\nKatzen wariness §Rincreases§! by §R3§!.\nResistance in §YGeschwollen§! decreases by §Y2§!."
 
+    giga_flusionoperations.5008.name:0 "Loris Kidnapped!"
+    giga_flusionoperations.5008.desc:0 "Our Solakian Allies report that the operation to kidnap §YLoris Von Kattensbach§! took place without issues. They managed to infiltrate §YLoris's§! home in the night and escaped via wormholes made by Zousanian Partisans to a safehouse and evacuated off planet via shuttle towards [Root.Capital.GetName]. Katzen authorities didnt notice the governor being gone for another 2 weeks, assuming he was just on holiday and forgot to call in, until eventually §YKaiser Kattail§! himself came to §YLoris's§! home to find the governor to find he was no-where to be found. Since then §YGrand General Itch§!, Head of the Katzen Police Force and Internal Peacekeeping, issued a top priority missing persons alert and the Katzen police are actively searching for him but appears our involvement went un-noticed."
+    giga_flusionoperations.5008.a:0 "Excellent, install the brain implants to keep him inline."
+    giga_flusionoperations.5008.assimilator:0 "Excellent, Assimilate him and his knowledge."
+    giga_flusionoperations.5008.a.tooltip:0 "§YLoris Von Kattensbach§! is now available as a governor.\nKatzen wariness §Rincreases§! by §R3§!."
+    giga_flusionoperations.5008.a.tooltip.assimilator:0 "§YLoris Von Kattensbach§! has now been assimilated into the central intelligience and is available as a governing drone.\nKatzen wariness §Rincreases§! by §R3§!."
 
-    giga_flusionoperations.5001.name:0 "Loris Assassination Foiled"
+    giga_flusionoperations.5001.name:0 "Loris Operation Foiled"
     giga_flusionoperations.5001.desc:0 "Our Solakian allies are reporting that our agents sent to assassinate §YLoris Von Kattensbach§! were unfortunately detected and summarily executed before any harm could be done to the Katzgouverneur.\n\nIt seems Loris will get to live another day.\n\nThe success chance was §Y[flusion_primitives_country.flusion_operation_odds]%§!"
+    giga_flusion_operations_5001.desc.kidnap:0 "Our Solakian allies are reporting that our agents sent to kidnap §YLoris Von Kattensbach§! were unfortunately detected and summarily executed before anyone of our agents could reach the Katzgouverneur.\n\nIt seems §YLoris§! will get to live freely another day.\n\nThe success chance was §Y[flusion_primitives_country.flusion_operation_odds]%§!"
     giga_flusionoperations.5001.a:0 "The rat!"
     giga_flusionoperations.5001.a.tooltip:0 "Katzen wariness §Rincreases§! by §R1§!."
 
@@ -18736,6 +18743,11 @@
 
     giga_flusionoperations.5000.c:0 "Blow him up! - 6 §BResistance Resources§! ([flusion_primitives_country.flusion_success_chance_total_3]% chance of success)"
     giga_flusionoperations.5000.c.tooltip:0 "If successful, resistance in §YGeschwollen§! will §Rdecrease§! by §Y2§! as destroying the §YBundeshalle§! will cause significant collateral damage and administrative troubles."
+
+    giga_flusionoperations.5000.d:0 "Kidnap Him! - 6 §BResistance Resources§! ([flusion_primitives_country.flusion_success_chance_total_3]% chance of success)"
+    giga_flusionoperations.5000.d.tooltip:0 "If successful, §YLoris Von Kattensbach§! will be transferred to us as a incredibly competent governor. Just ignore how he talks."
+    loris_kidnap_condition:0 "We need at least 6 §BResistance Resources§! and §SSignificant§! Partisan activity in §YZousa."
+    not_genocidal_loris:0 "We are genocidal, it would be easier to just kill him."
 
     cant_if_loris_soulbot:0 "Loris' new Soulbot chassis is immune to such crude methods."
 

--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -18720,7 +18720,7 @@
 
     giga_flusionoperations.5008.name:0 "Loris Kidnapped!"
     giga_flusionoperations.5008.desc:0 "Our Solakian Allies report that the operation to kidnap §YLoris Von Kattensbach§! took place without issues. They managed to infiltrate §YLoris's§! home in the night and escaped via wormholes made by Zousanian Partisans to a safehouse and evacuated off planet via shuttle towards [Root.Capital.GetName]. Katzen authorities didnt notice the governor being gone for another 2 weeks, assuming he was just on holiday and forgot to call in, until eventually §YKaiser Kattail§! himself came to §YLoris's§! home to find the governor to find he was no-where to be found. Since then §YGrand General Itch§!, Head of the Katzen Police Force and Internal Peacekeeping, issued a top priority missing persons alert and the Katzen police are actively searching for him but appears our involvement went un-noticed."
-    giga_flusionoperations.5008.a:0 "Excellent, install the brain implants to keep him inline."
+    giga_flusionoperations.5008.a:0 "Excellent, install the brain implants to keep him in line."
     giga_flusionoperations.5008.assimilator:0 "Excellent, Assimilate him and his knowledge."
     giga_flusionoperations.5008.a.tooltip:0 "§YLoris Von Kattensbach§! is now available as a governor.\nKatzen wariness §Rincreases§! by §R3§!."
     giga_flusionoperations.5008.a.tooltip.assimilator:0 "§YLoris Von Kattensbach§! has now been assimilated into the central intelligience and is available as a governing drone.\nKatzen wariness §Rincreases§! by §R3§!."


### PR DESCRIPTION
Adds an option to the flusion resistance operations to kidnap loris instead of assassinating him
Requirements/Costs: 
6 Resistance resources (same as detonating the Bundeshalle) 
Significant resistance in Zousa (due to their teleporting abilities making the kidnapping possible)
Also requires you to not be genocidal as you may as well kill him normally as its harder to kidnap

Effects:
If fail, it uses a triggered desc on the "assassination attempt"  to be kidnapping related
If success, it transfers Loris to the player as a governor
if success and also assimilator it gives loris the cybernetic governor trait

ive tested that all parts of the event, only events that were changed were giga_flusionoperations.5000 and giga_flusionoperations.5001, loc fore events has been added into the giga_l_english.yml file