### PR TITLE
Don't offer "Join the Blokkat" option to Elysium Overseers

### DIFF
--- a/events/giga_027_blokkat_expand.txt
+++ b/events/giga_027_blokkat_expand.txt
@@ -51,6 +51,7 @@ country_event = {
 				is_galactic_custodian = yes
 				is_galactic_emperor = yes
 				has_ascension_perk = ap_become_the_crisis
+				has_origin = origin_elysium
 			}
 		}
 	}


### PR DESCRIPTION
Empires with Elysium Overseers origin don't have building slots on their planets, so they can't build Nodes on every planet, which is mandatory to complete the Blokkat challenges.

They can workaround it by spending 400 influence per planet to abandon both planet and Elysium, but most empires are too large for this to be possible.
