### PR TITLE
Science Kilo descriptions now mention their required planet types

### DIFF
--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -124,7 +124,7 @@
 
   name_eng_test_site:0 "Macroengineering Testing Station"
   allow_eng_test_site:0 "§HUnlocks Megastructure:§! $name_eng_test_site$"
-  desc_eng_test_site:0 "A large station orbiting a planet to freely conduct engineering experiments."
+  desc_eng_test_site:0 "A large station orbiting a frozen planet to freely conduct engineering experiments."
 
   name_atmosphere_shredder:0 "Atmospheric Storm Observatory"
   allow_atmosphere_shredder:0 "§HUnlocks Megastructure:§! $name_atmosphere_shredder$"
@@ -7146,7 +7146,7 @@
 
   orbital_artificial_eco_0:0 "$gc_kilo$$name_orbital_artificial_eco$: Life Support"
   orbital_artificial_eco_0_DESC:0 "This site will serve as a base to construct an $name_orbital_artificial_eco$, which is a large structure housing a fully artificial ecosystem on which we can experiment freely."
-  orbital_artificial_eco_0_MEGASTRUCTURE_DETAILS:0 "$giga_list_category_kilostructure$ - $giga_list_category_science_production$\nGenerates £society_research£ §YSociety Research§! deposits on system planets.\n§LA station built to house and study a vast number of exotic species of flora and fauna.§!" #megalistentry ORBITAL ARTIFICIAL ECOSYSTEM
+  orbital_artificial_eco_0_MEGASTRUCTURE_DETAILS:0 "$giga_list_category_kilostructure$ - $giga_list_category_science_production$\nGenerates £society_research£ §YSociety Research§! deposits on system planets.\n§LA large station orbiting a toxic planet to house and study a vast number of exotic species of flora and fauna.§!" #megalistentry ORBITAL ARTIFICIAL ECOSYSTEM
 
   orbital_artificial_eco_1:0 "$name_orbital_artificial_eco$: Gene Bank"
   orbital_artificial_eco_1_DESC:0 "A set of external arms to functionally store the genetic information of all the housed species within in the planned $name_orbital_artificial_eco$, so that if any become extinct they can be recovered."

--- a/localisation/english/giga_mega_names_l_english.yml
+++ b/localisation/english/giga_mega_names_l_english.yml
@@ -328,7 +328,7 @@
 
     macro_test_site_0:0 "$gc_kilo$$name_eng_test_site$: Geo-Stabilizer"
     macro_test_site_0_DESC:0 "A large apparatus designed to help the frozen wastes of the planet from being completely destroyed by the constant stress of the magnitude of our planned weapon tests."
-    macro_test_site_0_MEGASTRUCTURE_DETAILS:0 "$giga_list_category_kilostructure$ - $giga_list_category_science_production$\nGenerates £engineering_research£ §YEngineering Research§! and increases §YArmor HP§! by §Y2.5%§!\n§LA large station orbiting a planet to freely conduct engineering-related experiments.§!" #megalistentry MACROENGINEERING TEST SITE
+    macro_test_site_0_MEGASTRUCTURE_DETAILS:0 "$giga_list_category_kilostructure$ - $giga_list_category_science_production$\nGenerates £engineering_research£ §YEngineering Research§! and increases §YArmor HP§! by §Y2.5%§!\n§LA large station orbiting a frozen planet to freely conduct engineering-related experiments.§!" #megalistentry MACROENGINEERING TEST SITE
 
     macro_test_site_1:0 "$name_eng_test_site$: Material Testing Bays"
     macro_test_site_1_DESC:0 "The Testing bays allow for large scale movement of materials and unfinished ships to the testing sites on the planet below, as well as other planets within the system."

--- a/localisation/french/giga_l_french.yml
+++ b/localisation/french/giga_l_french.yml
@@ -124,7 +124,7 @@
   
   name_eng_test_site:99 "Macroengineering Testing Station"
   allow_eng_test_site:99 "§HUnlocks Megastructure:§! $name_eng_test_site$"
-  desc_eng_test_site:99 "A large station orbiting a planet to freely conduct engineering experiments."
+  desc_eng_test_site:99 "A large station orbiting a frozen planet to freely conduct engineering experiments."
   
   name_atmosphere_shredder:99 "Atmospheric Storm Observatory"
   allow_atmosphere_shredder:99 "§HUnlocks Megastructure:§! $name_atmosphere_shredder$"
@@ -7146,7 +7146,7 @@
   
   orbital_artificial_eco_0:99 "$gc_kilo$$name_orbital_artificial_eco$: Life Support"
   orbital_artificial_eco_0_DESC:99 "This site will serve as a base to construct an $name_orbital_artificial_eco$, which is a large structure housing a fully artificial ecosystem on which we can experiment freely."
-  orbital_artificial_eco_0_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_science_production$\nGenerates £society_research£ §YSociety Research§! deposits on system planets.\n§LA station built to house and study a vast number of exotic species of flora and fauna.§!" #megalistentry ORBITAL ARTIFICIAL ECOSYSTEM
+  orbital_artificial_eco_0_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_science_production$\nGenerates £society_research£ §YSociety Research§! deposits on system planets.\n§LA large station orbiting a toxic planet to house and study a vast number of exotic species of flora and fauna.§!" #megalistentry ORBITAL ARTIFICIAL ECOSYSTEM
   
   orbital_artificial_eco_1:99 "$name_orbital_artificial_eco$: Gene Bank"
   orbital_artificial_eco_1_DESC:99 "A set of external arms to functionally store the genetic information of all the housed species within in the planned $name_orbital_artificial_eco$, so that if any become extinct they can be recovered."

--- a/localisation/french/giga_mega_names_l_french.yml
+++ b/localisation/french/giga_mega_names_l_french.yml
@@ -328,7 +328,7 @@
   
   macro_test_site_0:99 "$gc_kilo$$name_eng_test_site$: Geo-Stabilizer"
   macro_test_site_0_DESC:99 "A large apparatus designed to help the frozen wastes of the planet from being completely destroyed by the constant stress of the magnitude of our planned weapon tests."
-  macro_test_site_0_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_science_production$\nGenerates £engineering_research£ §YEngineering Research§! and increases §YArmor HP§! by §Y2.5%§!\n§LA large station orbiting a planet to freely conduct engineering-related experiments.§!" #megalistentry MACROENGINEERING TEST SITE
+  macro_test_site_0_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_science_production$\nGenerates £engineering_research£ §YEngineering Research§! and increases §YArmor HP§! by §Y2.5%§!\n§LA large station orbiting a frozen planet to freely conduct engineering-related experiments.§!" #megalistentry MACROENGINEERING TEST SITE
   
   macro_test_site_1:99 "$name_eng_test_site$: Material Testing Bays"
   macro_test_site_1_DESC:99 "The Testing bays allow for large scale movement of materials and unfinished ships to the testing sites on the planet below, as well as other planets within the system."

--- a/localisation/german/giga_l_german.yml
+++ b/localisation/german/giga_l_german.yml
@@ -124,7 +124,7 @@
   
   name_eng_test_site:99 "Macroengineering Testing Station"
   allow_eng_test_site:99 "§HUnlocks Megastructure:§! $name_eng_test_site$"
-  desc_eng_test_site:99 "A large station orbiting a planet to freely conduct engineering experiments."
+  desc_eng_test_site:99 "A large station orbiting a frozen planet to freely conduct engineering experiments."
   
   name_atmosphere_shredder:99 "Atmospheric Storm Observatory"
   allow_atmosphere_shredder:99 "§HUnlocks Megastructure:§! $name_atmosphere_shredder$"
@@ -7146,7 +7146,7 @@
   
   orbital_artificial_eco_0:99 "$gc_kilo$$name_orbital_artificial_eco$: Life Support"
   orbital_artificial_eco_0_DESC:99 "This site will serve as a base to construct an $name_orbital_artificial_eco$, which is a large structure housing a fully artificial ecosystem on which we can experiment freely."
-  orbital_artificial_eco_0_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_science_production$\nGenerates £society_research£ §YSociety Research§! deposits on system planets.\n§LA station built to house and study a vast number of exotic species of flora and fauna.§!" #megalistentry ORBITAL ARTIFICIAL ECOSYSTEM
+  orbital_artificial_eco_0_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_science_production$\nGenerates £society_research£ §YSociety Research§! deposits on system planets.\n§LA large station orbiting a toxic planet to house and study a vast number of exotic species of flora and fauna.§!" #megalistentry ORBITAL ARTIFICIAL ECOSYSTEM
   
   orbital_artificial_eco_1:99 "$name_orbital_artificial_eco$: Gene Bank"
   orbital_artificial_eco_1_DESC:99 "A set of external arms to functionally store the genetic information of all the housed species within in the planned $name_orbital_artificial_eco$, so that if any become extinct they can be recovered."

--- a/localisation/german/giga_mega_names_l_german.yml
+++ b/localisation/german/giga_mega_names_l_german.yml
@@ -328,7 +328,7 @@
   
   macro_test_site_0:99 "$gc_kilo$$name_eng_test_site$: Geo-Stabilizer"
   macro_test_site_0_DESC:99 "A large apparatus designed to help the frozen wastes of the planet from being completely destroyed by the constant stress of the magnitude of our planned weapon tests."
-  macro_test_site_0_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_science_production$\nGenerates £engineering_research£ §YEngineering Research§! and increases §YArmor HP§! by §Y2.5%§!\n§LA large station orbiting a planet to freely conduct engineering-related experiments.§!" #megalistentry MACROENGINEERING TEST SITE
+  macro_test_site_0_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_science_production$\nGenerates £engineering_research£ §YEngineering Research§! and increases §YArmor HP§! by §Y2.5%§!\n§LA large station orbiting a frozen planet to freely conduct engineering-related experiments.§!" #megalistentry MACROENGINEERING TEST SITE
   
   macro_test_site_1:99 "$name_eng_test_site$: Material Testing Bays"
   macro_test_site_1_DESC:99 "The Testing bays allow for large scale movement of materials and unfinished ships to the testing sites on the planet below, as well as other planets within the system."

--- a/localisation/polish/giga_l_polish.yml
+++ b/localisation/polish/giga_l_polish.yml
@@ -124,7 +124,7 @@
   
   name_eng_test_site:99 "Macroengineering Testing Station"
   allow_eng_test_site:99 "§HUnlocks Megastructure:§! $name_eng_test_site$"
-  desc_eng_test_site:99 "A large station orbiting a planet to freely conduct engineering experiments."
+  desc_eng_test_site:99 "A large station orbiting a frozen planet to freely conduct engineering experiments."
   
   name_atmosphere_shredder:99 "Atmospheric Storm Observatory"
   allow_atmosphere_shredder:99 "§HUnlocks Megastructure:§! $name_atmosphere_shredder$"
@@ -7146,7 +7146,7 @@
   
   orbital_artificial_eco_0:99 "$gc_kilo$$name_orbital_artificial_eco$: Life Support"
   orbital_artificial_eco_0_DESC:99 "This site will serve as a base to construct an $name_orbital_artificial_eco$, which is a large structure housing a fully artificial ecosystem on which we can experiment freely."
-  orbital_artificial_eco_0_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_science_production$\nGenerates £society_research£ §YSociety Research§! deposits on system planets.\n§LA station built to house and study a vast number of exotic species of flora and fauna.§!" #megalistentry ORBITAL ARTIFICIAL ECOSYSTEM
+  orbital_artificial_eco_0_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_science_production$\nGenerates £society_research£ §YSociety Research§! deposits on system planets.\n§LA large station orbiting a toxic planet to house and study a vast number of exotic species of flora and fauna.§!" #megalistentry ORBITAL ARTIFICIAL ECOSYSTEM
   
   orbital_artificial_eco_1:99 "$name_orbital_artificial_eco$: Gene Bank"
   orbital_artificial_eco_1_DESC:99 "A set of external arms to functionally store the genetic information of all the housed species within in the planned $name_orbital_artificial_eco$, so that if any become extinct they can be recovered."

--- a/localisation/polish/giga_mega_names_l_polish.yml
+++ b/localisation/polish/giga_mega_names_l_polish.yml
@@ -328,7 +328,7 @@
   
   macro_test_site_0:99 "$gc_kilo$$name_eng_test_site$: Geo-Stabilizer"
   macro_test_site_0_DESC:99 "A large apparatus designed to help the frozen wastes of the planet from being completely destroyed by the constant stress of the magnitude of our planned weapon tests."
-  macro_test_site_0_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_science_production$\nGenerates £engineering_research£ §YEngineering Research§! and increases §YArmor HP§! by §Y2.5%§!\n§LA large station orbiting a planet to freely conduct engineering-related experiments.§!" #megalistentry MACROENGINEERING TEST SITE
+  macro_test_site_0_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_science_production$\nGenerates £engineering_research£ §YEngineering Research§! and increases §YArmor HP§! by §Y2.5%§!\n§LA large station orbiting a frozen planet to freely conduct engineering-related experiments.§!" #megalistentry MACROENGINEERING TEST SITE
   
   macro_test_site_1:99 "$name_eng_test_site$: Material Testing Bays"
   macro_test_site_1_DESC:99 "The Testing bays allow for large scale movement of materials and unfinished ships to the testing sites on the planet below, as well as other planets within the system."

--- a/localisation/simp_chinese/giga_l_simp_chinese.yml
+++ b/localisation/simp_chinese/giga_l_simp_chinese.yml
@@ -124,7 +124,7 @@
   
   name_eng_test_site:0 "大型工程测试站"
   allow_eng_test_site:0 "§H解锁巨型建筑：§!$name_eng_test_site$"
-  desc_eng_test_site:0 "一个位于行星轨道的巨大空间站，以供自由实施工程实验。"
+  desc_eng_test_site:0 "一个位于冰冻行星轨道的巨大空间站，以供自由实施工程实验。"
   
   name_atmosphere_shredder:99 "Atmospheric Storm Observatory"
   allow_atmosphere_shredder:99 "§HUnlocks Megastructure:§! $name_atmosphere_shredder$"
@@ -149,7 +149,7 @@
   
   name_orbital_artificial_eco:0 "轨道人工生态系统"
   allow_orbital_artificial_eco:0 "§H解锁巨型建筑：§!$name_orbital_artificial_eco$"
-  desc_orbital_artificial_eco:0 "一个非常大的站点，里面有一个完全人造的生态系统以供研究自然。"
+  desc_orbital_artificial_eco:0 "一个位于剧毒行星轨道的巨大空间站，里面有一个完全人造的生态系统以供研究自然。"
   
   name_neut_gigaforge:0 "千兆零素锻造厂"
   allow_neut_gigaforge:0 "§H解锁巨型建筑：§!$name_neut_gigaforge$"

--- a/localisation/simp_chinese/giga_mega_names_l_simp_chinese.yml
+++ b/localisation/simp_chinese/giga_mega_names_l_simp_chinese.yml
@@ -328,7 +328,7 @@
   
   macro_test_site_0:0 "$gc_kilo$$name_eng_test_site$基址"
   macro_test_site_0_DESC:0 "一个大型建造基地，容纳了建造大型工程测试站需要的所有材料，该建筑可以让我们在下方的星球上进行各种工程相关实验。"
-  macro_test_site_0_MEGASTRUCTURE_DETAILS:0 "$giga_list_category_kilostructure$——$giga_list_category_science_production$\n产生£engineering_research£§Y研究点数§!并使§Y装甲值§!提升§Y2.5%§!\n§L一个围绕行星运行的大型空间站，可以自由进行工程实验。§!" #megalistentry MACROENGINEERING TEST SITE
+  macro_test_site_0_MEGASTRUCTURE_DETAILS:0 "$giga_list_category_kilostructure$——$giga_list_category_science_production$\n产生£engineering_research£§Y研究点数§!并使§Y装甲值§!提升§Y2.5%§!\n§L一个围绕冰冻行星运行的大型空间站，可以自由进行工程实验。§!" #megalistentry MACROENGINEERING TEST SITE
   
   macro_test_site_1:0 "$name_eng_test_site$"
   macro_test_site_1_DESC:0 "该空间站配备了许多科学实验室以及建筑设施，使我们能在下方星球进行与工程研究有关的各种试验。"


### PR DESCRIPTION
Was very confused why I can't build the new science kilos on barren worlds (old science kilos can do that). Turns out, science kilos now require specific planet types, but I have missed this detail, and the descriptions did not mention anything about this.

Interestingly, the descriptions of the physics science kilo Atmospheric Storm Observatory already correctly mention gas giants.

This PR modifies the descriptions of 2 science kilos (Macroengineering Testing Site and Orbital Artificial Ecosystem), to mention the planet type requirements.

Should have no problems merging.

------

Remaining languages to check:

- [x] English
- [ ] Brazilian Portuguese
- [x] French (placeholder)
- [x] German (placeholder)
- [x] Polish (placeholder)
- [ ] Russian
- [x] Simplified Chinese
- [ ] Spanish