### PR TITLE
Update gateway_restored to make Skrand be no longer eternally stuck in subspace

### DIFF
--- a/common/megastructures/zz_b_gateway.txt
+++ b/common/megastructures/zz_b_gateway.txt
@@ -177,10 +177,39 @@ gateway_restored = {
 				finish_upgrade = yes
 			}
 		}
-		from = {
-			country_event = { id = apoc.12 }
-			country_event = { id = apoc.10 }
-			country_event = { id = origin.1050 }
+		if = {
+			limit = { exists = from } #does not always exist when upgraded from script via "finish_upgrade = yes"
+			from = {
+				country_event = { id = origin.1050 }
+				random_list = {
+					98 = { #spawn chance
+						set_country_flag = sharpbeak_known
+						prev = { set_star_flag = sharpbeak_starsystem }
+						fromfrom = {
+							save_global_event_target_as = paragon_gateway_dude_homegate
+							set_megastructure_flag = paragon_gateway_dude_homegate_flag
+						}
+						country_event = { id = paragon.3000 }
+						set_global_flag = gateway_dude_found
+						set_global_flag = sharpbeak_recruit_phase
+						modifier = {
+							factor = 0
+							OR = {
+								has_paragon_dlc = no
+								is_ai = yes
+								has_global_flag = gateway_dude_found
+								NOR = {
+									has_country_flag = gateway_reactivated
+									has_country_flag = gateway_built
+								}
+							}
+						}
+					}
+					2 = {} # no luck
+				}
+				country_event = { id = apoc.12 }
+				country_event = { id = apoc.10 }
+			}
 		}
 	}
 }


### PR DESCRIPTION
This updates (read: Ctrl+CV from vanilla) `on_build_complete` of `gateway_restored` to make Skrand spawn-able again. I am not sure about other megastructure overrides, though.

And Github automatically adds EOL at EOF I guess...