### PR TITLE
Fixed FE Asteroid Artillery

### DIFF
--- a/common/global_ship_designs/giga_fe_ships.txt
+++ b/common/global_ship_designs/giga_fe_ships.txt
@@ -185,3 +185,60 @@ ship_design = {
 	required_component = "SENSOR_4"
 	required_component = "REACTOR_PLANET"
 }
+
+###############################
+### Asteroid Artillery ########
+###############################
+ship_design = {
+	name = "Ancient Asteroid Artillery"
+	ship_size = asteroid_artillery
+	section = {
+		template = "ASTEROID_ARTILLERY_STERN"
+		component = { slot = "TITANIC_GUN_01"		template = "PERDITION_BEAM_ARTILLERY"		}
+		component = { slot = "EXTRALARGE_GUN_01"	template = "ENERGY_LANCE_2"	}
+		component = { slot = "EXTRALARGE_GUN_02"	template = "ENERGY_LANCE_2"	}
+		component = { slot = "EXTRALARGE_GUN_03"	template = "ENERGY_LANCE_2"	}
+		component = { slot = "EXTRALARGE_GUN_04"	template = "ENERGY_LANCE_2"	}
+		component = { slot = "LARGE_GUN_01"		template = "KINETIC_ARTILLERY_2"		}
+		component = { slot = "LARGE_GUN_02"		template = "KINETIC_ARTILLERY_2"		}
+		component = { slot = "LARGE_GUN_03"		template = "KINETIC_ARTILLERY_2"		}
+		component = { slot = "LARGE_GUN_04"		template = "KINETIC_ARTILLERY_2"		}
+		component = { slot = "LARGE_GUN_05"		template = "KINETIC_ARTILLERY_2"		}
+		component = { slot = "LARGE_GUN_06"		template = "KINETIC_ARTILLERY_2"		}
+		component = { slot = "LARGE_GUN_07"		template = "KINETIC_ARTILLERY_2"		}
+		component = { slot = "LARGE_GUN_08"		template = "KINETIC_ARTILLERY_2"		}
+	}
+
+	section = {
+		template = ASTEROID_ARTILLERY_MID
+		component = { slot = "MEDIUM_GUN_01"		template = "MEDIUM_MASS_DRIVER_5"	}
+		component = { slot = "MEDIUM_GUN_02"		template = "MEDIUM_MASS_DRIVER_5"	}
+		component = { slot = "MEDIUM_GUN_03"		template = "MEDIUM_MASS_DRIVER_5"	}
+		component = { slot = "MEDIUM_GUN_04"		template = "MEDIUM_MASS_DRIVER_5"	}
+		component = { slot = "MEDIUM_GUN_05"		template = "MEDIUM_MASS_DRIVER_5"	}
+		component = { slot = "MEDIUM_GUN_06"		template = "MEDIUM_MASS_DRIVER_5"	}
+		component = { slot = "MEDIUM_GUN_07"		template = "MEDIUM_GAMMA_LASER"	}
+		component = { slot = "MEDIUM_GUN_08"		template = "MEDIUM_GAMMA_LASER"	}
+		component = { slot = "MEDIUM_GUN_09"		template = "MEDIUM_GAMMA_LASER"	}
+		component = { slot = "MEDIUM_GUN_10"		template = "MEDIUM_GAMMA_LASER"	}
+		component = { slot = "MEDIUM_GUN_11"		template = "MEDIUM_GAMMA_LASER"	}
+		component = { slot = "MEDIUM_GUN_12"		template = "MEDIUM_GAMMA_LASER"	}
+	}
+
+	section = {
+		template = ASTEROID_ARTILLERY_BOW
+		component = { slot = "SMALL_GUN_01"		template = "SMALL_PLASMA_3"		}
+		component = { slot = "SMALL_GUN_02"		template = "SMALL_PLASMA_3"		}
+		component = { slot = "SMALL_GUN_03"		template = "SMALL_PLASMA_3"		}
+		component = { slot = "SMALL_GUN_04"		template = "SMALL_PLASMA_3"		}
+		component = { slot = "SMALL_GUN_05"		template = "SMALL_PLASMA_3"		}
+		component = { slot = "SMALL_GUN_06"		template = "SMALL_PLASMA_3"		}
+		component = { slot = "SMALL_GUN_07"		template = "SMALL_MASS_DRIVER_5"		}
+		component = { slot = "SMALL_GUN_08"		template = "SMALL_MASS_DRIVER_5"		}
+		component = { slot = "SMALL_GUN_09"		template = "SMALL_MASS_DRIVER_5"		}
+		component = { slot = "SMALL_GUN_10"		template = "SMALL_MASS_DRIVER_5"		}
+		component = { slot = "SMALL_GUN_11"		template = "SMALL_MASS_DRIVER_5"		}
+		component = { slot = "SMALL_GUN_12"		template = "SMALL_MASS_DRIVER_5"		}
+	}
+	required_component = "REACTOR_ASTEROID"
+}

--- a/common/megastructures/zz_c_asteroid_artillery.txt
+++ b/common/megastructures/zz_c_asteroid_artillery.txt
@@ -278,26 +278,63 @@ asteroid_artillery_1 = {
 					value = 0
 				}
 			}
-			create_fleet = { 
-				name = "Asteroid Artillery" 
-				settings = { spawn_debris = no } 
-				effect = { 
-					set_owner = prev.space_owner
-					create_ship = { 
-						name = "Asteroid Artillery" 
-						random_existing_design = asteroid_artillery
+			if = {
+				limit = {
+					from = {
+						is_fallen_empire = no
 					}
-					set_location = {
-						target = event_target:giga_planet
-						distance = 0.5
-						angle = 0
-					}
-					set_variable = {
-						which = giga_asteroid_ship_id
-						value = ROOT.fromfrom.planet.giga_asteroid_id
-					}
-					apply_ast_art_tech_upgrades = yes
 				}
+				create_fleet = {
+					name = "Asteroid Artillery"
+					settings = { spawn_debris = no }
+					effect = {
+						set_owner = prev.space_owner
+						create_ship = {
+							name = "Asteroid Artillery"
+							random_existing_design = asteroid_artillery
+						}
+						set_location = {
+							target = event_target:giga_planet
+							distance = 0.5
+							angle = 0
+						}
+						set_variable = {
+							which = giga_asteroid_ship_id
+							value = ROOT.fromfrom.planet.giga_asteroid_id
+						}
+						apply_ast_art_tech_upgrades = yes
+					}
+				}
+
+			}
+			if = {
+				limit = {
+					from = {
+						is_fallen_empire = yes
+					}
+				}
+				create_fleet = {
+					name = "Asteroid Artillery"
+					settings = { spawn_debris = no }
+					effect = {
+						set_owner = prev.space_owner
+						create_ship = {
+							name = "Asteroid Artillery"
+							design = "Ancient Asteroid Artillery"
+						}
+						set_location = {
+							target = event_target:giga_planet
+							distance = 0.5
+							angle = 0
+						}
+						set_variable = {
+							which = giga_asteroid_ship_id
+							value = ROOT.fromfrom.planet.giga_asteroid_id
+						}
+						apply_ast_art_tech_upgrades = yes
+					}
+				}
+
 			}
 		}
 		if = {
@@ -306,27 +343,65 @@ asteroid_artillery_1 = {
 				remove_planet_flag = just_repaired_ast_art
 				set_planet_flag = asteroid_has_artillery
 			}
-			create_fleet = { 
-				name = "Asteroid Artillery" 
-				settings = { spawn_debris = no } 
-				effect = { 
-					set_owner = prev.space_owner
-					create_ship = { 
-						name = "Asteroid Artillery" 
-						random_existing_design = asteroid_artillery
+			if = {
+				limit = {
+					from = {
+						is_fallen_empire = no
 					}
-					set_location = {
-						target = event_target:giga_planet
-						distance = 0.5
-						angle = 0
-					}
-					set_variable = {
-						which = giga_asteroid_ship_id
-						value = ROOT.fromfrom.planet.giga_asteroid_id
-					}
-					reapply_ast_art_modifiers = yes
-					apply_ast_art_tech_upgrades = yes
 				}
+				create_fleet = {
+					name = "Asteroid Artillery"
+					settings = { spawn_debris = no }
+					effect = {
+						set_owner = prev.space_owner
+						create_ship = {
+							name = "Asteroid Artillery"
+							random_existing_design = asteroid_artillery
+						}
+						set_location = {
+							target = event_target:giga_planet
+							distance = 0.5
+							angle = 0
+						}
+						set_variable = {
+							which = giga_asteroid_ship_id
+							value = ROOT.fromfrom.planet.giga_asteroid_id
+						}
+						reapply_ast_art_modifiers = yes
+						apply_ast_art_tech_upgrades = yes
+					}
+				}
+
+			}
+			if = {
+				limit = {
+					from = {
+						is_fallen_empire = yes
+					}
+				}
+				create_fleet = {
+					name = "Asteroid Artillery"
+					settings = { spawn_debris = no }
+					effect = {
+						set_owner = prev.space_owner
+						create_ship = {
+							name = "Asteroid Artillery"
+							design = "Ancient Asteroid Artillery"
+						}
+						set_location = {
+							target = event_target:giga_planet
+							distance = 0.5
+							angle = 0
+						}
+						set_variable = {
+							which = giga_asteroid_ship_id
+							value = ROOT.fromfrom.planet.giga_asteroid_id
+						}
+						reapply_ast_art_modifiers = yes
+						apply_ast_art_tech_upgrades = yes
+					}
+				}
+
 			}
 		}
 		fromfrom = {

--- a/events/giga_007_fallen_empire.txt
+++ b/events/giga_007_fallen_empire.txt
@@ -1418,7 +1418,7 @@ country_event = {
 						}
 						every_system_megastructure = {
 							limit = { is_megastructure_type = asteroid_artillery_0 }
-							upgrade_megastructure_to = asteroid_artillery_1
+							upgrade_megastructure_to = asteroid_artillery_1_fake
 							finish_upgrade = yes
 						}
 					}
@@ -1447,7 +1447,7 @@ country_event = {
 							}
 							every_system_megastructure = {
 								limit = { is_megastructure_type = asteroid_artillery_0 }
-								upgrade_megastructure_to = asteroid_artillery_1
+								upgrade_megastructure_to = asteroid_artillery_1_fake
 								finish_upgrade = yes
 							}
 						}


### PR DESCRIPTION
Resolved broken asteroid artillery megas by correcting the invalid upgrade path in giga_fallen_empire_megas.1008 (asteroid_artillery_0 has no upgrade path to asteroid_artillery_1, but it has one to asteroid_artillery_1_fake which replaces itself with asteroid_artillery_1 anyway)

Fixed the actual asteroid artillery ship not spawning with the mega by creating a global ship design which the game defaults to if the owner of the mega is a fallen empire (previously it would fail to spawn the ship as the FE had no design for it)

Apparently the steam version has a similar but different issue with asteroid artillery, haven't tested for myself, only tested with master-dev where the mega itself was broken