### PR TITLE
Fix Fortifier trait description on Admiral 

### DIFF
--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -6009,7 +6009,7 @@
   leader_trait_admiral_farsighted_desc:0 "Imprinted with the overwhelming power of the Psionic Beacon, this Admiral can detect, engage and out-manuever enemies with unprecedented skill."
 
   leader_trait_admiral_fortifier:0 "Fortifier"
-  leader_trait_admiral_fortifier_desc:0 "Imprinted with the overwhelming power of the Psionic Beacon, this Admiral can keep track of all his ships and augment their capabilities by directing Shroud energies."
+  leader_trait_admiral_fortifier_desc:0 "Imprinted with the overwhelming power of the Psionic Beacon, this Admiral can keep track of all the ships in their fleet and augment their capabilities by directing Shroud energies."
 
   purge_sublimate:0 "Sublimation"
 


### PR DESCRIPTION
Fixes loc for English description of the Fortifier trait given to admirals by the Psionic Beacon to not assume the admiral is male.