### PR TITLE
alderson priest / servitor zones

### DIFF
--- a/common/inline_scripts/zones/alderson/unity_servitor_zone_alderson.txt
+++ b/common/inline_scripts/zones/alderson/unity_servitor_zone_alderson.txt
@@ -1,0 +1,47 @@
+icon = GFX_district_specialization_urban
+base_buildtime = @zone_buildtime
+potential = { # planet scope
+	hidden_trigger = { exists = owner }
+	owner = {
+		has_valid_civic = civic_machine_servitor
+	}
+}
+
+unlock = { # planet scope
+	exists = owner
+	owner = {
+		has_valid_civic = civic_machine_servitor
+	}
+}
+
+resources = {
+	category = planet_zones
+	cost = {
+		minerals = @giga_alderson_zone_cost
+	}
+}
+
+included_building_sets = {
+	unity
+	bio_trophy
+	origin
+	giga_automation
+}
+
+inline_script = {
+	script = jobs/zone_unity_jobs_add
+	AMOUNT = $AMOUNT$
+}
+
+planet_modifier = {
+	zone_building_slots_add = 3
+}
+
+ai_resource_production = {
+	unity = 15
+
+	trigger = {
+		has_any_unity_zone = yes
+	}
+}
+ai_priority = 10

--- a/common/inline_scripts/zones/alderson/unity_spiritualist_zone_alderson.txt
+++ b/common/inline_scripts/zones/alderson/unity_spiritualist_zone_alderson.txt
@@ -1,0 +1,52 @@
+icon = GFX_district_specialization_priest
+base_buildtime = @zone_buildtime
+potential = { # planet scope
+	hidden_trigger = { exists = owner }
+	owner = {
+		is_spiritualist = yes
+	}
+	OR = {
+		owner = {
+			is_ai = no
+		}
+		AND = {
+			has_any_research_zone = no
+			has_any_industrial_zone = no
+		}
+	}
+}
+
+unlock = { # planet scope
+	always = yes
+}
+
+resources = {
+	category = planet_zones
+	cost = {
+		minerals = @giga_alderson_zone_cost
+	}
+}
+
+included_building_sets = {
+	unity
+	origin
+	giga_automation
+}
+
+inline_script = {
+	script = jobs/zone_unity_jobs_add
+	AMOUNT = $AMOUNT$
+}
+
+planet_modifier = {
+	zone_building_slots_add = 3
+}
+
+ai_resource_production = {
+	unity = 15
+
+	trigger = {
+		has_any_unity_zone = yes
+	}
+}
+ai_priority = 10

--- a/common/zone_slots/gigas_zone_slots.txt
+++ b/common/zone_slots/gigas_zone_slots.txt
@@ -146,6 +146,8 @@ slot_district_alderson_pcc_01 = {
 		zone_alderson_research_engineering
 		zone_alderson_research
 		zone_alderson_unity
+		zone_alderson_unity_spiritualist
+		zone_alderson_unity_servitor
 		zone_alderson_trade
 	}
 
@@ -161,6 +163,8 @@ slot_district_alderson_pcc_02 = {
 		zone_alderson_research_engineering
 		zone_alderson_research
 		zone_alderson_unity
+		zone_alderson_unity_spiritualist
+		zone_alderson_unity_servitor
 		zone_alderson_trade
 	}
 
@@ -176,6 +180,8 @@ slot_district_alderson_pcc_03 = {
 		zone_alderson_research_engineering
 		zone_alderson_research
 		zone_alderson_unity
+		zone_alderson_unity_spiritualist
+		zone_alderson_unity_servitor
 		zone_alderson_trade
 	}
 
@@ -191,6 +197,8 @@ slot_district_alderson_pcc_04 = {
 		zone_alderson_research_engineering
 		zone_alderson_research
 		zone_alderson_unity
+		zone_alderson_unity_spiritualist
+		zone_alderson_unity_servitor
 		zone_alderson_trade
 	}
 

--- a/common/zones/giga_zones.txt
+++ b/common/zones/giga_zones.txt
@@ -418,6 +418,40 @@ zone_alderson_unity = {
 	ai_weight_coefficient = 1.1
 }
 
+zone_alderson_unity_spiritualist = {
+	inline_script = {
+		script = zones/alderson/unity_spiritualist_zone_alderson
+		AMOUNT = @giga_alderson_district_jobs
+	}
+
+	zone_sets = {
+		alderson
+	}
+
+	ai_priority = 15
+
+
+
+	ai_weight_coefficient = 1.1
+}
+
+zone_alderson_unity_servitor = {
+	inline_script = {
+		script = zones/alderson/unity_servitor_zone_alderson
+		AMOUNT = @giga_alderson_district_jobs * 5
+	}
+
+	zone_sets = {
+		alderson
+	}
+
+	ai_priority = 15
+
+
+
+	ai_weight_coefficient = 1.1
+}
+
 zone_alderson_cg = {
 	inline_script = {
 		script = zones/alderson/industrial_factory_zone_alderson

--- a/events/giga_203_origins_rings.txt
+++ b/events/giga_203_origins_rings.txt
@@ -271,18 +271,9 @@ country_event = {
 					}
 					add_district = district_rw_city
 					add_district = district_rw_urban_1
-					# is biological
+					# lithoid
 					if = {
-						limit = { root = { is_lithoid_empire = no } }
-						add_zone = {
-							district = district_rw_urban_1
-							zone = zone_food_ring_world
-							zone_slot = 0
-							replace = yes
-						} 
-					}
-					# is lithoid
-					else = {
+						limit = { root = { is_lithoid_empire = yes } }
 						add_deposit = d_interstellar_ringworld_commerce_blocker
 						add_zone = {
 							district = district_rw_urban_1
@@ -290,7 +281,26 @@ country_event = {
 							zone_slot = 0
 							replace = yes
 						} 
-						add_deposit = d_great_ring_excavated_mountain
+						add_deposit = d_great_ring_excavated_mountain	
+					}
+					# is indiv machine
+					else_if = {
+						limit = { root = { is_individual_machine = yes } }
+						add_zone = {
+							district = district_rw_urban_1
+							zone = zone_energy_ring_world
+							zone_slot = 0
+							replace = yes
+						}
+					}
+					# if biological
+					else = {
+						add_zone = {
+							district = district_rw_urban_1
+							zone = zone_food_ring_world
+							zone_slot = 0
+							replace = yes
+						} 
 					}
 					
 					## zones

--- a/localisation/braz_por/giga_l_braz_por.yml
+++ b/localisation/braz_por/giga_l_braz_por.yml
@@ -4232,6 +4232,10 @@
   zone_alderson_research_desc:99 "Futilely attempting to run Crysis."
   zone_alderson_unity:99 "Bureaucratic Gigaprocessors"
   zone_alderson_unity_desc:99 "Endless rows of processors dedicated solely to handling digital paperwork."
+  zone_alderson_unity_spiritualist:99 "Sanctified Gigatemples"
+  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshippers stretch to the horizon."
+  zone_alderson_unity_servitor:99 "Organic Gigasanctuary"
+  zone_alderson_unity_servitor_desc:99 "Endless rows of skyscrapers packed to the brim with sapient organics, given any luxury they require in a perfect environment."
   zone_alderson_trade:99 "Ecologistical Omnipredictors"
   zone_alderson_trade_desc:99 "Overworked procressors handling logistical and economical predictions for our entire empire."
   

--- a/localisation/braz_por/giga_l_braz_por.yml
+++ b/localisation/braz_por/giga_l_braz_por.yml
@@ -4233,7 +4233,7 @@
   zone_alderson_unity:99 "Bureaucratic Gigaprocessors"
   zone_alderson_unity_desc:99 "Endless rows of processors dedicated solely to handling digital paperwork."
   zone_alderson_unity_spiritualist:99 "Sanctified Gigatemples"
-  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshippers stretch to the horizon."
+  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshipers stretch to the horizon."
   zone_alderson_unity_servitor:99 "Organic Gigasanctuary"
   zone_alderson_unity_servitor_desc:99 "Endless rows of skyscrapers packed to the brim with sapient organics, given any luxury they require in a perfect environment."
   zone_alderson_trade:99 "Ecologistical Omnipredictors"

--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -4232,6 +4232,10 @@
   zone_alderson_research_desc:0 "Futilely attempting to run Crysis."
   zone_alderson_unity:0 "Bureaucratic Gigaprocessors"
   zone_alderson_unity_desc:0 "Endless rows of processors dedicated solely to handling digital paperwork."
+  zone_alderson_unity_spiritualist:0 "Sanctified Gigatemples"
+  zone_alderson_unity_spiritualist_desc:0 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshippers stretch to the horizon."
+  zone_alderson_unity_servitor:0 "Organic Gigasanctuary"
+  zone_alderson_unity_servitor_desc:0 "Endless rows of skyscrapers packed to the brim with sapient organics, given any luxury they require in a perfect environment."
   zone_alderson_trade:0 "Ecologistical Omnipredictors"
   zone_alderson_trade_desc:0 "Overworked procressors handling logistical and economical predictions for our entire empire."
 

--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -4233,7 +4233,7 @@
   zone_alderson_unity:0 "Bureaucratic Gigaprocessors"
   zone_alderson_unity_desc:0 "Endless rows of processors dedicated solely to handling digital paperwork."
   zone_alderson_unity_spiritualist:0 "Sanctified Gigatemples"
-  zone_alderson_unity_spiritualist_desc:0 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshippers stretch to the horizon."
+  zone_alderson_unity_spiritualist_desc:0 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshipers stretch to the horizon."
   zone_alderson_unity_servitor:0 "Organic Gigasanctuary"
   zone_alderson_unity_servitor_desc:0 "Endless rows of skyscrapers packed to the brim with sapient organics, given any luxury they require in a perfect environment."
   zone_alderson_trade:0 "Ecologistical Omnipredictors"

--- a/localisation/french/giga_l_french.yml
+++ b/localisation/french/giga_l_french.yml
@@ -4232,6 +4232,10 @@
   zone_alderson_research_desc:99 "Futilely attempting to run Crysis."
   zone_alderson_unity:99 "Bureaucratic Gigaprocessors"
   zone_alderson_unity_desc:99 "Endless rows of processors dedicated solely to handling digital paperwork."
+  zone_alderson_unity_spiritualist:99 "Sanctified Gigatemples"
+  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshippers stretch to the horizon."
+  zone_alderson_unity_servitor:99 "Organic Gigasanctuary"
+  zone_alderson_unity_servitor_desc:99 "Endless rows of skyscrapers packed to the brim with sapient organics, given any luxury they require in a perfect environment."
   zone_alderson_trade:99 "Ecologistical Omnipredictors"
   zone_alderson_trade_desc:99 "Overworked procressors handling logistical and economical predictions for our entire empire."
   

--- a/localisation/french/giga_l_french.yml
+++ b/localisation/french/giga_l_french.yml
@@ -4233,7 +4233,7 @@
   zone_alderson_unity:99 "Bureaucratic Gigaprocessors"
   zone_alderson_unity_desc:99 "Endless rows of processors dedicated solely to handling digital paperwork."
   zone_alderson_unity_spiritualist:99 "Sanctified Gigatemples"
-  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshippers stretch to the horizon."
+  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshipers stretch to the horizon."
   zone_alderson_unity_servitor:99 "Organic Gigasanctuary"
   zone_alderson_unity_servitor_desc:99 "Endless rows of skyscrapers packed to the brim with sapient organics, given any luxury they require in a perfect environment."
   zone_alderson_trade:99 "Ecologistical Omnipredictors"

--- a/localisation/german/giga_l_german.yml
+++ b/localisation/german/giga_l_german.yml
@@ -4232,6 +4232,10 @@
   zone_alderson_research_desc:99 "Futilely attempting to run Crysis."
   zone_alderson_unity:99 "Bureaucratic Gigaprocessors"
   zone_alderson_unity_desc:99 "Endless rows of processors dedicated solely to handling digital paperwork."
+  zone_alderson_unity_spiritualist:99 "Sanctified Gigatemples"
+  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshippers stretch to the horizon."
+  zone_alderson_unity_servitor:99 "Organic Gigasanctuary"
+  zone_alderson_unity_servitor_desc:99 "Endless rows of skyscrapers packed to the brim with sapient organics, given any luxury they require in a perfect environment."
   zone_alderson_trade:99 "Ecologistical Omnipredictors"
   zone_alderson_trade_desc:99 "Overworked procressors handling logistical and economical predictions for our entire empire."
   

--- a/localisation/german/giga_l_german.yml
+++ b/localisation/german/giga_l_german.yml
@@ -4233,7 +4233,7 @@
   zone_alderson_unity:99 "Bureaucratic Gigaprocessors"
   zone_alderson_unity_desc:99 "Endless rows of processors dedicated solely to handling digital paperwork."
   zone_alderson_unity_spiritualist:99 "Sanctified Gigatemples"
-  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshippers stretch to the horizon."
+  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshipers stretch to the horizon."
   zone_alderson_unity_servitor:99 "Organic Gigasanctuary"
   zone_alderson_unity_servitor_desc:99 "Endless rows of skyscrapers packed to the brim with sapient organics, given any luxury they require in a perfect environment."
   zone_alderson_trade:99 "Ecologistical Omnipredictors"

--- a/localisation/polish/giga_l_polish.yml
+++ b/localisation/polish/giga_l_polish.yml
@@ -4232,6 +4232,10 @@
   zone_alderson_research_desc:99 "Futilely attempting to run Crysis."
   zone_alderson_unity:99 "Bureaucratic Gigaprocessors"
   zone_alderson_unity_desc:99 "Endless rows of processors dedicated solely to handling digital paperwork."
+  zone_alderson_unity_spiritualist:99 "Sanctified Gigatemples"
+  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshippers stretch to the horizon."
+  zone_alderson_unity_servitor:99 "Organic Gigasanctuary"
+  zone_alderson_unity_servitor_desc:99 "Endless rows of skyscrapers packed to the brim with sapient organics, given any luxury they require in a perfect environment."
   zone_alderson_trade:99 "Ecologistical Omnipredictors"
   zone_alderson_trade_desc:99 "Overworked procressors handling logistical and economical predictions for our entire empire."
   

--- a/localisation/polish/giga_l_polish.yml
+++ b/localisation/polish/giga_l_polish.yml
@@ -4233,7 +4233,7 @@
   zone_alderson_unity:99 "Bureaucratic Gigaprocessors"
   zone_alderson_unity_desc:99 "Endless rows of processors dedicated solely to handling digital paperwork."
   zone_alderson_unity_spiritualist:99 "Sanctified Gigatemples"
-  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshippers stretch to the horizon."
+  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshipers stretch to the horizon."
   zone_alderson_unity_servitor:99 "Organic Gigasanctuary"
   zone_alderson_unity_servitor_desc:99 "Endless rows of skyscrapers packed to the brim with sapient organics, given any luxury they require in a perfect environment."
   zone_alderson_trade:99 "Ecologistical Omnipredictors"

--- a/localisation/russian/giga_l_russian.yml
+++ b/localisation/russian/giga_l_russian.yml
@@ -4232,6 +4232,10 @@
   zone_alderson_research_desc:99 "Futilely attempting to run Crysis."
   zone_alderson_unity:99 "Bureaucratic Gigaprocessors"
   zone_alderson_unity_desc:99 "Endless rows of processors dedicated solely to handling digital paperwork."
+  zone_alderson_unity_spiritualist:99 "Sanctified Gigatemples"
+  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshippers stretch to the horizon."
+  zone_alderson_unity_servitor:99 "Organic Gigasanctuary"
+  zone_alderson_unity_servitor_desc:99 "Endless rows of skyscrapers packed to the brim with sapient organics, given any luxury they require in a perfect environment."
   zone_alderson_trade:99 "Ecologistical Omnipredictors"
   zone_alderson_trade_desc:99 "Overworked procressors handling logistical and economical predictions for our entire empire."
   

--- a/localisation/russian/giga_l_russian.yml
+++ b/localisation/russian/giga_l_russian.yml
@@ -4233,7 +4233,7 @@
   zone_alderson_unity:99 "Bureaucratic Gigaprocessors"
   zone_alderson_unity_desc:99 "Endless rows of processors dedicated solely to handling digital paperwork."
   zone_alderson_unity_spiritualist:99 "Sanctified Gigatemples"
-  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshippers stretch to the horizon."
+  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshipers stretch to the horizon."
   zone_alderson_unity_servitor:99 "Organic Gigasanctuary"
   zone_alderson_unity_servitor_desc:99 "Endless rows of skyscrapers packed to the brim with sapient organics, given any luxury they require in a perfect environment."
   zone_alderson_trade:99 "Ecologistical Omnipredictors"

--- a/localisation/simp_chinese/giga_l_simp_chinese.yml
+++ b/localisation/simp_chinese/giga_l_simp_chinese.yml
@@ -4232,6 +4232,10 @@
   zone_alderson_research_desc:99 "Futilely attempting to run Crysis."
   zone_alderson_unity:99 "Bureaucratic Gigaprocessors"
   zone_alderson_unity_desc:99 "Endless rows of processors dedicated solely to handling digital paperwork."
+  zone_alderson_unity_spiritualist:99 "Sanctified Gigatemples"
+  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshippers stretch to the horizon."
+  zone_alderson_unity_servitor:99 "Organic Gigasanctuary"
+  zone_alderson_unity_servitor_desc:99 "Endless rows of skyscrapers packed to the brim with sapient organics, given any luxury they require in a perfect environment."
   zone_alderson_trade:99 "Ecologistical Omnipredictors"
   zone_alderson_trade_desc:99 "Overworked procressors handling logistical and economical predictions for our entire empire."
   

--- a/localisation/simp_chinese/giga_l_simp_chinese.yml
+++ b/localisation/simp_chinese/giga_l_simp_chinese.yml
@@ -4233,7 +4233,7 @@
   zone_alderson_unity:99 "Bureaucratic Gigaprocessors"
   zone_alderson_unity_desc:99 "Endless rows of processors dedicated solely to handling digital paperwork."
   zone_alderson_unity_spiritualist:99 "Sanctified Gigatemples"
-  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshippers stretch to the horizon."
+  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshipers stretch to the horizon."
   zone_alderson_unity_servitor:99 "Organic Gigasanctuary"
   zone_alderson_unity_servitor_desc:99 "Endless rows of skyscrapers packed to the brim with sapient organics, given any luxury they require in a perfect environment."
   zone_alderson_trade:99 "Ecologistical Omnipredictors"

--- a/localisation/spanish/giga_l_spanish.yml
+++ b/localisation/spanish/giga_l_spanish.yml
@@ -4232,6 +4232,10 @@
   zone_alderson_research_desc:99 "Futilely attempting to run Crysis."
   zone_alderson_unity:99 "Bureaucratic Gigaprocessors"
   zone_alderson_unity_desc:99 "Endless rows of processors dedicated solely to handling digital paperwork."
+  zone_alderson_unity_spiritualist:99 "Sanctified Gigatemples"
+  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshippers stretch to the horizon."
+  zone_alderson_unity_servitor:99 "Organic Gigasanctuary"
+  zone_alderson_unity_servitor_desc:99 "Endless rows of skyscrapers packed to the brim with sapient organics, given any luxury they require in a perfect environment."
   zone_alderson_trade:99 "Ecologistical Omnipredictors"
   zone_alderson_trade_desc:99 "Overworked procressors handling logistical and economical predictions for our entire empire."
   

--- a/localisation/spanish/giga_l_spanish.yml
+++ b/localisation/spanish/giga_l_spanish.yml
@@ -4233,7 +4233,7 @@
   zone_alderson_unity:99 "Bureaucratic Gigaprocessors"
   zone_alderson_unity_desc:99 "Endless rows of processors dedicated solely to handling digital paperwork."
   zone_alderson_unity_spiritualist:99 "Sanctified Gigatemples"
-  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshippers stretch to the horizon."
+  zone_alderson_unity_spiritualist_desc:99 "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshipers stretch to the horizon."
   zone_alderson_unity_servitor:99 "Organic Gigasanctuary"
   zone_alderson_unity_servitor_desc:99 "Endless rows of skyscrapers packed to the brim with sapient organics, given any luxury they require in a perfect environment."
   zone_alderson_trade:99 "Ecologistical Omnipredictors"


### PR DESCRIPTION
Fixes:
Added priest and servitor districts to alderson
Individualist machines now have generator instead of farm district in great ring




Tried my best with the loc:

"Sanctified Gigatemples" "Endless buildings of worship dot the landscape, and the lines of pilgrims and worshipers stretch to the horizon."
"Organic Gigasanctuary" "Endless rows of skyscrapers packed to the brim with sapient organics, given any luxury they require in a perfect environment."
