### PR TITLE
Updated names of missing Lux Aeternum components

### DIFF
--- a/common/component_templates/zzz_acot_placeholder_components.txt
+++ b/common/component_templates/zzz_acot_placeholder_components.txt
@@ -251,7 +251,7 @@ weapon_component_template = {
 
 #Core Components
 utility_component_template = {
-	key = "OE_SENSOR_SHIP"
+	key = "ACOT_SENSOR_OE"
 	size = small
 	icon = "GFX_qnm_thruster"
 	icon_frame = 1
@@ -265,7 +265,7 @@ utility_component_template = {
 	}
 }
 utility_component_template = {
-	key = "LIGHT_MATTER_REACTOR_OE"
+	key = "DARK_MATTER_REACTOR_OE"
 	size = small
 	icon = "GFX_qnm_thruster"
 	icon_frame = 1
@@ -279,7 +279,7 @@ utility_component_template = {
 	}
 }
 utility_component_template = {
-	key = "STELLARITE_DRIVE_OE"
+	key = "ACOT_ENIGMATIC_DRIVE_OE"
 	size = small
 	icon = "GFX_qnm_thruster"
 	icon_frame = 1
@@ -293,7 +293,7 @@ utility_component_template = {
 	}
 }
 utility_component_template = {
-	key = "SHIP_THRUSTER_OE"
+	key = "ACOT_SHIP_THRUSTER_OE"
 	size = small
 	icon = "GFX_qnm_thruster"
 	icon_frame = 1
@@ -419,7 +419,7 @@ utility_component_template = {
 	}
 }
 utility_component_template = {
-	key = "ACOT_AURA_HYPERJUMPDRIVE_OE"
+	key = "ACOT_HYPERCHARGED_JUMPER_AURA_OE"
 	size = small
 	icon = "GFX_qnm_thruster"
 	icon_frame = 1

--- a/common/global_ship_designs/giga_aeternum_acot.txt
+++ b/common/global_ship_designs/giga_aeternum_acot.txt
@@ -16,10 +16,10 @@ ship_design = {
 	}
 
 	required_component = "OE_OFFENSIVE_COMBAT_COMPUTER"
-	required_component = "OE_SENSOR_SHIP"
-	required_component = "LIGHT_MATTER_REACTOR_OE"
-	required_component = "STELLARITE_DRIVE_OE"
-	required_component = "SHIP_THRUSTER_OE"
+	required_component = "ACOT_SENSOR_OE"
+	required_component = "DARK_MATTER_REACTOR_OE"
+	required_component = "ACOT_ENIGMATIC_DRIVE_OE"
+	required_component = "ACOT_SHIP_THRUSTER_OE"
 }
 
 ship_design = {
@@ -50,10 +50,10 @@ ship_design = {
 	}
 
 	required_component = "OE_OFFENSIVE_COMBAT_COMPUTER_BATTLECRUISER"
-	required_component = "OE_SENSOR_SHIP"
-	required_component = "LIGHT_MATTER_REACTOR_OE"
-	required_component = "STELLARITE_DRIVE_OE"
-	required_component = "SHIP_THRUSTER_OE"
+	required_component = "ACOT_SENSOR_OE"
+	required_component = "DARK_MATTER_REACTOR_OE"
+	required_component = "ACOT_ENIGMATIC_DRIVE_OE"
+	required_component = "ACOT_SHIP_THRUSTER_OE"
 }
 
 ship_design = {
@@ -92,10 +92,10 @@ ship_design = {
 	}
 
 	required_component = "OE_OFFENSIVE_COMBAT_COMPUTER_BATTLECRUISER"
-	required_component = "OE_SENSOR_SHIP"
-	required_component = "LIGHT_MATTER_REACTOR_OE"
-	required_component = "STELLARITE_DRIVE_OE"
-	required_component = "SHIP_THRUSTER_OE"
+	required_component = "ACOT_SENSOR_OE"
+	required_component = "DARK_MATTER_REACTOR_OE"
+	required_component = "ACOT_ENIGMATIC_DRIVE_OE"
+	required_component = "ACOT_SHIP_THRUSTER_OE"
 }
 
 ship_design = {
@@ -163,10 +163,10 @@ ship_design = {
 	}
 
 	required_component = "OE_OFFENSIVE_COMBAT_COMPUTER_BATTLECRUISER"
-	required_component = "OE_SENSOR_SHIP"
-	required_component = "LIGHT_MATTER_REACTOR_OE"
-	required_component = "STELLARITE_DRIVE_OE"
-	required_component = "SHIP_THRUSTER_OE"
+	required_component = "ACOT_SENSOR_OE"
+	required_component = "DARK_MATTER_REACTOR_OE"
+	required_component = "ACOT_ENIGMATIC_DRIVE_OE"
+	required_component = "ACOT_SHIP_THRUSTER_OE"
 }
 
 ship_design = {
@@ -238,10 +238,10 @@ ship_design = {
 	}
 
 	required_component = "OE_OFFENSIVE_COMBAT_COMPUTER_BATTLECRUISER"
-	required_component = "OE_SENSOR_SHIP"
-	required_component = "LIGHT_MATTER_REACTOR_OE"
-	required_component = "STELLARITE_DRIVE_OE"
-	required_component = "SHIP_THRUSTER_OE"
+	required_component = "ACOT_SENSOR_OE"
+	required_component = "DARK_MATTER_REACTOR_OE"
+	required_component = "ACOT_ENIGMATIC_DRIVE_OE"
+	required_component = "ACOT_SHIP_THRUSTER_OE"
 }
 
 ship_design = {
@@ -320,9 +320,9 @@ ship_design = {
 			template = "ACOT_SHIELD_BOOSTER_OE"
 		}
 	}
-	required_component="OE_SENSOR_SHIP"
+	required_component="ACOT_SENSOR_OE"
 	required_component="OE_PLATFORM_DEFENSIVE_COMBAT_COMPUTER"
-	required_component="LIGHT_MATTER_REACTOR_OE"
+	required_component="DARK_MATTER_REACTOR_OE"
 }
 ship_design = {
 	name = "Valistus-Suojelija"
@@ -389,8 +389,8 @@ ship_design = {
 		component = { slot = "AUX_UTILITY_1" template = "ACOT_SHIELD_BOOSTER_OE" }
 	}
 
-	required_component = "LIGHT_MATTER_REACTOR_OE"
-	required_component = "OE_SENSOR_SHIP"
+	required_component = "DARK_MATTER_REACTOR_OE"
+	required_component = "ACOT_SENSOR_OE"
 	required_component = "OE_PLATFORM_DEFENSIVE_COMBAT_COMPUTER"
 	required_component = "STARBASE_AURA_FTL_INHIBITOR"
 }
@@ -431,8 +431,8 @@ ship_design = {
 	}
 
 	required_component = "OE_OFFENSIVE_COMBAT_COMPUTER"
-	required_component = "OE_SENSOR_SHIP"
-	required_component = "LIGHT_MATTER_REACTOR_OE"
+	required_component = "ACOT_SENSOR_OE"
+	required_component = "DARK_MATTER_REACTOR_OE"
 }
 
 ship_design = {
@@ -482,10 +482,10 @@ ship_design = {
 	}
 
 	required_component = "BASE_COMBAT_COMPUTER_COLOSSUS_OE"
-	required_component = "OE_SENSOR_SHIP"
-	required_component = "LIGHT_MATTER_REACTOR_OE"
-	required_component = "STELLARITE_DRIVE_OE"
-	required_component = "SHIP_THRUSTER_OE"
+	required_component = "ACOT_SENSOR_OE"
+	required_component = "DARK_MATTER_REACTOR_OE"
+	required_component = "ACOT_ENIGMATIC_DRIVE_OE"
+	required_component = "ACOT_SHIP_THRUSTER_OE"
 }
 
 #herc (lol)
@@ -766,6 +766,6 @@ ship_design = {
 	required_component = "ACOT_HERCULEAN_FTL_E7"
 	required_component = "ACOT_TACTIC_MAX_STATIOANRY"
 	required_component = "ACOT_AURA_TECH_INHIBITOR_OE"
-	required_component = "ACOT_AURA_HYPERJUMPDRIVE_OE" 
+	required_component = "ACOT_HYPERCHARGED_JUMPER_AURA_OE" 
 	required_component = "ACOT_AURA_SUPERAURA_OE"
 }


### PR DESCRIPTION
ACOT changed the names of several components, causing Lux Aeternum to use nonfunctional placeholders. This fixes the names so they use the real ones again.