### PR TITLE
Toggle to use Machines & Robots Expac rules in orbital ring placement rules

### DIFF
--- a/common/megastructures/zz_b_orbital_ring.txt
+++ b/common/megastructures/zz_b_orbital_ring.txt
@@ -124,11 +124,31 @@ orbital_ring = {
 					has_planet_flag = has_orbital_debris
 				}
 			}
-			if = {
-				limit = {
-					from = { is_ai = yes }
+			OR = {
+				# Machines & Robot Expac: Continued checks will be here
+				inline_script = {
+					script = generic_parts/giga_toggled_code
+					code = "
+					AND = {
+						oxr_mdlc_is_planet_world_machine = yes
+						exists = owner
+						owner = {
+							OR = {
+								has_xvcv_mdlc_ap_world_machines = yes
+								has_oxr_mdlc_origin_world_machine_awakened = yes
+							}
+						}
+					}
+					"
+					toggle = @oxr_mdlc_mod
 				}
-				num_pops >= 25
+				# Vanilla
+				if = {
+					limit = {
+						from = { is_ai = yes }
+					}
+					num_pops >= 25
+				}
 			}
 		}
 	}

--- a/common/scripted_variables/zz_giga_compat_overwrite_me.txt
+++ b/common/scripted_variables/zz_giga_compat_overwrite_me.txt
@@ -12,4 +12,8 @@
 # Planetary Diversity
 @has_planetary_diversity = 0
 
+# Machines & Robot Expansion: Continued
+@oxr_mdlc_mod = 0
+
+
 # EOF


### PR DESCRIPTION
Hello, I am maintaining & developing the Machines & Robots Expansion: Continued mod. I recently added a (as-popless-as-possible) origin revolving around automated machine worlds.

Because players with the origin (called World Machines, Awakened) don't have sufficient pops to build the orbital ring by the rules of the base game, I'd like to propose a small code change to support using rules from MRE:C in the orbital ring placement rules block.