### PR TITLE
Fixed swarms being valid for Realspace O Class stars

### DIFF
--- a/common/megastructures/zz_c_dyson_swarm.txt
+++ b/common/megastructures/zz_c_dyson_swarm.txt
@@ -130,7 +130,7 @@ dyson_swarm_1 = {
 			custom_tooltip = {
 				fail_text = "requires_standard_star_class"
 				giga_is_standard_star_system = yes
-				NOT = { is_planet_class = pc_giga_o_star }
+				giga_is_o_star_for_megas = no
 			}
 			if = {
 				limit = {


### PR DESCRIPTION
Would've thought that the giga_is_standard_star_system check would restrict O class stars of all types but Realspace O Class stars are included in that trigger, not sure if that's intended but I imagine it may be necessary for certain other megas to function so the giga_is_o_star_for_megas check will do