### PR TITLE
Fixed Alderson + Great Ring Origins

### DIFF
--- a/common/deposits/giga_planetary_deposits.txt
+++ b/common/deposits/giga_planetary_deposits.txt
@@ -752,11 +752,11 @@ d_great_ring_excavated_mountain = {
 
 	triggered_planet_modifier = {
 		potential = { exists = owner owner = { is_gestalt = no } }
-		job_matter_synthesizer_add = 5
+		job_matter_synthesizer_add = 500
 	}
 	triggered_planet_modifier = {
 		potential = { exists = owner owner = { is_gestalt = yes } }
-		job_matter_synthesizer_drone_add = 5
+		job_matter_synthesizer_drone_add = 500
 	}
 }
 

--- a/common/scripted_effects/giga_primitives.txt
+++ b/common/scripted_effects/giga_primitives.txt
@@ -730,7 +730,7 @@ generate_alderson_01_primitives_on_planet = {
 	set_capital = yes
 	create_pop_group = { 
 		species = last_created 
-		count = 24
+		size = 2400
 	}
 	add_building = building_primitive_farm
 	add_building = building_primitive_factory
@@ -815,7 +815,7 @@ generate_alderson_02_primitives_on_planet = {
 	set_capital = yes
 	create_pop_group = { 
 		species = last_created 
-		count = 24
+		size = 2400
 	}
 	add_building = building_primitive_farm
 	add_building = building_primitive_factory

--- a/common/scripted_triggers/giga_scripted_triggers.txt
+++ b/common/scripted_triggers/giga_scripted_triggers.txt
@@ -1106,3 +1106,12 @@ can_dismantle_planet_for_bm = {
 	}
 	NOT = { has_planet_flag = has_megastructure } # This is gonna make people mad but you shouldn't be taking apart a planet that's anchoring a mega
 }
+
+giga_has_consumer_goods_civic_or_individualist = {
+	# checks if empire is individualist or is a gestalt that uses consumer goods
+	OR = {
+		is_gestalt = no
+		has_civic = civic_machine_servitor
+		has_civic = civic_machine_obsessional_directive
+	}
+}

--- a/events/giga_201_origins_alderson.txt
+++ b/events/giga_201_origins_alderson.txt
@@ -247,9 +247,10 @@ country_event = {
 				}
 	
 				# 2 jobs
-				add_district_and_planet_size_if_needed_effect = {
-					district = district_srw_commercial
-				}
+				# add_district_and_planet_size_if_needed_effect = {
+				# 	district = district_srw_commercial
+				# }
+				# immediately dies, so commented out
 	
 				# 4 jobs
 				add_district_and_planet_size_if_needed_effect = {
@@ -260,7 +261,10 @@ country_event = {
 				add_building = building_capital
 	
 				# 2 jobs
-				add_building = building_bureaucratic_1
+				add_building = {
+					zone = zone_research_unity 
+					building = building_bureaucratic_1
+				}
 	
 				# 2 jobs
 				if = {
@@ -283,7 +287,10 @@ country_event = {
 					}
 				}
 				else = {
-					add_building = building_research_lab_1
+					add_building = {
+						zone = zone_research_unity 
+						building = building_research_lab_1
+					}
 				}
 	
 				# 4-5 jobs
@@ -309,7 +316,10 @@ country_event = {
 								has_valid_civic = civic_death_cult
 							}
 						}
-						add_building = building_sacrificial_temple_1
+						add_building = {
+							zone = zone_research_unity 
+							building = building_sacrificial_temple_1
+						}
 					}
 					else_if = {
 						limit = {
@@ -318,7 +328,10 @@ country_event = {
 								is_spiritualist = yes
 							}
 						}
-						add_building = building_temple
+						add_building = {
+							zone = zone_research_unity 
+							building = building_temple
+						}
 					}
 					else = {
 						add_building = building_commercial_zone
@@ -385,10 +398,16 @@ country_event = {
 				add_building = building_hive_capital
 	
 				# 2 jobs
-				add_building = building_research_lab_1
+				add_building = {
+					zone = zone_research_unity 
+					building = building_research_lab_1
+				}
 	
 				# 2 jobs
-				add_building = building_hive_node
+				add_building = {
+					zone = zone_research_unity 
+					building = building_hive_node
+				}
 	
 				# 1 job
 				add_building = building_spawning_pool
@@ -419,10 +438,16 @@ country_event = {
 				add_building = building_machine_assembly_plant
 	
 				# 2 job
-				add_building = building_uplink_node
+				add_building = {
+					zone = zone_research_unity 
+					building = building_uplink_node
+				}
 	
-				# 2 jobs
-				add_building = building_research_lab_1
+				# 2 jobs 
+				add_building = {
+					zone = zone_research_unity 
+					building = building_research_lab_1
+				}
 	
 				# 4 jobs
 				add_district_and_planet_size_if_needed_effect = {
@@ -471,7 +496,10 @@ country_event = {
 					add_district_and_planet_size_if_needed_effect = {
 						district = district_nexus
 					}
-					add_building = building_organic_sanctuary
+					add_building = {
+						zone = zone_research_unity 
+						building = building_organic_sanctuary
+					}
 				}
 			}
 			# i litcherally just copy pasted these from shattered ring

--- a/events/giga_203_origins_rings.txt
+++ b/events/giga_203_origins_rings.txt
@@ -304,7 +304,7 @@ country_event = {
 						district = district_rw_city
 						zone = zone_research_unity # why is there no specific rw version lol
 						zone_slot = 2
-						replace = yes
+						replace = no
 					} 
 					
 				}
@@ -335,17 +335,28 @@ country_event = {
 					}
 
 					## zones
-					add_zone = {
-						district = district_rw_hive
-						zone = zone_industrial_ring_world
-						zone_slot = 1
-						replace = no
-					} 
+					if = {
+						limit = { owner = { giga_has_consumer_goods_civic_or_individualist = yes } }
+						add_zone = {
+							district = district_rw_hive
+							zone = zone_industrial_ring_world
+							zone_slot = 1
+							replace = no
+						} 
+					}
+					else = {
+						add_zone = {
+							district = district_rw_hive
+							zone = zone_foundry_ring_world
+							zone_slot = 1
+							replace = no
+						}
+					}
 					add_zone = {
 						district = district_rw_hive
 						zone = zone_research_unity # why is there no specific rw version lol
 						zone_slot = 2
-						replace = yes
+						replace = no
 					} 
 				}
 				# machine empires
@@ -406,17 +417,28 @@ country_event = {
 					}
 
 					## zones
-					add_zone = {
-						district = district_rw_nexus
-						zone = zone_industrial_ring_world
-						zone_slot = 1
-						replace = no
-					} 
+					if = {
+						limit = { owner = { giga_has_consumer_goods_civic_or_individualist = yes } }
+						add_zone = {
+							district = district_rw_nexus
+							zone = zone_industrial_ring_world
+							zone_slot = 1
+							replace = no
+						} 
+					}
+					else = {
+						add_zone = {
+							district = district_rw_nexus
+							zone = zone_foundry_ring_world
+							zone_slot = 1
+							replace = no
+						}
+					}
 					add_zone = {
 						district = district_rw_nexus
 						zone = zone_research_unity # why is there no specific rw version lol
 						zone_slot = 2
-						replace = yes
+						replace = no
 					} 
 				}
 

--- a/events/giga_203_origins_rings.txt
+++ b/events/giga_203_origins_rings.txt
@@ -247,7 +247,6 @@ country_event = {
 				add_deposit = d_ringworld_capital_city
 				add_deposit = d_segment_rubble_3
 				add_deposit = d_segment_rubble_4
-				add_district = district_rw_industrial
 
 				# special deposit blockers for DA/RS machines
 				if = {
@@ -271,37 +270,89 @@ country_event = {
 						root = { is_gestalt = no }
 					}
 					add_district = district_rw_city
+					add_district = district_rw_urban_1
 					# is biological
 					if = {
 						limit = { root = { is_lithoid_empire = no } }
-						add_district = district_rw_farming
+						add_zone = {
+							district = district_rw_urban_1
+							zone = zone_food_ring_world
+							zone_slot = 0
+							replace = yes
+						} 
 					}
 					# is lithoid
 					else = {
 						add_deposit = d_interstellar_ringworld_commerce_blocker
-						add_district = district_rw_commercial
+						add_zone = {
+							district = district_rw_urban_1
+							zone = zone_trade_ring_world
+							zone_slot = 0
+							replace = yes
+						} 
 						add_deposit = d_great_ring_excavated_mountain
 					}
+					
+					## zones
+					add_zone = {
+						district = district_rw_city
+						zone = zone_industrial_ring_world
+						zone_slot = 1
+						replace = no
+					} 
+					add_zone = {
+						district = district_rw_city
+						zone = zone_research_unity # why is there no specific rw version lol
+						zone_slot = 2
+						replace = yes
+					} 
+					
 				}
 				# hiveminds
 				if = {
 					limit = { root = { is_hive_empire = yes } }
 					add_district = district_rw_hive
+					add_district = district_rw_urban_1
 					# is biological
 					if = {
 						limit = { root = { is_lithoid_empire = no } }
-						add_district = district_rw_farming
+						add_zone = {
+							district = district_rw_urban_1
+							zone = zone_food_ring_world
+							zone_slot = 0
+							replace = yes
+						} 
 					}
 					# is lithoid
 					else = {
-						add_district = district_rw_generator
+						add_zone = {
+							district = district_rw_urban_1
+							zone = zone_energy_ring_world
+							zone_slot = 0
+							replace = yes
+						} 
 						add_deposit = d_great_ring_excavated_mountain
 					}
+
+					## zones
+					add_zone = {
+						district = district_rw_hive
+						zone = zone_industrial_ring_world
+						zone_slot = 1
+						replace = no
+					} 
+					add_zone = {
+						district = district_rw_hive
+						zone = zone_research_unity # why is there no specific rw version lol
+						zone_slot = 2
+						replace = yes
+					} 
 				}
 				# machine empires
 				else_if = {
 					limit = { root = { is_machine_empire = yes } }
 					add_district = district_rw_nexus
+					add_district = district_rw_urban_1
 					# is normal machine empire
 					if = {
 						limit = {
@@ -312,7 +363,12 @@ country_event = {
 								}
 							}
 						}
-						add_district = district_rw_generator
+						add_zone = {
+							district = district_rw_urban_1
+							zone = zone_energy_ring_world
+							zone_slot = 0
+							replace = yes
+						}
 					}
 					else = {
 						# rogue servitor / determined assimilator with biological pops
@@ -321,7 +377,14 @@ country_event = {
 								root = { NOT = { any_owned_pop_group = { has_trait = trait_lithoid } } }
 							}
 							add_district = district_rw_nexus
-							add_building = building_giga_interstellar_hydroponic_farm
+							# add_building = building_giga_interstellar_hydroponic_farm
+								# swapped it for a district
+							add_zone = {
+								district = district_rw_urban_1
+								zone = zone_food_ring_world
+								zone_slot = 0
+								replace = yes
+							} 
 							remove_deposit = d_segment_rubble_1
 							remove_deposit = d_segment_rubble_1
 							remove_deposit = d_segment_rubble_2
@@ -330,12 +393,34 @@ country_event = {
 						# rogue servitor / determined assimilator with lithoid pops
 						else = {
 							add_district = district_rw_nexus
+							add_zone = {
+								district = district_rw_urban_1
+								zone = zone_energy_ring_world
+								zone_slot = 0
+								replace = yes
+							} 
 							add_deposit = d_great_ring_excavated_mountain
 							remove_deposit = d_segment_rubble_2
 							remove_deposit = d_segment_rubble_2
 						}
 					}
+
+					## zones
+					add_zone = {
+						district = district_rw_nexus
+						zone = zone_industrial_ring_world
+						zone_slot = 1
+						replace = no
+					} 
+					add_zone = {
+						district = district_rw_nexus
+						zone = zone_research_unity # why is there no specific rw version lol
+						zone_slot = 2
+						replace = yes
+					} 
 				}
+
+				
 			}
 		}
 	}


### PR DESCRIPTION
# Alderson Origin Fixes
Fixed the random commercial alderson district that appears then disappears on galaxy generation
Moved the start buildings of alderson origin to the archive zone where appropriate
# Great Ring Origin Fixes
Fixed the starting districts + specializations (you will need to disable some metallurgists)
Increased the number of Matter Synthesizer jobs by 100x to match 4.0 pop numbers
