### PR TITLE
Fix to missing supertensile upkeep without GPM

### DIFF
--- a/common/scripted_triggers/giga_mega_categories.txt
+++ b/common/scripted_triggers/giga_mega_categories.txt
@@ -696,15 +696,10 @@ gigas_ruined_megas_list = {
 third_party_ruined_megas_list = {
 	[[$CONDITION$]]
 	or = {
-		if = {
-			limit = {
-				has_global_flag = has_guillis_planet_modifiers_mod
-			}
-			$CONDITION$ = gpm_refinery_ruined
-			$CONDITION$ = gpm_mining_facility_ruined
-			$CONDITION$ = gpm_observation_station_ruined
-			$CONDITION$ = gpm_silo_ruined
-		}
+		$CONDITION$ = gpm_refinery_ruined
+		$CONDITION$ = gpm_mining_facility_ruined
+		$CONDITION$ = gpm_observation_station_ruined
+		$CONDITION$ = gpm_silo_ruined
 	}
 }
 


### PR DESCRIPTION
All megas were being considered ruined third party megastructures unless Guilli's Planetary Modifiers was detected due to the if statement logic (if = {limit = {always = no}} will evaluate to true). I've just removed the if block to match the third party technical mega evaluation.

Due to the triggered upkeep modifiers requiring the megastructure not be ruined, without GPM the modifier adding supertensile upkeep wasn't valid for any structure.