### PR TITLE
Improved consistency of celestial printing costs

### DIFF
--- a/common/megastructures/zz_i_behemoth_assembly_plant.txt
+++ b/common/megastructures/zz_i_behemoth_assembly_plant.txt
@@ -435,7 +435,7 @@ planetcraft_printer_make_planet = {
 		}
 		inline_script = {
 			script = megastructures/generic_parts/giga_mega_alloy_cost
-			alloys = 250000
+			alloys = 285000 # ~35% more than building it normally
 		}
 		upkeep = {
 			energy = 1500
@@ -533,7 +533,7 @@ planetcraft_printer_make_planet_fake = {
 		}
 		inline_script = {
 			script = megastructures/generic_parts/giga_mega_alloy_cost
-			alloys = 250000
+			alloys = 285000 # ~35% more than building it normally
 		}
 		upkeep = {
 			energy = 1500

--- a/common/megastructures/zz_i_lunar_macroreplicator.txt
+++ b/common/megastructures/zz_i_lunar_macroreplicator.txt
@@ -373,9 +373,9 @@ lunar_macroreplicator_make_moon = {
 		}
 		inline_script = {
 			script = megastructures/generic_parts/giga_mega_alloy_cost
-			alloys = 30000
+			alloys = 24500 # ~35% more than building it normally (excluding the construction site)
 		}
-		cost = { alloys = -1 multiplier = value:giga_ai_savings_cost|CATEGORY|military|RESOURCE|alloys|AMOUNT|30000| }
+		cost = { alloys = -1 multiplier = value:giga_ai_savings_cost|CATEGORY|military|RESOURCE|alloys|AMOUNT|24500| }
 		cost = { unity = -1 multiplier = value:giga_ai_savings_cost|CATEGORY|military|RESOURCE|unity|AMOUNT|@giga_mega_unity_cost| }
 		upkeep = {
 			energy = 400
@@ -490,9 +490,9 @@ lunar_macroreplicator_make_moon_fake = {
 		}
 		inline_script = {
 			script = megastructures/generic_parts/giga_mega_alloy_cost
-			alloys = 30000
+			alloys = 24500 # ~35% more than building it normally (excluding the construction site)
 		}
-		cost = { alloys = -1 multiplier = value:giga_ai_savings_cost|CATEGORY|military|RESOURCE|alloys|AMOUNT|30000| }
+		cost = { alloys = -1 multiplier = value:giga_ai_savings_cost|CATEGORY|military|RESOURCE|alloys|AMOUNT|24500| }
 		cost = { unity = -1 multiplier = value:giga_ai_savings_cost|CATEGORY|military|RESOURCE|unity|AMOUNT|@giga_mega_unity_cost| }
 		upkeep = {
 			energy = 400


### PR DESCRIPTION
The changes made here intend to improve the consistency of celestial fabrication costs relative to the cost of building one on a pre-existing planet/moon

Attack moons:
A regular attack moon costs 23k alloys (including construction site, 18k when not included)
A printed attack moon costs 30k alloys, ~30% more than building one normally (66% more when not including the construction site cost)

Planetcraft:
A regular planetcraft costs 220k alloys (including construction site, 210k without)
A printed planetcraft costs 250k alloys, ~14% more than building one normally (~20% more when not including the construction site cost)

To fix this, the cost of fabricating both attack moons and planetcraft has been made ~35% more than building them normally (when excluding the construction site,  my logic there is pretty much "the celestial fabricators aren't printing the construction sites, so why would they add to the cost?")

I'd be more than happy to revise these numbers at a devs request (especially the attack moon EC cost, since that's nearly the same as the alloy cost), just let me know