### PR TITLE
Updated pd compat

### DIFF
--- a/common/scripted_triggers/00_giga_compat_overwrite_me.txt
+++ b/common/scripted_triggers/00_giga_compat_overwrite_me.txt
@@ -58,35 +58,53 @@ is_hypo_stars_white_hole = { always = no }
 ESC_TRIGGER_needs_dark_matter_for_ship_components = { always = no }
 
 # PD
-is_pd_regular = { always = no }
-is_pd_gaia = { always = no }
-is_pd_rare = { always = no }
-is_pd_nuked = { always = no }
-is_pd_exotic = { always = no }
-is_pd_hive_world = { always = no }
-is_pd_planet_for_aqua_trait = { always = no }
-is_pd_unique = { always = no }
-is_pd_megaflora_hive = { always = no }
-is_pd_shroud_world = { always = no }
-is_pd_aquatics = { always = no }
-is_pd_ocean = { always = no }
-is_pd_arcology = { always = no }
-is_pd_hive_arcology = { always = no }
-is_pd_robot_arcology = { always = no }
-is_pd_alpine = { always = no } 
-is_pd_arctic = { always = no } 
-is_pd_arid = { always = no }
-is_pd_continental = { always = no }
-is_pd_desert = { always = no }
-is_pd_savannah = { always = no }
-is_pd_tropical = { always = no }
-is_pd_tundra = { always = no }
-is_pd_machine = { always = no }
-is_pd_barren = { always = no }
-is_pd_barren_cold = { always = no }
-is_pd_toxic = { always = no }
-is_pd_molten = { always = no }
-is_planetary_diversity_ringworld = {always = no}
+has_planetary_diversity = { always = no }
+pd_is_continental  = { always = no }
+pd_is_ocean = { always = no }
+pd_is_tropical = { always = no }
+pd_is_desert = { always = no }
+pd_is_arid = { always = no }
+pd_is_savannah = { always = no }
+pd_is_arctic = { always = no }
+pd_is_alpine = { always = no }
+pd_is_tundra = { always = no }
+pd_is_planet_class_all = { always = no }
+pd_is_planet_class_uncommon = { always = no }
+pd_is_planet_class_superhabitable = { always = no }
+pd_is_planet_class_tidally_locked = { always = no }
+pd_is_planet_class_cave = { always = no }
+pd_is_planet_class_pd_gaia = { always = no }
+pd_is_planet_class_gaia = { always = no }
+pd_is_planet_class_nuked = { always = no }
+pd_is_planet_pd_class_nuked = { always = no }
+pd_is_planet_for_aqua_trait = { always = no }
+pd_is_planet_class_hive = { always = no }
+pd_is_planet_class_hive_all = { always = no }
+pd_is_planet_class_machine = { always = no }
+pd_is_planet_class_machine_all = { always = no }
+pd_is_wet_gaia_class = { always = no }
+pd_is_domed_colony_class = { always = no }
+pd_has_domed_base_modifier = { always = no }
+pd_has_domed_moon_base_modifier = { always = no }
+is_pd_uncommon_hive = { always = no }
+is_pd_uncommon_hive_arc = { always = no }
+is_pd_uncommon_machine = { always = no }
+is_pd_uncommon_machine_arc = { always = no }
+
+# PD Arcologies
+pd_shielded_world_modifier = { always = no }
+pd_is_pd_arcology = { always = no }
+pd_is_pd_hive_world = { always = no }
+pd_is_pd_hive_arc = { always = no }
+pd_is_pd_machine_arc = { always = no }
+has_pd_capital_deposit = { always = no }
+is_pd_commercial_arcology = { always = no }
+is_pd_fortress_arcology = { always = no }
+is_pd_garden_arcology = { always = no }
+is_pd_palace_arcology = { always = no }
+is_pd_senate_arcology = { always = no }
+is_pd_machine_capital = { always = no }
+is_pd_headquarters_arcology = { always = no }
 
 # Ancient Empire
 ag_is_ancient_ringworld = { always = no }
@@ -123,5 +141,9 @@ has_forerunner_defensive_traditions = {
 
 # guilli's
 gpm_mod_active = { always = no }
+
+# Stellar Manipulation
 stellar_manip_is_active = { always = no }
+
+# Hyperquasaric Megaconstruction
 quasarmod_enabled = { always = no }

--- a/common/scripted_triggers/giga_planet_class_triggers.txt
+++ b/common/scripted_triggers/giga_planet_class_triggers.txt
@@ -72,7 +72,6 @@
 			is_planet_class = pc_toxic
 			is_planet_class = pc_red_toxic
 			atw_is_toxic = yes
-			 #The rest of the uninhabitable PD triggers brought to you by Inny
 		}
 	}
 

--- a/common/scripted_triggers/giga_planet_class_triggers.txt
+++ b/common/scripted_triggers/giga_planet_class_triggers.txt
@@ -72,7 +72,7 @@
 			is_planet_class = pc_toxic
 			is_planet_class = pc_red_toxic
 			atw_is_toxic = yes
-			is_pd_toxic = yes #The rest of the uninhabitable PD triggers brought to you by Inny
+			 #The rest of the uninhabitable PD triggers brought to you by Inny
 		}
 	}
 
@@ -82,7 +82,6 @@
 		OR = {
 			is_planet_class = pc_molten
 			atw_is_molten = yes
-			is_pd_molten = yes
 		}
 	}
 
@@ -109,7 +108,6 @@
 		OR = {
 			is_planet_class = pc_barren
 			atw_is_barren = yes
-			is_pd_barren = yes
 		}
 	}
 
@@ -118,7 +116,6 @@
 		OR = {
 			is_planet_class = pc_barren_cold
 			atw_is_barren = yes
-			is_pd_barren_cold = yes
 		}
 	}
 
@@ -127,7 +124,7 @@
 		optimize_memory
 		OR = {
 			is_planet_class = pc_alpine
-			is_pd_alpine = yes
+			pd_is_alpine = yes
 			atw_is_alpine = yes
 		}
 	}
@@ -136,7 +133,7 @@
 		optimize_memory
 		OR = {
 			is_planet_class = pc_arctic
-			is_pd_arctic = yes
+			pd_is_arctic = yes
 			atw_is_arctic = yes
 		}
 	}
@@ -145,7 +142,7 @@
 		optimize_memory
 		OR = {
 			is_planet_class = pc_arid
-			is_pd_arid = yes
+			pd_is_arid = yes
 			atw_is_arid = yes
 		}
 	}
@@ -154,7 +151,7 @@
 		optimize_memory
 		OR = {
 			is_planet_class = pc_continental
-			is_pd_continental = yes
+			pd_is_continental = yes
 			atw_is_continental = yes
 		}
 	}
@@ -163,7 +160,7 @@
 		optimize_memory
 		OR = {
 			is_planet_class = pc_desert
-			is_pd_desert = yes
+			pd_is_desert = yes
 			atw_is_desert = yes
 		}
 	}
@@ -173,8 +170,7 @@
 		OR = {
 			is_planet_class = pc_ocean
 			is_planet_class = pc_giga_edge_of_eternity
-			is_pd_ocean = yes
-			is_pd_aquatics = yes
+			pd_is_ocean = yes
 			atw_is_ocean_basic = yes
 		}
 	}
@@ -183,7 +179,7 @@
 		optimize_memory
 		OR = {
 			is_planet_class = pc_savannah
-			is_pd_savannah = yes
+			pd_is_savannah = yes
 			atw_is_savannah = yes
 		}
 	}
@@ -192,7 +188,7 @@
 		optimize_memory
 		OR = {
 			is_planet_class = pc_tropical
-			is_pd_tropical = yes
+			pd_is_tropical = yes
 			atw_is_tropical = yes
 		}
 	}
@@ -201,7 +197,7 @@
 		optimize_memory
 		OR = {
 			is_planet_class = pc_tundra
-			is_pd_tundra = yes
+			pd_is_tundra = yes
 			atw_is_tundra = yes
 		}
 	}
@@ -219,7 +215,7 @@
 		optimize_memory
 		OR = {
 			is_planet_class = pc_hive
-			is_pd_hive_world = yes
+			pd_is_planet_class_hive = yes
 		}
 	}
 
@@ -227,7 +223,7 @@
 		optimize_memory
 		OR = {
 			is_planet_class = pc_machine
-			is_pd_machine = yes
+			pd_is_planet_class_machine = yes
 		}
 	}
 
@@ -235,7 +231,7 @@
 		optimize_memory
 		OR = {
 			is_planet_class = pc_gaia
-			is_pd_gaia = yes
+			pd_is_planet_class_pd_gaia = yes
 			atw_is_gaia = yes
 		}
 	}
@@ -245,7 +241,7 @@
 		OR = {
 			is_planet_class = pc_nuked
 			is_planet_class = pc_katzenland
-			is_pd_nuked = yes
+			pd_is_planet_pd_class_nuked = yes
 		}
 
 	}
@@ -255,7 +251,7 @@
 		OR = {
 			is_planet_class = pc_flusion_gaia_ecu
 			is_planet_class = pc_city
-			is_pd_arcology = yes
+			pd_is_pd_arcology = yes
 		}
 	}
 
@@ -304,7 +300,6 @@
 			is_planet_class = pc_ringworld_hive
 			is_planet_class = pc_ringworld_habitable
 			is_planet_class = pc_giga_maginot_ringworld
-			is_planetary_diversity_ringworld = yes
 		}
 	}
 	
@@ -328,7 +323,6 @@
 			is_planet_class = pc_ringworld_hive
 			is_planet_class = pc_squareworld_habitable
 			is_planet_class = pc_giga_maginot_ringworld
-			is_planetary_diversity_ringworld = yes
 		}
 	}
 	

--- a/common/scripted_triggers/zzz_overwrites.txt
+++ b/common/scripted_triggers/zzz_overwrites.txt
@@ -1472,6 +1472,9 @@ can_destroy_planet_with_PLANET_KILLER_CRACKER = {
 				is_planet_class = pc_nuked
 				is_planet_class = pc_ringworld_habitable
 				is_planet_class = pc_habitat
+
+				# Planetary Diversity
+				pd_is_planet_class_all = yes
 			}
 		}
 	}
@@ -1998,9 +2001,7 @@ habitable_planet = {
 		is_planet_class = pc_flusion_gaia_ecu
 
 		# Planetary Diversity
-		is_pd_arcology = yes 
-		is_pd_hive_arcology = yes
-		is_pd_robot_arcology = yes
+		pd_is_planet_class_all = yes
 	}
 }
 habitable_planet_not_urban = {
@@ -2022,20 +2023,7 @@ habitable_planet_not_urban = {
 		is_planet_class = pc_katzenland
 
 		#PD
-		is_pd_nuked = yes
-		is_pd_rare = yes
-		is_pd_exotic = yes
-		is_pd_hive_world = yes
-		is_pd_planet_for_aqua_trait = yes
-		is_pd_rare = yes
-		is_pd_unique = yes
-		is_pd_megaflora_hive = yes
-		is_pd_rare = yes
-		is_pd_shroud_world = yes
-		is_pd_aquatics = yes
-		is_pd_gaia = yes
-		is_pd_ocean = yes
-		is_pd_regular = yes
+		pd_is_planet_class_all = yes
 	}
 }
 uses_habitat_capitals = {
@@ -2045,18 +2033,6 @@ uses_habitat_capitals = {
 			
 		# gigas
 		giga_uses_habitat_capitals = yes
-			
-		# PD planetary habitats
-		# as per Inny
-		# is_planet_class = pc_pd_gas_giant_hab 
-		# is_planet_class = pc_pd_barren_hab
-		# is_planet_class = pc_pd_barren_cold_hab
-		# is_planet_class = pc_pd_frozen_hab
-		# is_planet_class = pc_pd_molten_hab
-		# is_planet_class = pc_pd_toxic_hab
-		# is_planet_class = pc_pd_hothouse_hab
-		# is_planet_class = pc_pd_asteroid_hab
-		uses_district_set = pdplanethab
 
 		#misc compat
 		has_planet_flag = giga_habitat_capital_compat


### PR DESCRIPTION
Removed old PD placeholders, replaced with new ones

Definitely added more placeholders than necessary, but i guess it's better to have them and not need them to need them and not have them lol

Can't guarantee that I haven't missed something but up-to-date partial compat is better than entirely broken, outdated compat :clueless:

These changes should resolve the issue of the cultivated worldscaping decision not appearing on gaia worlds when running Gigas alongside PR and hopefully resolve any other yet undiscovered issues

Also corrected improper labels of Stellar Manipulation/Hyperquasaric Megaconstruction placeholders