### PR TITLE
Fixed machine ringworld habitability (silly way)

### DIFF
--- a/common/game_rules/giga_rules.txt
+++ b/common/game_rules/giga_rules.txt
@@ -440,3 +440,67 @@ can_resettle_planet_no_owner_check = {
 
 	giga_can_resettle_planet = yes
 }
+
+# overwrite for machine ringworld
+species_can_live_on_planet = {
+	hidden_trigger = {
+		exists = root #somehow this appeared in the error log. No idea how!
+		NAND = {
+			root = { 
+				OR = {
+					is_planet_class = pc_machine 
+					is_planet_class = pc_ringworld_machine 
+				}
+			}
+			NOR = {
+				has_trait = trait_machine_unit
+				has_trait = trait_mechanical
+				AND = {
+					has_trait = trait_cybernetic
+					exists = root.owner
+					root.owner = {
+						is_machine_empire = yes
+						OR = {
+							has_civic = civic_machine_assimilator # Assimilator empire
+							has_ascension_perk = ap_mechromancy
+						}
+					}
+				}
+			}
+		}
+		if = {
+			limit = {
+				root = { is_planet_class = pc_hive }
+			}
+			OR = {
+				has_trait = trait_hive_mind
+				AND = { #Necrophage Hive Mind can have Necrophytes
+					exists = root.owner
+					root.owner = {
+						is_hive_empire = yes
+						has_origin = origin_necrophage
+						prev = { species_can_be_necrophaged = yes }
+					}
+				}
+			}
+		}
+	}
+	if = {
+		limit = {
+			exists = root.owner
+			root.owner = {
+				has_origin = origin_clone_army
+			}
+			OR = {
+				has_trait = trait_clone_soldier_infertile
+				has_trait = trait_clone_soldier_infertile_full_potential
+			}
+		}
+		custom_tooltip = {
+			fail_text = CLONE_ARMY_FORCE_DECLINE
+			root = {
+				check_variable = { which = clone_pops_missing value >= 0 }
+			}
+		}
+	}
+}

--- a/common/planet_classes/giga_city_rings.txt
+++ b/common/planet_classes/giga_city_rings.txt
@@ -51,6 +51,7 @@ pc_ringworld_machine = {
 	planet_size = 10
 	moon_size = 1
 	colonizable = yes
+	ideal = yes
 	starting_planet = no
 	orbit_lines = no
 	has_colonization_influence_cost = no


### PR DESCRIPTION
Machine ringworlds don't offer perfect habitability for machines (and related) due to a sensible unwillingness to overwrite the entirety of `01_species_traits_habitability` just to align machine/ringworld preferences. This issue can be rectified much more cleanly by overwriting the `species_can_live_on_planet` game rule to check machine ringworlds in addition to machine worlds, which mirrors the inhabitability behavior of machine worlds to their ring counterpart (can only be inhabited by machines, cyborgs, etc.), and the machine ringworld can safely be set as ideal again without encountering undesirable behavior.

I know Gigas isn't particularly fond of vanilla overwrites, but I figured that since it's already overwriting several game rules, one more wouldn't be _that_ bad. It's probably better to do it this way than a monthly pulse that applies an effect to all machine (and related) species, or something scary like that.

An aside: Merger of Rules also essentially does the same change to this game rule (in a more encompassing fashion) by checking `merg_is_machine_world`, which includes machine ringworlds.