### PR TITLE
HAY Realspaceification

### DIFF
--- a/common/megastructures/zz_i_hyperstructural_assembly.txt
+++ b/common/megastructures/zz_i_hyperstructural_assembly.txt
@@ -53,7 +53,7 @@ hyperstructural_ass_0 = {
 		custom_tooltip = { fail_text = "requires_inside_border"								is_inside_border = from }
 		custom_tooltip = { fail_text = "requires_surveyed_system"							giga_system_is_surveyed = yes }
 		custom_tooltip = { fail_text = "requires_no_colonized_planets"						NOT = { any_system_planet = { is_colony = yes } } }
-		custom_tooltip = { fail_text = "requires_big_star"									OR = { is_star_class = sc_b is_star_class = sc_a } }
+		custom_tooltip = { fail_text = "requires_big_star"								OR = { giga_is_a_star_for_megas = yes giga_is_b_star_for_megas = yes } }
 		custom_tooltip = { fail_text = "requires_no_existing_megastructure"					has_no_non_gate_megastructure = yes }
 		custom_tooltip = { fail_text = "requires_no_crisis_system"							NOT = { any_system_planet = { has_planet_flag = crisis_vital_planet } } }
 		custom_tooltip = {


### PR DESCRIPTION
The HAY now checks for the giga_is_a_star_for_megas and giga_is_b_star_for_megas triggers instead of directly checking for the vanilla star classes, allowing for the megas construction on stars added by Real Space