### PR TITLE
Updated relics to 4.0 standards

### DIFF
--- a/common/relics/giga_eawaf_relics.txt
+++ b/common/relics/giga_eawaf_relics.txt
@@ -10,7 +10,12 @@ r_eawaf_sirens_crystal = {
 	sound = relic_activation_generic
 	score = 10000
 	resources = { category = relics cost = { influence = 150 energy = 10000 rare_crystals = 500 } }
-	possible = { custom_tooltip = { fail_text = "requires_relic_no_cooldown" NOT = { has_modifier = relic_activation_cooldown } } }
+	possible = {
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_eawaf_sirens_crystal
+		}
+	}
 
 	triggered_country_modifier = {
 		potential = { always = yes }
@@ -38,7 +43,12 @@ r_eawaf_eqg_portal = {
 	sound = relic_activation_generic
 	score = 10000
 	resources = { category = relics cost = { energy = 5000 rare_crystals = 500 } }
-	possible = { custom_tooltip = { fail_text = "requires_relic_no_cooldown" NOT = { has_modifier = relic_activation_cooldown } } }
+	possible = {
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_eawaf_eqg_portal
+		}
+	}
 
 	triggered_country_modifier = {
 		potential = { always = yes }

--- a/common/relics/giga_paluush_relic.txt
+++ b/common/relics/giga_paluush_relic.txt
@@ -9,7 +9,12 @@ r_soul_of_grandbunny = {
 	sound = relic_activation_generic
 	score = 10000
 	resources = { category = relics cost = { influence = 150 } }
-	possible = { custom_tooltip = { fail_text = "requires_relic_no_cooldown" NOT = { has_modifier = relic_activation_cooldown } } }
+	possible = {
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_soul_of_grandbunny
+		}
+	}
 
 	triggered_country_modifier = {
 		potential = { always = yes }

--- a/common/relics/giga_relics.txt
+++ b/common/relics/giga_relics.txt
@@ -39,13 +39,11 @@ r_creator_shard = {
 			unity = @activation_cost
 		} 
 	}
-	possible = { 
-		custom_tooltip = { 
-			fail_text = "requires_relic_no_cooldown" 
-			NOT = { 
-				has_modifier = relic_activation_cooldown 
-			} 
-		} 
+	possible = {
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_creator_shard
+		}
 	}
 
 	triggered_country_modifier = {
@@ -113,9 +111,9 @@ r_ehof_dragon_trophy = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_dragon_trophy
 		}
 	}
 }
@@ -179,9 +177,9 @@ r_ehof_khans_throne = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_khans_throne
 		}
 	}
 }
@@ -208,7 +206,7 @@ r_ehof_worm_scales = {
 		potential = {
 			always = yes
 		}
-		country_physics_tech_research_speed = 0.10
+		country_physics_tech_research_speed = 0.05
 	}
 
 	score = 0
@@ -231,9 +229,9 @@ r_ehof_worm_scales = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_worm_scales
 		}
 	}
 }
@@ -281,7 +279,7 @@ r_ehof_rubricator = {
 				modifier = "relic_activation_cooldown"
 				days = @triumph_duration
 			}
-			add_resource = { minor_artifacts = 500 }
+			add_resource = { minor_artifacts = 2000 }
 			remove_country_flag = ehof_has_rubricator
 			remove_relic = r_ehof_rubricator
 		}
@@ -289,9 +287,9 @@ r_ehof_rubricator = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_rubricator
 		}
 	}
 }
@@ -343,9 +341,9 @@ r_ehof_galaxy = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_galaxy
 		}
 	}
 }
@@ -464,9 +462,9 @@ r_ehof_surveyor = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_surveyor
 		}
 	}
 }
@@ -517,9 +515,9 @@ r_ehof_galatron = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_galatron
 		}
 	}
 }
@@ -571,9 +569,9 @@ r_ehof_ancient_sword = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_ancient_sword
 		}
 	}
 }
@@ -625,9 +623,9 @@ r_ehof_severed_head = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_severed_head
 		}
 	}
 }
@@ -686,9 +684,9 @@ r_ehof_prethoryn_queen = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_prethoryn_queen
 		}
 	}
 }
@@ -750,13 +748,12 @@ r_ehof_unbidden_warlock = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_unbidden_warlock
 		}
 	}
 }
-
 
 r_ehof_contingency_core = {
 	activation_duration = @triumph_duration
@@ -778,13 +775,20 @@ r_ehof_contingency_core = {
 
 	triggered_country_modifier = {
 		potential = {
-			always = yes
+			is_hive_empire = no
 		}
 		planet_pop_assembly_mult = 1.00
 		show_only_custom_tooltip = no
-		custom_tooltip = relic_contingecy_core
+		custom_tooltip = relic_contingecy_core # +1 Megastructure
 	}
-
+	triggered_country_modifier = {
+		potential = {
+			is_hive_empire = yes
+		}
+		country_engineering_research_produces_mult = 1.5
+		show_only_custom_tooltip = no
+		custom_tooltip = relic_contingecy_core # +1 Megastructure
+	}
 	score = 0
 
 	active_effect = {
@@ -805,9 +809,9 @@ r_ehof_contingency_core = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_contingency_core
 		}
 	}
 }
@@ -889,18 +893,22 @@ r_ehof_the_last_baol = {
 	triggered_country_modifier = {
 		potential = {
 			is_machine_empire = no
+			is_wilderness_empire = no
 		}
 		modifier = {
-			pop_growth_speed = 0.10
+			logistic_growth_mult = 0.1
 		}
 	}
 
 	triggered_country_modifier = {
 		potential = {
-			is_machine_empire = yes
+			OR = {
+				is_machine_empire = yes
+				is_wilderness_empire = yes
+			}
 		}
 		modifier = {
-			pop_growth_speed = 0.10
+			logistic_growth_mult = 0.1
 			country_society_research_produces_mult = 0.10
 		}
 	}
@@ -924,9 +932,9 @@ r_ehof_the_last_baol = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_the_last_baol
 		}
 	}
 }
@@ -997,9 +1005,9 @@ r_ehof_the_defragmentor = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_the_defragmentor
 		}
 	}
 }
@@ -1047,9 +1055,9 @@ r_ehof_reality_perforator = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_reality_perforator
 		}
 	}
 }
@@ -1101,9 +1109,9 @@ r_ehof_pox_sample = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_pox_sample
 		}
 	}
 }
@@ -1128,10 +1136,19 @@ r_ehof_cryo_core = {
 
 	triggered_country_modifier = {
 		potential = {
-			always = yes
+			is_wilderness_empire = no
 		}
-		colony_start_num_pops_add = 1
+		planet_colony_development_speed_mult = 2
 		#custom_tooltip = r_cryo_core_effect
+		weapon_type_energy_weapon_fire_rate_mult = 0.2
+	}
+	triggered_country_modifier = {
+		potential = {
+			is_wilderness_empire = yes
+		}
+		custom_tooltip = tr_expansion_colonization_fever_wilderness_desc
+		show_only_custom_tooltip = no
+		# see 'wilderness.500'
 		weapon_type_energy_weapon_fire_rate_mult = 0.2
 	}
 
@@ -1155,9 +1172,9 @@ r_ehof_cryo_core = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_cryo_core
 		}
 	}
 }
@@ -1225,9 +1242,9 @@ r_ehof_war_forge = {
 
 	# Possible check for activation
 	possible = {
-		custom_tooltip = {
-			fail_text = "requires_relic_no_cooldown"
-			NOT = { has_modifier = relic_activation_cooldown }
+		inline_script = {
+			script = relics/activation_checks
+			RELIC = r_ehof_war_forge
 		}
 	}
 }


### PR DESCRIPTION
Updates relic `possible` checks to the new inline (so now various relics can now be used alongside another via Lateral Artifacting)

Updates actual relic mechanics to match those of vanilla where applicable