### PR TITLE
Celestials minor rebalance/update

### DIFF
--- a/common/ship_sizes/giga_ships.txt
+++ b/common/ship_sizes/giga_ships.txt
@@ -73,8 +73,12 @@ asteroid_artillery = {
 	resources = {
 		category = ships
 		upkeep = {
-			energy = 250
-			alloys = 75
+			energy = 75
+			alloys = 25
+		}
+
+		logistics = {
+			trade = 25
 		}
 	}
 
@@ -152,8 +156,11 @@ giga_massive_planet = {
 			alloys = 10000
 		}
 		upkeep = {
-			energy = 500
-			alloys = 125
+			energy = 250
+			alloys = 75
+		}
+		logistics = {
+			trade = 75
 		}
 	}
 
@@ -162,7 +169,7 @@ giga_massive_planet = {
 
 giga_planet_behemoth = {
 	entity = "war_planet_complete_entity"
-	max_speed = 75
+	max_speed = 80
 	acceleration = 0.15
 	rotation_speed = 0.05
 	collision_radius = 48
@@ -208,8 +215,11 @@ giga_planet_behemoth = {
 			alloys = 10000
 		}
 		upkeep = {
-			energy = 250
-			alloys = 75
+			energy = 500
+			alloys = 125
+		}
+		logistics = {
+			trade = 125
 		}
 	}
 
@@ -219,7 +229,7 @@ giga_planet_behemoth = {
 giga_systemcraft = {
 	graphical_culture = no
 	entity = "war_system_complete_entity"
-	max_speed = 100
+	max_speed = 60
 	acceleration = 0.10
 	rotation_speed = 0.05
 	collision_radius = 512
@@ -267,6 +277,9 @@ giga_systemcraft = {
 		upkeep = {
 			alloys = 1500
 			influence = 0.5
+		}
+		logistics = {
+			trade = 250
 		}
 	}
 


### PR DESCRIPTION
Added logistics upkeep to the Asteroid Artillery, Attack Moon, Behemoth Planetcraft and Stellar Systemcraft

Edited Alloy/EC upkeep values for all of the above (excluding the Systemcraft) as they were inconsistent before (Asteroid Artillery had the same upkeep as the Planetcraft and the Attack Moon had double that)

Tweaked maximum speed values for the Asteroid Artillery, Attack Moon, Behemoth Planetcraft and Stellar Systemcraft to be in line with vanillas general rule of (bigger ship = lower max speed)