### PR TITLE
Fix High Density Planet Scaling and Hyperdimension Rift modifiers for 4.0

### DIFF
--- a/common/deposits/giga_planetary_deposits.txt
+++ b/common/deposits/giga_planetary_deposits.txt
@@ -152,7 +152,7 @@ d_flusion_kaiser_rift = {
 			exists = owner
 			owner = { is_gestalt = no }
 		}
-		job_researcher_add = 50
+		job_physicist_add = 5000
 		planet_researchers_produces_mult = 1
 	}
 
@@ -161,7 +161,7 @@ d_flusion_kaiser_rift = {
 			exists = owner
 			owner = { is_hive_empire = yes }
 		}
-		job_brain_drone_add = 50
+		job_calculator_physicist_add = 5000
 		planet_researchers_produces_mult = 1
 	}
 
@@ -170,7 +170,7 @@ d_flusion_kaiser_rift = {
 			exists = owner
 			owner = { is_machine_empire = yes }
 		}
-		job_calculator_add = 50
+		job_calculator_physicist_add = 5000
 		planet_researchers_produces_mult = 1
 	}
 

--- a/common/script_values/giga_job_scaling_values.txt
+++ b/common/script_values/giga_job_scaling_values.txt
@@ -86,6 +86,7 @@ giga_planet_density_offset_jobs_by_pops = {
         mode = weight
     }
     multiply = value:giga_planet_density_by_pops|pops|$pops|20000$|
+    divide = 100 # Divide by 100 since 4.0 changed how pop numbers work
 }
 
 giga_planet_density_offset_jobs_by_districts = {

--- a/localisation/braz_por/giga_job_scaling_l_braz_por.yml
+++ b/localisation/braz_por/giga_job_scaling_l_braz_por.yml
@@ -22,7 +22,7 @@
   
   d_giga_job_upkeep:99 "High Density Planet Scaling"
   d_giga_job_upkeep_desc:99 "Even the best efforts in efficiency can be thwarted by scale of deployment."
-  d_giga_job_upkeep_tooltip:99 "This planet type can support a much higher population than a normal planet, so many bonuses can potentially be stacked more than normal.\n\nThis feature dilutes several modifiers for populations §Yover 200§! so that they are only half as strong at 400, one third as strong at 600, and so on.\n "
+  d_giga_job_upkeep_tooltip:99 "This planet type can support a much higher population than a normal planet, so many bonuses can potentially be stacked more than normal.\n\nThis feature dilutes several modifiers for populations §Yover 20 000§! so that they are only half as strong at 40 000, one third as strong at 60 000, and so on.\n "
   d_giga_job_upkeep_tooltip_short:99 ""
   
   # hidden modifiers used to track the effect of the deposit

--- a/localisation/english/giga_job_scaling_l_english.yml
+++ b/localisation/english/giga_job_scaling_l_english.yml
@@ -22,7 +22,7 @@
 
     d_giga_job_upkeep:0 "High Density Planet Scaling"
     d_giga_job_upkeep_desc:0 "Even the best efforts in efficiency can be thwarted by scale of deployment."
-    d_giga_job_upkeep_tooltip:0 "This planet type can support a much higher population than a normal planet, so many bonuses can potentially be stacked more than normal.\n\nThis feature dilutes several modifiers for populations §Yover 200§! so that they are only half as strong at 400, one third as strong at 600, and so on.\n "
+    d_giga_job_upkeep_tooltip:0 "This planet type can support a much higher population than a normal planet, so many bonuses can potentially be stacked more than normal.\n\nThis feature dilutes several modifiers for populations §Yover 20 000§! so that they are only half as strong at 40 000, one third as strong at 60 000, and so on.\n "
     d_giga_job_upkeep_tooltip_short:0 ""
 
     # hidden modifiers used to track the effect of the deposit

--- a/localisation/french/giga_job_scaling_l_french.yml
+++ b/localisation/french/giga_job_scaling_l_french.yml
@@ -22,7 +22,7 @@
   
   d_giga_job_upkeep:99 "High Density Planet Scaling"
   d_giga_job_upkeep_desc:99 "Even the best efforts in efficiency can be thwarted by scale of deployment."
-  d_giga_job_upkeep_tooltip:99 "This planet type can support a much higher population than a normal planet, so many bonuses can potentially be stacked more than normal.\n\nThis feature dilutes several modifiers for populations §Yover 200§! so that they are only half as strong at 400, one third as strong at 600, and so on.\n "
+  d_giga_job_upkeep_tooltip:99 "This planet type can support a much higher population than a normal planet, so many bonuses can potentially be stacked more than normal.\n\nThis feature dilutes several modifiers for populations §Yover 20 000§! so that they are only half as strong at 40 000, one third as strong at 60 000, and so on.\n "
   d_giga_job_upkeep_tooltip_short:99 ""
   
   # hidden modifiers used to track the effect of the deposit

--- a/localisation/german/giga_job_scaling_l_german.yml
+++ b/localisation/german/giga_job_scaling_l_german.yml
@@ -22,7 +22,7 @@
   
   d_giga_job_upkeep:99 "High Density Planet Scaling"
   d_giga_job_upkeep_desc:99 "Even the best efforts in efficiency can be thwarted by scale of deployment."
-  d_giga_job_upkeep_tooltip:99 "This planet type can support a much higher population than a normal planet, so many bonuses can potentially be stacked more than normal.\n\nThis feature dilutes several modifiers for populations §Yover 200§! so that they are only half as strong at 400, one third as strong at 600, and so on.\n "
+  d_giga_job_upkeep_tooltip:99 "This planet type can support a much higher population than a normal planet, so many bonuses can potentially be stacked more than normal.\n\nThis feature dilutes several modifiers for populations §Yover 20 000§! so that they are only half as strong at 40 000, one third as strong at 60 000, and so on.\n "
   d_giga_job_upkeep_tooltip_short:99 ""
   
   # hidden modifiers used to track the effect of the deposit

--- a/localisation/polish/giga_job_scaling_l_polish.yml
+++ b/localisation/polish/giga_job_scaling_l_polish.yml
@@ -22,7 +22,7 @@
   
   d_giga_job_upkeep:99 "High Density Planet Scaling"
   d_giga_job_upkeep_desc:99 "Even the best efforts in efficiency can be thwarted by scale of deployment."
-  d_giga_job_upkeep_tooltip:99 "This planet type can support a much higher population than a normal planet, so many bonuses can potentially be stacked more than normal.\n\nThis feature dilutes several modifiers for populations §Yover 200§! so that they are only half as strong at 400, one third as strong at 600, and so on.\n "
+  d_giga_job_upkeep_tooltip:99 "This planet type can support a much higher population than a normal planet, so many bonuses can potentially be stacked more than normal.\n\nThis feature dilutes several modifiers for populations §Yover 20 000§! so that they are only half as strong at 40 000, one third as strong at 60 000, and so on.\n "
   d_giga_job_upkeep_tooltip_short:99 ""
   
   # hidden modifiers used to track the effect of the deposit

--- a/localisation/russian/giga_job_scaling_l_russian.yml
+++ b/localisation/russian/giga_job_scaling_l_russian.yml
@@ -22,7 +22,7 @@
   
   d_giga_job_upkeep:99 "High Density Planet Scaling"
   d_giga_job_upkeep_desc:99 "Even the best efforts in efficiency can be thwarted by scale of deployment."
-  d_giga_job_upkeep_tooltip:99 "This planet type can support a much higher population than a normal planet, so many bonuses can potentially be stacked more than normal.\n\nThis feature dilutes several modifiers for populations §Yover 200§! so that they are only half as strong at 400, one third as strong at 600, and so on.\n "
+  d_giga_job_upkeep_tooltip:99 "This planet type can support a much higher population than a normal planet, so many bonuses can potentially be stacked more than normal.\n\nThis feature dilutes several modifiers for populations §Yover 20 000§! so that they are only half as strong at 40 000, one third as strong at 60 000, and so on.\n "
   d_giga_job_upkeep_tooltip_short:99 ""
   
   # hidden modifiers used to track the effect of the deposit

--- a/localisation/simp_chinese/giga_job_scaling_l_simp_chinese.yml
+++ b/localisation/simp_chinese/giga_job_scaling_l_simp_chinese.yml
@@ -22,7 +22,7 @@
   
   d_giga_job_upkeep:0 "高密度行星缩放"
   d_giga_job_upkeep_desc:0 "即使尽最大努力，效率也会因部署规模而受挫。"
-  d_giga_job_upkeep_tooltip:0 "此类行星可以承担比普通行星更大的人口，因此很多增益可能比平常叠的更高。\n\n本功能在人口§Y超过200§!时稀释特定几个修正，使其在人口为400时增益仅为一半，人口为600时为三分之一，以此类推。\n"
+  d_giga_job_upkeep_tooltip:0 "此类行星可以承担比普通行星更大的人口，因此很多增益可能比平常叠的更高。\n\n本功能在人口§Y超过20 000§!时稀释特定几个修正，使其在人口为40 000时增益仅为一半，人口为60 000时为三分之一，以此类推。\n"
   d_giga_job_upkeep_tooltip_short:0 ""
   
   # hidden modifiers used to track the effect of the deposit

--- a/localisation/spanish/giga_job_scaling_l_spanish.yml
+++ b/localisation/spanish/giga_job_scaling_l_spanish.yml
@@ -22,7 +22,7 @@
   
   d_giga_job_upkeep:0 "Escalado Planetario de Alta Densidad"
   d_giga_job_upkeep_desc:0 "Incluso los mejores esfuerzos en eficiencia pueden verse frustrados por la escala de despliegue."
-  d_giga_job_upkeep_tooltip:0 "Este tipo de planeta puede soportar una población mucho mayor que un planeta normal, por lo que muchas bonificaciones pueden apilarse potencialmente más de lo normal.\n\nEsta característica diluye varios modificadores para poblaciones §Ypor encima de 200§! de modo que sólo son la mitad de fuertes a 400, un tercio de fuertes a 600, etc.\n "
+  d_giga_job_upkeep_tooltip:0 "Este tipo de planeta puede soportar una población mucho mayor que un planeta normal, por lo que muchas bonificaciones pueden apilarse potencialmente más de lo normal.\n\nEsta característica diluye varios modificadores para poblaciones §Ypor encima de 20 000§! de modo que sólo son la mitad de fuertes a 40 000, un tercio de fuertes a 60 000, etc.\n "
   d_giga_job_upkeep_tooltip_short:99 ""
   
   # hidden modifiers used to track the effect of the deposit


### PR DESCRIPTION
This pull request does two things:
1) Fixes High Density Planet Scaling stability affecting modifier being 100 times too strong. This change also includes multiplying job numbers in the description by 100.
2) Fixes the Hyperdimensional Rift planetary modifier giving 50 non-functional researcher jobs. I've opted to give it 5 000 physicist jobs since the deposit is physics based.