### PR TITLE
Added scripted trigger for frame relocation exclusion

### DIFF
--- a/common/scripted_triggers/giga_frameworld_triggers.txt
+++ b/common/scripted_triggers/giga_frameworld_triggers.txt
@@ -252,6 +252,11 @@ giga_frameworld_has_expanded_maintenance_modifier = {
 	}
 }
 
+giga_is_excluded_from_frameworld_resettlement = {
+	or = {
+		is_planet_class = pc_cosmogenesis_world
+	}
+}
 
 ###############################################################################################################
 ###############################################################################################################

--- a/common/scripted_triggers/giga_scripted_triggers.txt
+++ b/common/scripted_triggers/giga_scripted_triggers.txt
@@ -912,7 +912,7 @@ giga_can_resettle_planet = {
 				giga_has_frameworld_origin = yes
 			}
 			nor = {
-				is_planet_class = pc_cosmogenesis_world
+				giga_is_excluded_from_frameworld_resettlement = yes
 				has_planet_flag = giga_frameworld@owner
 			}
 		}
@@ -932,6 +932,12 @@ giga_exclude_planet_from_virtual_growth = {
 	or = {
 		is_planet_class = pc_cosmogenesis_world
 		has_modifier = frameworld_conquered
+	}
+}
+
+giga_is_excluded_from_frameworld_resettlement = {
+	or = {
+		is_planet_class = pc_cosmogenesis_world
 	}
 }
 

--- a/common/scripted_triggers/giga_scripted_triggers.txt
+++ b/common/scripted_triggers/giga_scripted_triggers.txt
@@ -914,6 +914,7 @@ giga_can_resettle_planet = {
 			nor = {
 				giga_is_excluded_from_frameworld_resettlement = yes
 				has_planet_flag = giga_frameworld@owner
+				has_planet_flag = giga_excluded_frameworld_resettlement
 			}
 		}
 		always = no
@@ -932,12 +933,6 @@ giga_exclude_planet_from_virtual_growth = {
 	or = {
 		is_planet_class = pc_cosmogenesis_world
 		has_modifier = frameworld_conquered
-	}
-}
-
-giga_is_excluded_from_frameworld_resettlement = {
-	or = {
-		is_planet_class = pc_cosmogenesis_world
 	}
 }
 

--- a/events/giga_210_origins_frameworld.txt
+++ b/events/giga_210_origins_frameworld.txt
@@ -574,6 +574,7 @@ country_event = {
 				nor = {
 					is_same_value = event_target:target_frameworld
 					giga_is_excluded_from_frameworld_resettlement = yes
+					has_planet_flag = giga_excluded_frameworld_resettlement
 				}
 				has_orbital_bombardment = no
 				is_occupied_flag = no
@@ -1019,6 +1020,7 @@ planet_event = {
 		nor = {
 			has_planet_flag = giga_frameworld@from
 			giga_is_excluded_from_frameworld_resettlement = yes
+			has_planet_flag = giga_excluded_frameworld_resettlement
 		}
 	}
 

--- a/events/giga_210_origins_frameworld.txt
+++ b/events/giga_210_origins_frameworld.txt
@@ -573,7 +573,7 @@ country_event = {
 			limit = {
 				nor = {
 					is_same_value = event_target:target_frameworld
-					is_planet_class = pc_cosmogenesis_world
+					giga_is_excluded_from_frameworld_resettlement = yes
 				}
 				has_orbital_bombardment = no
 				is_occupied_flag = no
@@ -1018,7 +1018,7 @@ planet_event = {
 		}
 		nor = {
 			has_planet_flag = giga_frameworld@from
-			is_planet_class = pc_cosmogenesis_world
+			giga_is_excluded_from_frameworld_resettlement = yes
 		}
 	}
 


### PR DESCRIPTION
Currently, adding a planet to class to ignore frame relocation rules (like in the style of the synaptic lathe) requires overwriting two events in **giga_210_origins_frameworld.txt**.

This is a compatibility issue which makes it harder for modders to add patches.

I've created `giga_is_excluded_from_frameworld_resettlement`, which only contains the synaptic lathe. The 2 frameworld events + 1 scripted trigger which handle resettlement have been updated to use the new scripted trigger.

Importantly, `giga_exclude_planet_from_virtual_growth` has NOT been updated, since modders may want to create a planet type / habitable mega that is usable by a frameworld country, and uses virtual pop mechanics