### PR TITLE
Count Frameworld Decompresspr/Penrose/PCC towards achievements

### DIFF
--- a/events/giga_000_achievements.txt
+++ b/events/giga_000_achievements.txt
@@ -259,6 +259,7 @@ country_event = {
 		from = {
 			OR = {
 				is_megastructure_type = matter_decompressor_4
+				is_megastructure_type = frameworld_decompressor_2
 				is_megastructure_type = matter_decompressor_restored
 			}
 		}
@@ -272,6 +273,7 @@ country_event = {
 					limit = {
 						OR = {
 							is_megastructure_type = matter_decompressor_4
+							is_megastructure_type = frameworld_decompressor_2
 							is_megastructure_type = matter_decompressor_restored
 						}
 					}
@@ -298,6 +300,7 @@ country_event = {
 					limit = {
 						OR = {
 							is_megastructure_type = matter_decompressor_4
+							is_megastructure_type = frameworld_decompressor_2
 							is_megastructure_type = matter_decompressor_restored
 						}
 					}
@@ -322,6 +325,7 @@ country_event = {
 					limit = {
 						OR = {
 							is_megastructure_type = matter_decompressor_4
+							is_megastructure_type = frameworld_decompressor_2
 							is_megastructure_type = matter_decompressor_restored
 						}
 					}
@@ -344,6 +348,7 @@ country_event = {
 					limit = {
 						OR = {
 							is_megastructure_type = matter_decompressor_4
+							is_megastructure_type = frameworld_decompressor_2
 							is_megastructure_type = matter_decompressor_restored
 						}
 					}
@@ -364,6 +369,7 @@ country_event = {
 					limit = {
 						OR = {
 							is_megastructure_type = matter_decompressor_4
+							is_megastructure_type = frameworld_decompressor_2
 							is_megastructure_type = matter_decompressor_restored
 						}
 					}
@@ -733,6 +739,7 @@ country_event = {
 						has_country_flag = giga_achievement_23
 						from = {
 							OR = {
+								is_megastructure_type = frameworld_penrose_2
 								is_megastructure_type = penrose_sphere_b4
 								is_megastructure_type = planetary_computer_2
 								is_megastructure_type = fusion_suppressor_6
@@ -962,6 +969,7 @@ country_event = {
 				has_country_flag = giga_achievement_23
 				OR = {
 					has_megastructure = penrose_sphere_b4
+					has_megastructure = frameworld_penrose_2
 					has_megastructure = planetary_computer_2
 					has_megastructure = fusion_suppressor_6
 					has_megastructure = fusion_suppressor_7
@@ -1037,6 +1045,7 @@ country_event = {
 					any_planet_within_border = {
 						OR = {
 							is_planet_class = pc_giga_planetary_computer
+							has_deposit = d_frameworld_computing_complex
 							has_planet_flag = giga_ringworld_beh
 							is_planet_class = pc_interstellar_ringworld_habitable
 						}
@@ -1241,6 +1250,7 @@ country_event = {
 				has_megastructure = penrose_sphere_b4
 				OR = {
 					has_megastructure = planetary_computer_2
+					any_planet_within_border = { has_deposit = d_frameworld_computing_complex }
 					any_planet_within_border = { is_planet_class = pc_giga_planetary_computer }
 				}
 				OR = {
@@ -1488,6 +1498,7 @@ country_event = {
 				has_megastructure = penrose_sphere_b4
 				OR = {
 					has_megastructure = planetary_computer_2
+					any_planet_within_border = { has_deposit = d_frameworld_computing_complex }
 					any_planet_within_border = { is_planet_class = pc_giga_planetary_computer }
 				}
 				OR = {

--- a/events/giga_000_achievements.txt
+++ b/events/giga_000_achievements.txt
@@ -1045,7 +1045,10 @@ country_event = {
 					any_planet_within_border = {
 						OR = {
 							is_planet_class = pc_giga_planetary_computer
-							has_deposit = d_frameworld_computing_complex
+							AND = {
+								is_planet_class = pc_giga_frameworld
+								has_deposit = d_frameworld_computing_complex
+							}
 							has_planet_flag = giga_ringworld_beh
 							is_planet_class = pc_interstellar_ringworld_habitable
 						}
@@ -1250,8 +1253,15 @@ country_event = {
 				has_megastructure = penrose_sphere_b4
 				OR = {
 					has_megastructure = planetary_computer_2
-					any_planet_within_border = { has_deposit = d_frameworld_computing_complex }
-					any_planet_within_border = { is_planet_class = pc_giga_planetary_computer }
+					any_planet_within_border = { 
+						OR = {
+							AND = {
+								is_planet_class = pc_giga_frameworld
+								has_deposit = d_frameworld_computing_complex
+							}
+							is_planet_class = pc_giga_planetary_computer 
+						}	
+					}
 				}
 				OR = {
 					has_megastructure = fusion_suppressor_6
@@ -1498,8 +1508,15 @@ country_event = {
 				has_megastructure = penrose_sphere_b4
 				OR = {
 					has_megastructure = planetary_computer_2
-					any_planet_within_border = { has_deposit = d_frameworld_computing_complex }
-					any_planet_within_border = { is_planet_class = pc_giga_planetary_computer }
+					any_planet_within_border = {
+						OR = {
+							AND = {
+								is_planet_class = pc_giga_frameworld
+								has_deposit = d_frameworld_computing_complex
+							}
+							is_planet_class = pc_giga_planetary_computer 
+						}	
+					}
 				}
 				OR = {
 					has_megastructure = fusion_suppressor_6


### PR DESCRIPTION
- Adds a check for the deposit created by the Frameworld computing upgrade for the Megastructure Mogul achievement
- Adds a check for the Integrated Matter Decompressor megastructure of the Frameworld for the Black Hole Acquisition achievement chain
- Adds a check for the Integrated Penrose Sphere to count towards Megastructure achievements at the same tier as Stabilized Penrose