### PR TITLE
Fix typo in requirements to reprogram Cooperative Blokkat

### DIFF
--- a/events/giga_021_blokkat.txt
+++ b/events/giga_021_blokkat.txt
@@ -9828,7 +9828,7 @@ country_event = {
 				has_technology = giga_tech_blokkat_reprogram
 				check_variable = {
 					which = blokkat_knowledge_value
-					value >= 40
+					value >= 35
 				}
 			}
 		}


### PR DESCRIPTION
The label says that Cooperative Blokkat requires 35 Blokkat Knowledge.
Number 40 was likely copy-pasted from Indifferent Blokkat code.