### PR TITLE
Prevent people from accidentally declaring war on angry cats when their precious moon with wings attached gets bonked by others into oblivion

### DIFF
--- a/events/giga_012_katzen.txt
+++ b/events/giga_012_katzen.txt
@@ -8870,6 +8870,7 @@ country_event = { #IF MOON IS GONE
 	}
 
 	option = { #oh lol
+		default_hide_option = yes
 		name = "giga_katzen.092.a"
 	}
 }


### PR DESCRIPTION
So, basically, when Kaiservorherrschaft gets destroyed (and subsequently the godforsaken country flag named `kaiser_moon_destroyed` is set) *whilst* the player is not at war, we are greeted with a special diplomacy event `giga_katzen.092` instead of normal, sane `giga_katzen.020`.

You see, that's not the problem. Considering how important that fancy moon with random voidcraft shenanigans is to the Kaiser -- and consequently the empire as a whole -- it isn't very out-of-place to have, let's say, diminished opportunities for diplomacy. With that said, we can still declare war on it, if not we already did that long time ago. So there's that.

But the problem here is that `giga_katzen.092` doesn't have a default cancel option explicitly stated, and the game thinks declaring war on an empire that's already in crisis is the default way to go. You press ESC and you end up declaring war on the angry, angry cats. This is not optimal. I just want it to burn a little more. So I add `default_hide_option = yes` to the "oh lol" option and tell the game that incessant opportunistic warmongering isn't the default way to go.

On another note, the chances of our extremely trustworthy AI empires bonking that moon into oblivion without express player consent are very low. I don't think there will be more than a few person affected by this bugfix.