### PR TITLE
FE Planetcraft no longer use the Attack Moon laser

### DIFF
--- a/common/global_ship_designs/giga_fe_ships.txt
+++ b/common/global_ship_designs/giga_fe_ships.txt
@@ -80,7 +80,7 @@ ship_design = {
 	section = {
 		template = "ancient_holy_behemoth_ship_mid_01_key"
 		slot = "mid"
-		component = { slot = "TITANIC_GUN_01"		template = "GIGA_OMEGA_LANCE_1" }
+		component = { slot = "TITANIC_GUN_01"		template = "GIGA_SUPER_OMEGA_LANCE_1" }
 		component = { slot = "TITANIC_GUN_02"		template = "GIGA_PLANET_MISSILE_1" }
 		component = { slot = "TITANIC_GUN_03"		template = "GIGA_PLANET_MISSILE_1" }
 		component = { slot = "TITANIC_GUN_04"		template = "GIGA_PLANET_MISSILE_1" }
@@ -136,7 +136,7 @@ ship_design = {
 	section = {
 		template = "ancient_behemoth_ship_mid_01_key"
 		slot = "mid"
-		component = { slot = "TITANIC_GUN_01"		template = "GIGA_OMEGA_LANCE_1" }
+		component = { slot = "TITANIC_GUN_01"		template = "GIGA_SUPER_OMEGA_LANCE_1" }
 		component = { slot = "TITANIC_GUN_02"		template = "GIGA_PLANET_MISSILE_1" }
 		component = { slot = "TITANIC_GUN_03"		template = "GIGA_PLANET_MISSILE_1" }
 		component = { slot = "TITANIC_GUN_04"		template = "GIGA_PLANET_MISSILE_1" }


### PR DESCRIPTION
Previously, FE planetcraft spawned with the Attack Moon's lance instead of the Planetcraft one, making them far weaker against player planetcraft or systemcraft than they normally would be. This makes them use the correct component.