### PR TITLE
Patch Grand Archive placement rules to support building on World Machines

### DIFF
--- a/common/megastructures/zz_c_grand_archive.txt
+++ b/common/megastructures/zz_c_grand_archive.txt
@@ -65,6 +65,12 @@ grand_archive_0 = {
 		planet_possible = {
 			is_colony = yes
 			OR = {
+				# Machines & Robot Expac: Continued checks will be here
+				inline_script = {
+					script = generic_parts/giga_toggled_code
+					code = "oxr_mdlc_can_build_grand_archive = yes"
+					toggle = @oxr_mdlc_mod
+				}
 				pop_amount >= 2500
 				AND = {
 					exists = owner

--- a/common/scripted_triggers/00_giga_compat_overwrite_me.txt
+++ b/common/scripted_triggers/00_giga_compat_overwrite_me.txt
@@ -125,3 +125,7 @@ has_forerunner_defensive_traditions = {
 gpm_mod_active = { always = no }
 stellar_manip_is_active = { always = no }
 quasarmod_enabled = { always = no }
+
+
+# Machine & Robot Expansion: Continued
+oxr_mdlc_can_build_grand_archive = { always = no }


### PR DESCRIPTION
Hello Gigastructural Engineering devs,

This is a compatibility patch to support building the Grand Archive on World Machine planets from the "Machines & Robots Expansion Continued" mod. There are different placement rules for those planet types requirements, which are checked in the `oxr_mdlc_can_build_grand_archive` trigger. I missed adding this back when I submitted a pull request to adjust placement rules for placing orbital rings around World Machine planets.

Changes:

- Add placeholder trigger for `oxr_mdlc_can_build_grand_archive` placement rule
- Use code toggle to conditionally load the trigger, if the other mod is loaded