### PR TITLE
Aeternum core shuffle spawn fix

### DIFF
--- a/events/giga_001_mega_events.txt
+++ b/events/giga_001_mega_events.txt
@@ -1030,7 +1030,51 @@ country_event = {
 				# Quasar
 				1 = { no_scope = { spawn_system = { min_distance >= 0 max_distance <= 0 min_orientation_angle = 44 max_orientation_angle = 46 initializer = "giga_black_hole_quasar_initializer"	hyperlane = no  authorize_spawn_on_galactic_core = yes } } }
 				# Aeternum
-				1 = { no_scope = { spawn_system = { min_distance >= 0 max_distance <= 0 min_orientation_angle = 44 max_orientation_angle = 46 initializer = "giga_black_hole_aeternum_initializer"	hyperlane = no  authorize_spawn_on_galactic_core = yes } } }
+				1 = { no_scope = { spawn_system = { min_distance >= 0 max_distance <= 0 min_orientation_angle = 44 max_orientation_angle = 46 initializer = "giga_black_hole_aeternum_initializer"	hyperlane = no  authorize_spawn_on_galactic_core = yes } }
+					set_global_flag = giga_core_shuffle_spawned_aeternum
+					event_target:giga_core_system = {
+						every_country = {
+							limit = { is_ai = no }
+							country_event = { id = giga_aeternum.2010 days = 30 }
+						}
+						spawn_system = { min_distance >= 15	max_distance <= 15	min_orientation_angle = 90	max_orientation_angle = 90	initializer = "giga_inner_1_aeternum_initializer"	hyperlane = no }
+						spawn_system = { min_distance >= 15	max_distance <= 15	min_orientation_angle = 150	max_orientation_angle = 150	initializer = "giga_inner_2_aeternum_initializer"	hyperlane = no }
+						spawn_system = { min_distance >= 15	max_distance <= 15	min_orientation_angle = 210	max_orientation_angle = 210	initializer = "giga_inner_3_aeternum_initializer"	hyperlane = no }
+						spawn_system = { min_distance >= 15	max_distance <= 15	min_orientation_angle = 270	max_orientation_angle = 270	initializer = "giga_inner_4_aeternum_initializer"	hyperlane = no }
+						spawn_system = { min_distance >= 15	max_distance <= 15	min_orientation_angle = 330	max_orientation_angle = 330	initializer = "giga_inner_5_aeternum_initializer"	hyperlane = no }
+						spawn_system = { min_distance >= 15	max_distance <= 15	min_orientation_angle = 30	max_orientation_angle = 30	initializer = "giga_inner_6_aeternum_initializer"	hyperlane = no }
+
+						spawn_system = { min_distance >= 55	max_distance <= 55	min_orientation_angle = 90	max_orientation_angle = 90	initializer = "giga_outer_1_initializer"	hyperlane = no }
+						spawn_system = { min_distance >= 55	max_distance <= 55	min_orientation_angle = 210	max_orientation_angle = 210	initializer = "giga_outer_2_initializer"	hyperlane = no }
+						spawn_system = { min_distance >= 55	max_distance <= 55	min_orientation_angle = 330	max_orientation_angle = 330	initializer = "giga_outer_3_initializer"	hyperlane = no }
+						#Inner hexagon lanes
+						add_hyperlane_safe = { from = event_target:giga_core_system	to = event_target:giga_inner_1 }
+						add_hyperlane_safe = { from = event_target:giga_core_system	to = event_target:giga_inner_2 }
+						add_hyperlane_safe = { from = event_target:giga_core_system	to = event_target:giga_inner_3 }
+						add_hyperlane_safe = { from = event_target:giga_core_system	to = event_target:giga_inner_4 }
+						add_hyperlane_safe = { from = event_target:giga_core_system	to = event_target:giga_inner_5 }
+						add_hyperlane_safe = { from = event_target:giga_core_system	to = event_target:giga_inner_6 }
+
+						add_hyperlane_safe = { from = event_target:giga_inner_1		to = event_target:giga_inner_2 }
+						add_hyperlane_safe = { from = event_target:giga_inner_2		to = event_target:giga_inner_3 }
+						add_hyperlane_safe = { from = event_target:giga_inner_3		to = event_target:giga_inner_4 }
+						add_hyperlane_safe = { from = event_target:giga_inner_4		to = event_target:giga_inner_5 }
+						add_hyperlane_safe = { from = event_target:giga_inner_5		to = event_target:giga_inner_6 }
+						add_hyperlane_safe = { from = event_target:giga_inner_6		to = event_target:giga_inner_1 }
+
+						add_hyperlane_safe = { from = event_target:giga_inner_1		to = event_target:giga_outer_1 }
+						add_hyperlane_safe = { from = event_target:giga_inner_3		to = event_target:giga_outer_2 }
+						add_hyperlane_safe = { from = event_target:giga_inner_5		to = event_target:giga_outer_3 }
+						#Outer systems connect to allow going around the hexagon
+						add_hyperlane_safe = { from = event_target:giga_outer_1		to = event_target:giga_outer_2 }
+						add_hyperlane_safe = { from = event_target:giga_outer_2		to = event_target:giga_outer_3 }
+						add_hyperlane_safe = { from = event_target:giga_outer_3		to = event_target:giga_outer_1 }
+						event_target:birch_aeternum = { #Initialize stuff
+							country_event = { id = giga_aeternum.1000 days = 2 }
+						}
+
+					}
+				}
 			}
 		}
 		else = { # Quasar
@@ -1080,7 +1124,7 @@ country_event = {
 				}
 			}
 			else_if = {
-				limit = { NOT = { has_global_flag = giga_core_aeternum } }
+				limit = { NOR = { has_global_flag = giga_core_aeternum has_global_flag = giga_core_shuffle_spawned_aeternum } }
 			if = {
 				limit = { galaxy_size = tiny } #Reduced to 1/3
 				spawn_system = { min_distance >= 10	max_distance <= 10	min_orientation_angle = 25	max_orientation_angle = 25	initializer = "giga_inner_1_initializer"	hyperlane = no }


### PR DESCRIPTION
Previously Aeternite systems would fail to spawn correctly when the core was set to its shuffle setting, spawning only Aiondia surrounded by the generic systems from the uninhabited cores, the changes here seek to fix that, tested with all difficulties except lux

![image](https://github.com/user-attachments/assets/44401bf3-5e21-48a9-a8d8-e4f5c9622af1)
![image](https://github.com/user-attachments/assets/6e6166f1-06c1-461f-9646-5d24ba547861)

Attached images show the exact same save with aeternum generated with the core being set to shuffle before/after the fix, other core types generate correctly in testing (screenshots not included)

"Merge pull request #4 from Pouchkinn-s-Gigastructures/Master-Dev" can be ignored I think, that was just me grabbing any changes i was missing before making this PR, forgot that doing so was unncessary and the PR would show up here, apologies