### PR TITLE
Disabled Void Birch and Lux Aeternum

### DIFF
--- a/common/button_effects/giga_button_effects.txt
+++ b/common/button_effects/giga_button_effects.txt
@@ -1302,6 +1302,7 @@ giga_galactic_core_aet_4 = {
 
 giga_galactic_core_aet_5 = {
 	potential = {
+		always = no # Disabled for 4.0
 		exists = from
 		from = {
 			has_country_flag = giga_menu_page_00
@@ -1455,6 +1456,7 @@ giga_galactic_core_aet_4_disabled = {
 
 giga_galactic_core_aet_5_disabled = {
 	potential = {
+		always = no # Disabled for 4.0
 		exists = from
 		from = {
 			has_country_flag = giga_menu_page_00

--- a/common/decisions/giga_birch_decisions.txt
+++ b/common/decisions/giga_birch_decisions.txt
@@ -582,6 +582,7 @@ vsbw_begin = {
 	}
 
 	potential = {
+		always = no # Disabled for 4.0
 		has_global_flag = acot_activated
 		is_planet_class = pc_birch
 		owner = { 


### PR DESCRIPTION
Added `always = no` to the potentials of the Void Birch construction decision and the button effects for enabling/disabling Lux Aeternum in the startup menu

All edited code can be easily found by searching for the "# Disabled for 4.0" comment when the time comes to re-enable them