### PR TITLE
Hyperstructural Assembly Yard slight rebalance

### DIFF
--- a/common/megastructures/zz_i_hyperstructural_assembly.txt
+++ b/common/megastructures/zz_i_hyperstructural_assembly.txt
@@ -380,7 +380,6 @@ hyperstructural_ass_4 = {
 			trigger = { NOT = { has_global_flag = giga_disable_influence_upkeep } }
 			influence = 1.5
 		}
-		produces = { minerals = 1500 }
 	}
 
 	on_build_start = {
@@ -398,7 +397,7 @@ hyperstructural_ass_4 = {
 
 	country_modifier = {
 		country_naval_cap_add = 1500
-		country_resource_max_add = 40000
+		country_resource_max_add = 25000
 		starbase_shipyard_build_speed_mult = 0.75
 	}
 


### PR DESCRIPTION
Removed the mineral output and reduced the resource cap from the hyperstructural assembly yard.