### PR TITLE
planetary defense nexus army spawning

### DIFF
--- a/events/giga_001_mega_events.txt
+++ b/events/giga_001_mega_events.txt
@@ -2442,7 +2442,7 @@ planet_event = {
 			}
 			divide_variable = {
 				which = giga_nexus_army_count
-				value = 10
+				value = 1000
 			}
 			ceiling_variable = giga_nexus_army_count
 			while = {


### PR DESCRIPTION
fixed planetary defense nexus spawning too many armies from pops