### PR TITLE
Fix to empty bulwark tradition tooltips

### DIFF
--- a/common/traditions/00_gigabulwark.txt
+++ b/common/traditions/00_gigabulwark.txt
@@ -17,9 +17,7 @@ tr_gigabulwark_happy_defenses = {
 	ai_weight = {
 		factor = 5000	# AI should prefer this one first, more useful early
 	}
-	modifier = {
-		custom_tooltip = tr_gigabulwark_happy_defenses_desc
-	}
+	custom_tooltip = tr_gigabulwark_happy_defenses_desc
 	on_enabled = {
 		every_owned_planet = {
 			limit = { is_giga_maginot_world = yes NOT = { has_modifier = giga_bulwark_trad_stability_maginot } }
@@ -49,9 +47,7 @@ tr_gigabulwark_asteroid_fortresses = {
 	ai_weight = {
 		factor = 5000
 	}
-	modifier = {
-		custom_tooltip = tr_gigabulwark_asteroid_fortresses_desc
-	}
+	custom_tooltip = tr_gigabulwark_asteroid_fortresses_desc
 	on_enabled = {
 		hidden_effect = {
 			change_variable = {
@@ -67,9 +63,7 @@ tr_gigabulwark_enhanced_dockyards = {
 	possible = {
 		has_tradition = tr_gigabulwark_asteroid_fortresses
 	}
-	modifier = {
-		custom_tooltip = tr_gigabulwark_enhanced_dockyards_desc
-	}
+	custom_tooltip = tr_gigabulwark_enhanced_dockyards_desc
 	ai_weight = {
 		factor = 1000
 	}
@@ -81,9 +75,7 @@ tr_gigabulwark_grand_fortifications = {
 		has_tradition = tr_gigabulwark_asteroid_fortresses
 		has_tradition = tr_gigabulwark_happy_defenses
 	}
-	modifier = {
-		custom_tooltip = tr_gigabulwark_grand_fortifications_desc
-	}
+	custom_tooltip = tr_gigabulwark_grand_fortifications_desc
 	ai_weight = {
 		factor = 5000
 	}
@@ -121,9 +113,7 @@ tr_gigabulwark_maginot_protocols = {
 	ai_weight = {
 		factor = 5000
 	}
-	modifier = {
-		custom_tooltip = tr_gigabulwark_maginot_protocols_desc
-	}
+	custom_tooltip = tr_gigabulwark_maginot_protocols_desc
 	on_enabled = {
 		every_owned_planet = {
 			limit = {


### PR DESCRIPTION
Noticed tooltips for Bulwark tradition were empty post 3.9; cause seems to be the custom_tooltip being inside a modifier block