### PR TITLE
Kaiser Uboat Bugfix

### DIFF
--- a/common/component_templates/giga_flusion_weapons.txt
+++ b/common/component_templates/giga_flusion_weapons.txt
@@ -222,6 +222,7 @@ weapon_component_template = {
 	ai_tag_weight = 0
 
 	firing_arc = 70
+
 	min_range = 10
 	
 	damage = { min = 100 max = 210 }
@@ -230,7 +231,7 @@ weapon_component_template = {
 	range = 500
 	accuracy = 1.00
 	tracking = 0.2
-	missile_speed = 70
+	missile_speed = 40 # Reduced from 70 because they were previously too fast to actually properly trigger their hit / redirect / miss check.
 	missile_evasion = 0.10
 	missile_health = 500.0
 	shield_penetration = 1.00


### PR DESCRIPTION
Kaiser's Uboat missiles were too fast previously and could end up staying around after "hitting" their target because of paradox spaghetti code This was bad because it made them VERY laggy in system view as they would continously churn out hit particle effects and it could also confuse strikecraft who would shoot down missiles that should have already hit