### PR TITLE
Fixed scaled dyson swarm economic category

### DIFF
--- a/common/inline_scripts/megastructures/dyson_swarm/dyson_swarm_scale.txt
+++ b/common/inline_scripts/megastructures/dyson_swarm/dyson_swarm_scale.txt
@@ -69,7 +69,7 @@ on_dismantle_complete = {
 potential = { always = no }
 
 resources = {
-	category = megastructures
+	category = giga_kilostructures
 
 	upkeep = {
 		alloys = 20


### PR DESCRIPTION
Previously used the megastructures eco category instead of giga_kilostructures, meaning several modifiers would fail to apply properly (perhaps the most noticeable being the kilo upkeep reduction modifier from the macroengineering tradition)

Tested ingame by playing on the master-dev branch on my fork (up to date with the main repo) before the fix and playing on a new branch on my fork (identical to master dev, only difference being the eco category fix)