### PR TITLE
Handle Ancient Empire mod ringworld upgrades

### DIFF
--- a/common/decisions/giga_decisions.txt
+++ b/common/decisions/giga_decisions.txt
@@ -505,8 +505,7 @@ decision_ringworld_arcology_project = {
 			has_modifier = resort_colony
 			has_modifier = penal_colony
 			has_modifier = slave_colony
-			ag_is_mod_habitable_ringworld = true
-			is_ancient_empire_ringworld_fallback = true
+			ag_is_ancient_ringworld = true
 			has_global_flag = cityring_disabled
 		}
 		is_planet_class = pc_ringworld_habitable
@@ -660,8 +659,7 @@ decision_ringworld_upgrade = {
 		NOR = {
 			has_global_flag = upgrade_disabled
 			has_planet_flag = giga_ringworld_upgraded
-			ag_is_mod_habitable_ringworld = true
-			is_ancient_empire_ringworld_fallback = true
+			ag_is_ancient_ringworld = true
 			is_planet_class = pc_ringworld_shielded
 		}
 		is_planet_class = pc_ringworld_tech

--- a/common/decisions/giga_decisions.txt
+++ b/common/decisions/giga_decisions.txt
@@ -505,6 +505,8 @@ decision_ringworld_arcology_project = {
 			has_modifier = resort_colony
 			has_modifier = penal_colony
 			has_modifier = slave_colony
+			ag_is_mod_habitable_ringworld = true
+			is_ancient_empire_ringworld_fallback = true
 			has_global_flag = cityring_disabled
 		}
 		is_planet_class = pc_ringworld_habitable
@@ -658,10 +660,9 @@ decision_ringworld_upgrade = {
 		NOR = {
 			has_global_flag = upgrade_disabled
 			has_planet_flag = giga_ringworld_upgraded
-			has_planet_flag = ag_ring_habitable_section
-			has_planet_flag = ag_ancient_construction_section_0
-			has_planet_flag = ag_ancient_resource_section_0
-			has_planet_flag = ag_ring_struct_4
+			ag_is_mod_habitable_ringworld = true
+			is_ancient_empire_ringworld_fallback = true
+			is_planet_class = pc_ringworld_shielded
 		}
 		is_planet_class = pc_ringworld_tech
 		solar_system.owner ={ is_same_value = from }

--- a/common/decisions/giga_decisions.txt
+++ b/common/decisions/giga_decisions.txt
@@ -658,6 +658,10 @@ decision_ringworld_upgrade = {
 		NOR = {
 			has_global_flag = upgrade_disabled
 			has_planet_flag = giga_ringworld_upgraded
+			has_planet_flag = ag_ring_habitable_section
+			has_planet_flag = ag_ancient_construction_section_0
+			has_planet_flag = ag_ancient_resource_section_0
+			has_planet_flag = ag_ring_struct_4
 		}
 		is_planet_class = pc_ringworld_tech
 		solar_system.owner ={ is_same_value = from }

--- a/common/decisions/giga_decisions.txt
+++ b/common/decisions/giga_decisions.txt
@@ -659,7 +659,7 @@ decision_ringworld_upgrade = {
 		NOR = {
 			has_global_flag = upgrade_disabled
 			has_planet_flag = giga_ringworld_upgraded
-			ag_is_ancient_ringworld = true
+			ag_is_ancient_ringworld = yes
 			is_planet_class = pc_ringworld_shielded
 		}
 		is_planet_class = pc_ringworld_tech

--- a/common/decisions/giga_decisions.txt
+++ b/common/decisions/giga_decisions.txt
@@ -505,7 +505,7 @@ decision_ringworld_arcology_project = {
 			has_modifier = resort_colony
 			has_modifier = penal_colony
 			has_modifier = slave_colony
-			ag_is_ancient_ringworld = true
+			ag_is_ancient_ringworld = yes
 			has_global_flag = cityring_disabled
 		}
 		is_planet_class = pc_ringworld_habitable

--- a/common/scripted_triggers/00_giga_compat_overwrite_me.txt
+++ b/common/scripted_triggers/00_giga_compat_overwrite_me.txt
@@ -49,21 +49,4 @@ is_pd_hive_arcology= { always = no }
 is_pd_robot_arcology = { always = no }
 
 # Ancient Empire
-is_ancient_empire_ringworld_fallback = {
-	OR = {
-	has_planet_flag = ag_ring_habitable_section
-	has_planet_flag = ag_ancient_construction_section_0
-	has_planet_flag = ag_ancient_resource_section_0
-	has_planet_flag = ag_ring_struct_1
-	has_planet_flag = ag_ring_struct_2
-	has_planet_flag = ag_ring_struct_3
-	has_planet_flag = ag_ring_struct_4
-	has_planet_flag = ag_ring_struct_5
-	has_planet_flag = ag_ring_struct_6
-	has_planet_flag = ag_ring_struct_7
-	has_planet_flag = ag_ring_struct_8
-	has_planet_flag = ag_ring_struct_9
-	has_planet_flag = ag_ring_struct_10
-	has_planet_flag = ag_ring_struct_11
-	}
-}
+ag_is_ancient_ringworld = { always = no }

--- a/common/scripted_triggers/00_giga_compat_overwrite_me.txt
+++ b/common/scripted_triggers/00_giga_compat_overwrite_me.txt
@@ -49,7 +49,7 @@ is_pd_hive_arcology= { always = no }
 is_pd_robot_arcology = { always = no }
 
 # Ancient Empire
-is_ancient_empire_ringworld = {
+is_ancient_empire_ringworld_fallback = {
 	OR = {
 	has_planet_flag = ag_ring_habitable_section
 	has_planet_flag = ag_ancient_construction_section_0

--- a/common/scripted_triggers/00_giga_compat_overwrite_me.txt
+++ b/common/scripted_triggers/00_giga_compat_overwrite_me.txt
@@ -47,3 +47,23 @@ is_pd_ocean = { always = no }
 is_pd_arcology = { always = no }
 is_pd_hive_arcology= { always = no }
 is_pd_robot_arcology = { always = no }
+
+# Ancient Empire
+is_ancient_empire_ringworld = {
+	OR = {
+	has_planet_flag = ag_ring_habitable_section
+	has_planet_flag = ag_ancient_construction_section_0
+	has_planet_flag = ag_ancient_resource_section_0
+	has_planet_flag = ag_ring_struct_1
+	has_planet_flag = ag_ring_struct_2
+	has_planet_flag = ag_ring_struct_3
+	has_planet_flag = ag_ring_struct_4
+	has_planet_flag = ag_ring_struct_5
+	has_planet_flag = ag_ring_struct_6
+	has_planet_flag = ag_ring_struct_7
+	has_planet_flag = ag_ring_struct_8
+	has_planet_flag = ag_ring_struct_9
+	has_planet_flag = ag_ring_struct_10
+	has_planet_flag = ag_ring_struct_11
+	}
+}


### PR DESCRIPTION
An in-built version of compatibility that previously required a patch mod I made back in 2021 - updated to work with current game versions and with a trigger provided by the Ancient Empire mod to determine what segments should not be permitted to upgrade.