### PR TITLE
Missing scoping on non-priest swaps

### DIFF
--- a/common/inline_scripts/planet/unity/parts/giga_non_priest_swap.txt
+++ b/common/inline_scripts/planet/unity/parts/giga_non_priest_swap.txt
@@ -4,7 +4,7 @@ inline_script = {
 
     jobs = $jobs$
     condition = "
-        is_gestalt = no
+        owner = { is_gestalt = no }
         $condition$
     "
 }
@@ -14,7 +14,7 @@ inline_script = {
 
     jobs = $jobs$
     condition = "
-        is_gestalt = yes
+        owner = { is_gestalt = yes }
         $condition$
     "
 }


### PR DESCRIPTION
One of the new inline scripts was missing scoping, resulting in some weirdness for hives
Not fixed: PCC administrative districts for Rogue Servitors will not produce any jobs