### PR TITLE
Attempts to fix blokkat willingness removal

### DIFF
--- a/events/giga_027_blokkat_expand.txt
+++ b/events/giga_027_blokkat_expand.txt
@@ -336,11 +336,8 @@ country_event = {
 			set_country_flag = giga_decided_to_fight_blokkats
 			remove_country_flag = blokkat_project_underway
 			remove_country_flag = blokkat_willingness_active
-			remove_modifier = giga_blokkat_blokkat_willingness_global
-			remove_modifier = giga_blokkat_blokkat_willingness_military
-			remove_modifier = giga_blokkat_blokkat_willingness_science
-			remove_modifier = giga_blokkat_blokkat_willingness_government
-			remove_modifier = giga_blokkat_blokkat_willingness_population
+			clear_willingness_modifiers = yes
+			remove_country_flag = blokkat_willingness_strikes_active
 			every_owned_leader = { clear_strike_leader_traits = yes }
 		}
 	}
@@ -816,17 +813,14 @@ country_event = {
 		set_name = "CE-1461 Dismantlement Zone"
 		update_blokkat_inquietude_display = yes
 		remove_country_flag = blokkat_willingness_active
-		remove_modifier = giga_blokkat_blokkat_willingness_global
-		remove_modifier = giga_blokkat_blokkat_willingness_military
-		remove_modifier = giga_blokkat_blokkat_willingness_science
-		remove_modifier = giga_blokkat_blokkat_willingness_government
-		remove_modifier = giga_blokkat_blokkat_willingness_population
+		clear_willingness_modifiers = yes
 		remove_country_flag = blokkat_bureau_unlocked
 		remove_country_flag = blokkat_inquietude_taught
 		set_country_flag = giga_ascended_blokkat_country
 		save_global_event_target_as = giga_ascended_blokkat_country
 		set_global_flag = blokkat_crisis_defeated
 		change_species = event_target:diverse_blokkat_species
+		remove_country_flag = blokkat_willingness_strikes_active
 		every_owned_leader = {
 			change_species = event_target:diverse_blokkat_species
 			clear_strike_leader_traits = yes


### PR DESCRIPTION
Due to `giga_blokkat_join.5600` event, which checks for country flag `blokkat_willingness_strikes_active`, blokkat willingness modifiers may reappear via `update_blokkat_willingness_value = yes` even after supposedly disabling the blokkat willingness mechanic, effectively making a zombie mechanic that won't go away. So I removed the flag wherever appropriate.

Also I changed manual modifier removals to `clear_willingness_modifiers = yes` because why not.