### PR TITLE
Fix for missing new psionic tradition condition + missing alderson mutagenic hab trait

### DIFF
--- a/common/buildings/giga_buildings.txt
+++ b/common/buildings/giga_buildings.txt
@@ -520,7 +520,10 @@ building_giga_shroud_conduit = {
 		}
 		exists = owner
 		owner = {
-			has_tradition = tr_psionics_adopt
+			OR = {
+				has_tradition = tr_psionics_adopt
+				has_tradition = tr_psionics_shroud_adopt
+			}
 		}
 	}
 

--- a/common/decisions/giga_decisions.txt
+++ b/common/decisions/giga_decisions.txt
@@ -431,7 +431,10 @@ decision_psionic_sublimation = {
 	potential = {
 		exists = owner
 		owner = {
-			has_tradition = tr_psionics_psi_corps
+			OR = {
+				has_tradition = tr_psionics_adopt
+				has_tradition = tr_psionics_shroud_adopt
+			}
 			has_technology = giga_tech_psychic_beacon
 			OR = {
 				has_megastructure = psychic_beacon_3
@@ -449,6 +452,7 @@ decision_psionic_sublimation = {
 			has_building = building_eater_sanctum
 			has_building = building_instrument_sanctum
 			has_building = building_whisperers_sanctum
+			has_building = building_cradle_sanctum
 			# equivalent on orbital ring
 			if = {
 				limit = {
@@ -466,10 +470,17 @@ decision_psionic_sublimation = {
 			}
 		}
 		#any_owned_pop_group = { has_job = telepath }
-		num_assigned_jobs = {
-			job = telepath
-			value > 0
+		OR = {
+			num_assigned_jobs = {
+				job = telepath
+				value > 0
+			}
+			num_assigned_jobs = {
+				job = telepath_drone
+				value > 0
+			}
 		}
+		
 	}
 
 	effect = {

--- a/common/inline_scripts/buildings/elysium/giga_elysium_capital_modifiers.txt
+++ b/common/inline_scripts/buildings/elysium/giga_elysium_capital_modifiers.txt
@@ -44,7 +44,10 @@ triggered_planet_modifier = {
     potential = {
         exists = owner
         owner = {
-            has_tradition = tr_psionics_psi_corps
+            OR = {
+				has_tradition = tr_psionics_psi_corps
+				has_tradition = tr_psionics_shroud_psi_corps
+			}
         }
     }
     modifier = {
@@ -86,7 +89,10 @@ triggered_desc = {
     trigger = {
         exists = owner
         owner = {
-            has_tradition = tr_psionics_psi_corps
+            OR = {
+				has_tradition = tr_psionics_psi_corps
+				has_tradition = tr_psionics_shroud_psi_corps
+			}
         }
     }
     text = job_telepath_effect_desc

--- a/common/planet_classes/giga_alderson.txt
+++ b/common/planet_classes/giga_alderson.txt
@@ -14,6 +14,10 @@ pc_alderson_slice_gaia = {
 	atmosphere_intensity 	= 1.0
 	atmosphere_width 		= 0.5
 
+	auto_trait_prio = {
+		trait_auto_pc_alderson_slice_preference
+	}
+
 	show_city = yes
 	city_color_lut = "gfx/portraits/misc/colorcorrection_continental.dds"
 	extra_orbit_size = 0
@@ -51,6 +55,10 @@ pc_alderson_slice_gaia_shattered = {
 	atmosphere_intensity 	= 1.0
 	atmosphere_width 		= 0.5
 
+	auto_trait_prio = {
+		trait_auto_pc_alderson_slice_preference
+	}
+	
 	show_city = yes
 	city_color_lut = "gfx/portraits/misc/colorcorrection_continental.dds"
 	extra_orbit_size = 0

--- a/common/scripted_triggers/giga_aeternum_triggers.txt
+++ b/common/scripted_triggers/giga_aeternum_triggers.txt
@@ -12,7 +12,10 @@ is_regular_birch_empire = {
 is_psionic_or_aeternum = {
 	or = {
 		is_country_type = dormant_aeternum
-		has_tradition = tr_psionics_adopt
+		OR = {
+			has_tradition = tr_psionics_adopt
+			has_tradition = tr_psionics_shroud_adopt
+		}
 	}
 }
 

--- a/common/traits/giga_habitibility.txt
+++ b/common/traits/giga_habitibility.txt
@@ -737,272 +737,272 @@ trait_pc_alderson_slice_pc_preference = {
     ai_weight = { weight = 0 }
 }
 
-trait_pc_alderson_slice_ecu_preference = {
-	icon = "gfx/interface/icons/traits/trait_pc_ring_preference.dds"
-	allowed_archetypes = { BIOLOGICAL PRESAPIENT LITHOID }
-	sorting_priority = 30
-	initial = no
-	randomized = no
-	species_potential_add = { always = no }
-	species_possible_merge_add = { always = yes }
-	modifier = {
-		pc_alderson_slice_gaia_habitability = 1.0
-		pc_alderson_slice_pc_habitability = 1.0
-		pc_alderson_slice_ecu_habitability = 1.0
-		pc_alderson_slice_hive_habitability = 0.0
-		pc_alderson_slice_machine_habitability = 0.0
-		pc_desert_habitability = 0.4
-		pc_arid_habitability =  0.4
-		pc_savannah_habitability = 0.4
-		pc_tropical_habitability = 0.4
-		pc_continental_habitability = 0.4
-		pc_tundra_habitability = 0.4
-		pc_arctic_habitability = 0.4
-		pc_ocean_habitability = 0.4
-		pc_alpine_habitability = 0.4
+# trait_pc_alderson_slice_ecu_preference = {
+# 	icon = "gfx/interface/icons/traits/trait_pc_ring_preference.dds"
+# 	allowed_archetypes = { BIOLOGICAL PRESAPIENT LITHOID }
+# 	sorting_priority = 30
+# 	initial = no
+# 	randomized = no
+# 	species_potential_add = { always = no }
+# 	species_possible_merge_add = { always = yes }
+# 	modifier = {
+# 		pc_alderson_slice_gaia_habitability = 1.0
+# 		pc_alderson_slice_pc_habitability = 1.0
+# 		pc_alderson_slice_ecu_habitability = 1.0
+# 		pc_alderson_slice_hive_habitability = 0.0
+# 		pc_alderson_slice_machine_habitability = 0.0
+# 		pc_desert_habitability = 0.4
+# 		pc_arid_habitability =  0.4
+# 		pc_savannah_habitability = 0.4
+# 		pc_tropical_habitability = 0.4
+# 		pc_continental_habitability = 0.4
+# 		pc_tundra_habitability = 0.4
+# 		pc_arctic_habitability = 0.4
+# 		pc_ocean_habitability = 0.4
+# 		pc_alpine_habitability = 0.4
 
-		# Planetary Diversity
-		# NOOOOOOOO MORE PLANETARY DIVERSITY PLANET CLASSES :3 (thx gate <3)
+# 		# Planetary Diversity
+# 		# NOOOOOOOO MORE PLANETARY DIVERSITY PLANET CLASSES :3 (thx gate <3)
 		
-		pc_superhabitable_habitability = 0.4
-		pc_tidallylocked_habitability = 0.4
+# 		pc_superhabitable_habitability = 0.4
+# 		pc_tidallylocked_habitability = 0.4
 		
-		# pc_cascadian_habitability = 0.4
-		# pc_desertislands_habitability = 0.4
-		# pc_subarctic_habitability = 0.4
-		# pc_mangrove_habitability = 0.4
-		# pc_wetswamp_habitability = 0.4
-		# pc_hajungle_habitability = 0.4
-		# pc_retinal_habitability = 0.4
-		# pc_forest_habitability = 0.4
-		# pc_lake_habitability = 0.4
-		# pc_outback_habitability = 0.4
-		# pc_steppe_habitability = 0.4
-		# pc_sandsea_habitability = 0.4
-		# pc_oasis_habitability = 0.4
-		# pc_mesa_habitability = 0.4
-		# pc_hadesert_habitability = 0.4
-		# pc_prairie_habitability = 0.4
-		# pc_veld_habitability = 0.4
-		# pc_med_habitability = 0.4
-		# pc_highland_habitability = 0.4
-		# pc_swamp_habitability = 0.4
-		# pc_mud_habitability = 0.4
-		# pc_frozen_desert_habitability = 0.4
-		# pc_glacial_habitability = 0.4
-		# pc_boreal_habitability = 0.4
-		# pc_mushroom_habitability = 0.4
-		# pc_antarctic_habitability = 0.4
-		# pc_snow_habitability = 0.4
-		# pc_geothermal_habitability = 0.4
-		# pc_biolumen_habitability = 0.4
-		# pc_karst_habitability = 0.4
-		# pc_primal_habitability = 0.4
-		# pc_salt_habitability = 0.4
-		# pc_coral_habitability = 0.4
-		# pc_storm_habitability = 0.4
-		# pc_megaflora_habitability = 0.4
-		# pc_irradiated_habitability = 0.4
-		# pc_megafloratol_habitability = 0.4
-		# pc_aquatic_habitability = 0.4
-		# pc_graveyard_habitability = 0.4
-		# pc_floating_habitability = 0.4
-		# pc_crystal_habitability = 0.4
-		# pc_technoorganic_habitability = 0.4
-		# pc_archive_habitability = 0.4
-		# pc_bioforge_habitability = 0.4
-		# pc_ecocity_habitability = 0.4
-		# pc_relic_habitability = 0.4
-		# pc_aquatichot_habitability = 0.4
-		# pc_aquaticcold_habitability = 0.4
-		# pc_aquaticcity_habitability = 0.4
-		# pc_pdfloraforge_habitability = 0.4
-		# pc_ammonia_habitability = 0.4
-		# pc_methane_habitability = 0.4
-		# pc_ash_habitability = 0.4
-		# pc_acid_habitability = 0.4
-		# pc_rogue_habitability = 0.4
-	}
-    ai_weight = { weight = 0 }
-}
+# 		# pc_cascadian_habitability = 0.4
+# 		# pc_desertislands_habitability = 0.4
+# 		# pc_subarctic_habitability = 0.4
+# 		# pc_mangrove_habitability = 0.4
+# 		# pc_wetswamp_habitability = 0.4
+# 		# pc_hajungle_habitability = 0.4
+# 		# pc_retinal_habitability = 0.4
+# 		# pc_forest_habitability = 0.4
+# 		# pc_lake_habitability = 0.4
+# 		# pc_outback_habitability = 0.4
+# 		# pc_steppe_habitability = 0.4
+# 		# pc_sandsea_habitability = 0.4
+# 		# pc_oasis_habitability = 0.4
+# 		# pc_mesa_habitability = 0.4
+# 		# pc_hadesert_habitability = 0.4
+# 		# pc_prairie_habitability = 0.4
+# 		# pc_veld_habitability = 0.4
+# 		# pc_med_habitability = 0.4
+# 		# pc_highland_habitability = 0.4
+# 		# pc_swamp_habitability = 0.4
+# 		# pc_mud_habitability = 0.4
+# 		# pc_frozen_desert_habitability = 0.4
+# 		# pc_glacial_habitability = 0.4
+# 		# pc_boreal_habitability = 0.4
+# 		# pc_mushroom_habitability = 0.4
+# 		# pc_antarctic_habitability = 0.4
+# 		# pc_snow_habitability = 0.4
+# 		# pc_geothermal_habitability = 0.4
+# 		# pc_biolumen_habitability = 0.4
+# 		# pc_karst_habitability = 0.4
+# 		# pc_primal_habitability = 0.4
+# 		# pc_salt_habitability = 0.4
+# 		# pc_coral_habitability = 0.4
+# 		# pc_storm_habitability = 0.4
+# 		# pc_megaflora_habitability = 0.4
+# 		# pc_irradiated_habitability = 0.4
+# 		# pc_megafloratol_habitability = 0.4
+# 		# pc_aquatic_habitability = 0.4
+# 		# pc_graveyard_habitability = 0.4
+# 		# pc_floating_habitability = 0.4
+# 		# pc_crystal_habitability = 0.4
+# 		# pc_technoorganic_habitability = 0.4
+# 		# pc_archive_habitability = 0.4
+# 		# pc_bioforge_habitability = 0.4
+# 		# pc_ecocity_habitability = 0.4
+# 		# pc_relic_habitability = 0.4
+# 		# pc_aquatichot_habitability = 0.4
+# 		# pc_aquaticcold_habitability = 0.4
+# 		# pc_aquaticcity_habitability = 0.4
+# 		# pc_pdfloraforge_habitability = 0.4
+# 		# pc_ammonia_habitability = 0.4
+# 		# pc_methane_habitability = 0.4
+# 		# pc_ash_habitability = 0.4
+# 		# pc_acid_habitability = 0.4
+# 		# pc_rogue_habitability = 0.4
+# 	}
+#     ai_weight = { weight = 0 }
+# }
 
-trait_pc_alderson_slice_hive_preference = {
-	icon = "gfx/interface/icons/traits/trait_pc_ring_preference.dds"
-	allowed_archetypes = { BIOLOGICAL PRESAPIENT LITHOID }
-	sorting_priority = 30
-	initial = no
-	randomized = no
-	species_potential_add = { always = no }
-	species_possible_merge_add = { always = yes }
-	modifier = {
-		pc_alderson_slice_gaia_habitability = 1.0
-		pc_alderson_slice_pc_habitability = 1.0
-		pc_alderson_slice_ecu_habitability = 0.0
-		pc_alderson_slice_hive_habitability = 1.0
-		pc_alderson_slice_machine_habitability = 0.0
-		pc_desert_habitability = 0.4
-		pc_arid_habitability =  0.4
-		pc_savannah_habitability = 0.4
-		pc_tropical_habitability = 0.4
-		pc_continental_habitability = 0.4
-		pc_tundra_habitability = 0.4
-		pc_arctic_habitability = 0.4
-		pc_ocean_habitability = 0.4
-		pc_alpine_habitability = 0.4
+# trait_pc_alderson_slice_hive_preference = {
+# 	icon = "gfx/interface/icons/traits/trait_pc_ring_preference.dds"
+# 	allowed_archetypes = { BIOLOGICAL PRESAPIENT LITHOID }
+# 	sorting_priority = 30
+# 	initial = no
+# 	randomized = no
+# 	species_potential_add = { always = no }
+# 	species_possible_merge_add = { always = yes }
+# 	modifier = {
+# 		pc_alderson_slice_gaia_habitability = 1.0
+# 		pc_alderson_slice_pc_habitability = 1.0
+# 		pc_alderson_slice_ecu_habitability = 0.0
+# 		pc_alderson_slice_hive_habitability = 1.0
+# 		pc_alderson_slice_machine_habitability = 0.0
+# 		pc_desert_habitability = 0.4
+# 		pc_arid_habitability =  0.4
+# 		pc_savannah_habitability = 0.4
+# 		pc_tropical_habitability = 0.4
+# 		pc_continental_habitability = 0.4
+# 		pc_tundra_habitability = 0.4
+# 		pc_arctic_habitability = 0.4
+# 		pc_ocean_habitability = 0.4
+# 		pc_alpine_habitability = 0.4
 
-		# Planetary Diversity
-		# NOOOOOOOO MORE PLANETARY DIVERSITY PLANET CLASSES :3 (thx gate <3)
+# 		# Planetary Diversity
+# 		# NOOOOOOOO MORE PLANETARY DIVERSITY PLANET CLASSES :3 (thx gate <3)
 		
-		pc_superhabitable_habitability = 0.4
-		pc_tidallylocked_habitability = 0.4
+# 		pc_superhabitable_habitability = 0.4
+# 		pc_tidallylocked_habitability = 0.4
 		
-		# pc_cascadian_habitability = 0.4
-		# pc_desertislands_habitability = 0.4
-		# pc_subarctic_habitability = 0.4
-		# pc_mangrove_habitability = 0.4
-		# pc_wetswamp_habitability = 0.4
-		# pc_hajungle_habitability = 0.4
-		# pc_retinal_habitability = 0.4
-		# pc_forest_habitability = 0.4
-		# pc_lake_habitability = 0.4
-		# pc_outback_habitability = 0.4
-		# pc_steppe_habitability = 0.4
-		# pc_sandsea_habitability = 0.4
-		# pc_oasis_habitability = 0.4
-		# pc_mesa_habitability = 0.4
-		# pc_hadesert_habitability = 0.4
-		# pc_prairie_habitability = 0.4
-		# pc_veld_habitability = 0.4
-		# pc_med_habitability = 0.4
-		# pc_highland_habitability = 0.4
-		# pc_swamp_habitability = 0.4
-		# pc_mud_habitability = 0.4
-		# pc_frozen_desert_habitability = 0.4
-		# pc_glacial_habitability = 0.4
-		# pc_boreal_habitability = 0.4
-		# pc_mushroom_habitability = 0.4
-		# pc_antarctic_habitability = 0.4
-		# pc_snow_habitability = 0.4
-		# pc_geothermal_habitability = 0.4
-		# pc_biolumen_habitability = 0.4
-		# pc_karst_habitability = 0.4
-		# pc_primal_habitability = 0.4
-		# pc_salt_habitability = 0.4
-		# pc_coral_habitability = 0.4
-		# pc_storm_habitability = 0.4
-		# pc_megaflora_habitability = 0.4
-		# pc_irradiated_habitability = 0.4
-		# pc_megafloratol_habitability = 0.4
-		# pc_aquatic_habitability = 0.4
-		# pc_graveyard_habitability = 0.4
-		# pc_floating_habitability = 0.4
-		# pc_crystal_habitability = 0.4
-		# pc_technoorganic_habitability = 0.4
-		# pc_archive_habitability = 0.4
-		# pc_bioforge_habitability = 0.4
-		# pc_ecocity_habitability = 0.4
-		# pc_relic_habitability = 0.4
-		# pc_aquatichot_habitability = 0.4
-		# pc_aquaticcold_habitability = 0.4
-		# pc_aquaticcity_habitability = 0.4
-		# pc_pdfloraforge_habitability = 0.4
-		# pc_ammonia_habitability = 0.4
-		# pc_methane_habitability = 0.4
-		# pc_ash_habitability = 0.4
-		# pc_acid_habitability = 0.4
-		# pc_rogue_habitability = 0.4
-	}
-    ai_weight = { weight = 0 }
-}
+# 		# pc_cascadian_habitability = 0.4
+# 		# pc_desertislands_habitability = 0.4
+# 		# pc_subarctic_habitability = 0.4
+# 		# pc_mangrove_habitability = 0.4
+# 		# pc_wetswamp_habitability = 0.4
+# 		# pc_hajungle_habitability = 0.4
+# 		# pc_retinal_habitability = 0.4
+# 		# pc_forest_habitability = 0.4
+# 		# pc_lake_habitability = 0.4
+# 		# pc_outback_habitability = 0.4
+# 		# pc_steppe_habitability = 0.4
+# 		# pc_sandsea_habitability = 0.4
+# 		# pc_oasis_habitability = 0.4
+# 		# pc_mesa_habitability = 0.4
+# 		# pc_hadesert_habitability = 0.4
+# 		# pc_prairie_habitability = 0.4
+# 		# pc_veld_habitability = 0.4
+# 		# pc_med_habitability = 0.4
+# 		# pc_highland_habitability = 0.4
+# 		# pc_swamp_habitability = 0.4
+# 		# pc_mud_habitability = 0.4
+# 		# pc_frozen_desert_habitability = 0.4
+# 		# pc_glacial_habitability = 0.4
+# 		# pc_boreal_habitability = 0.4
+# 		# pc_mushroom_habitability = 0.4
+# 		# pc_antarctic_habitability = 0.4
+# 		# pc_snow_habitability = 0.4
+# 		# pc_geothermal_habitability = 0.4
+# 		# pc_biolumen_habitability = 0.4
+# 		# pc_karst_habitability = 0.4
+# 		# pc_primal_habitability = 0.4
+# 		# pc_salt_habitability = 0.4
+# 		# pc_coral_habitability = 0.4
+# 		# pc_storm_habitability = 0.4
+# 		# pc_megaflora_habitability = 0.4
+# 		# pc_irradiated_habitability = 0.4
+# 		# pc_megafloratol_habitability = 0.4
+# 		# pc_aquatic_habitability = 0.4
+# 		# pc_graveyard_habitability = 0.4
+# 		# pc_floating_habitability = 0.4
+# 		# pc_crystal_habitability = 0.4
+# 		# pc_technoorganic_habitability = 0.4
+# 		# pc_archive_habitability = 0.4
+# 		# pc_bioforge_habitability = 0.4
+# 		# pc_ecocity_habitability = 0.4
+# 		# pc_relic_habitability = 0.4
+# 		# pc_aquatichot_habitability = 0.4
+# 		# pc_aquaticcold_habitability = 0.4
+# 		# pc_aquaticcity_habitability = 0.4
+# 		# pc_pdfloraforge_habitability = 0.4
+# 		# pc_ammonia_habitability = 0.4
+# 		# pc_methane_habitability = 0.4
+# 		# pc_ash_habitability = 0.4
+# 		# pc_acid_habitability = 0.4
+# 		# pc_rogue_habitability = 0.4
+# 	}
+#     ai_weight = { weight = 0 }
+# }
 
-trait_pc_alderson_slice_machine_preference = {
-	icon = "gfx/interface/icons/traits/trait_pc_ring_preference.dds"
-	allowed_archetypes = { BIOLOGICAL PRESAPIENT LITHOID }
-	sorting_priority = 30
-	initial = no
-	randomized = no
-	species_potential_add = { always = no }
-	species_possible_merge_add = { always = yes }
-	modifier = {
-		pc_alderson_slice_gaia_habitability = 1.0
-		pc_alderson_slice_pc_habitability = 1.0
-		pc_alderson_slice_ecu_habitability = 0.0
-		pc_alderson_slice_hive_habitability = 0.0
-		pc_alderson_slice_machine_habitability = 1.0
-		pc_desert_habitability = 0.4
-		pc_arid_habitability =  0.4
-		pc_savannah_habitability = 0.4
-		pc_tropical_habitability = 0.4
-		pc_continental_habitability = 0.4
-		pc_tundra_habitability = 0.4
-		pc_arctic_habitability = 0.4
-		pc_ocean_habitability = 0.4
-		pc_alpine_habitability = 0.4
+# trait_pc_alderson_slice_machine_preference = {
+# 	icon = "gfx/interface/icons/traits/trait_pc_ring_preference.dds"
+# 	allowed_archetypes = { BIOLOGICAL PRESAPIENT LITHOID }
+# 	sorting_priority = 30
+# 	initial = no
+# 	randomized = no
+# 	species_potential_add = { always = no }
+# 	species_possible_merge_add = { always = yes }
+# 	modifier = {
+# 		pc_alderson_slice_gaia_habitability = 1.0
+# 		pc_alderson_slice_pc_habitability = 1.0
+# 		pc_alderson_slice_ecu_habitability = 0.0
+# 		pc_alderson_slice_hive_habitability = 0.0
+# 		pc_alderson_slice_machine_habitability = 1.0
+# 		pc_desert_habitability = 0.4
+# 		pc_arid_habitability =  0.4
+# 		pc_savannah_habitability = 0.4
+# 		pc_tropical_habitability = 0.4
+# 		pc_continental_habitability = 0.4
+# 		pc_tundra_habitability = 0.4
+# 		pc_arctic_habitability = 0.4
+# 		pc_ocean_habitability = 0.4
+# 		pc_alpine_habitability = 0.4
 
-		# Planetary Diversity
-		# NOOOOOOOO MORE PLANETARY DIVERSITY PLANET CLASSES :3 (thx gate <3)
+# 		# Planetary Diversity
+# 		# NOOOOOOOO MORE PLANETARY DIVERSITY PLANET CLASSES :3 (thx gate <3)
 		
-		pc_superhabitable_habitability = 0.4
-		pc_tidallylocked_habitability = 0.4
+# 		pc_superhabitable_habitability = 0.4
+# 		pc_tidallylocked_habitability = 0.4
 		
-		# pc_cascadian_habitability = 0.4
-		# pc_desertislands_habitability = 0.4
-		# pc_subarctic_habitability = 0.4
-		# pc_mangrove_habitability = 0.4
-		# pc_wetswamp_habitability = 0.4
-		# pc_hajungle_habitability = 0.4
-		# pc_retinal_habitability = 0.4
-		# pc_forest_habitability = 0.4
-		# pc_lake_habitability = 0.4
-		# pc_outback_habitability = 0.4
-		# pc_steppe_habitability = 0.4
-		# pc_sandsea_habitability = 0.4
-		# pc_oasis_habitability = 0.4
-		# pc_mesa_habitability = 0.4
-		# pc_hadesert_habitability = 0.4
-		# pc_prairie_habitability = 0.4
-		# pc_veld_habitability = 0.4
-		# pc_med_habitability = 0.4
-		# pc_highland_habitability = 0.4
-		# pc_swamp_habitability = 0.4
-		# pc_mud_habitability = 0.4
-		# pc_frozen_desert_habitability = 0.4
-		# pc_glacial_habitability = 0.4
-		# pc_boreal_habitability = 0.4
-		# pc_mushroom_habitability = 0.4
-		# pc_antarctic_habitability = 0.4
-		# pc_snow_habitability = 0.4
-		# pc_geothermal_habitability = 0.4
-		# pc_biolumen_habitability = 0.4
-		# pc_karst_habitability = 0.4
-		# pc_primal_habitability = 0.4
-		# pc_salt_habitability = 0.4
-		# pc_coral_habitability = 0.4
-		# pc_storm_habitability = 0.4
-		# pc_megaflora_habitability = 0.4
-		# pc_irradiated_habitability = 0.4
-		# pc_megafloratol_habitability = 0.4
-		# pc_aquatic_habitability = 0.4
-		# pc_graveyard_habitability = 0.4
-		# pc_floating_habitability = 0.4
-		# pc_crystal_habitability = 0.4
-		# pc_technoorganic_habitability = 0.4
-		# pc_archive_habitability = 0.4
-		# pc_bioforge_habitability = 0.4
-		# pc_ecocity_habitability = 0.4
-		# pc_relic_habitability = 0.4
-		# pc_aquatichot_habitability = 0.4
-		# pc_aquaticcold_habitability = 0.4
-		# pc_aquaticcity_habitability = 0.4
-		# pc_pdfloraforge_habitability = 0.4
-		# pc_ammonia_habitability = 0.4
-		# pc_methane_habitability = 0.4
-		# pc_ash_habitability = 0.4
-		# pc_acid_habitability = 0.4
-		# pc_rogue_habitability = 0.4
-	}
-    ai_weight = { weight = 0 }
-}
+# 		# pc_cascadian_habitability = 0.4
+# 		# pc_desertislands_habitability = 0.4
+# 		# pc_subarctic_habitability = 0.4
+# 		# pc_mangrove_habitability = 0.4
+# 		# pc_wetswamp_habitability = 0.4
+# 		# pc_hajungle_habitability = 0.4
+# 		# pc_retinal_habitability = 0.4
+# 		# pc_forest_habitability = 0.4
+# 		# pc_lake_habitability = 0.4
+# 		# pc_outback_habitability = 0.4
+# 		# pc_steppe_habitability = 0.4
+# 		# pc_sandsea_habitability = 0.4
+# 		# pc_oasis_habitability = 0.4
+# 		# pc_mesa_habitability = 0.4
+# 		# pc_hadesert_habitability = 0.4
+# 		# pc_prairie_habitability = 0.4
+# 		# pc_veld_habitability = 0.4
+# 		# pc_med_habitability = 0.4
+# 		# pc_highland_habitability = 0.4
+# 		# pc_swamp_habitability = 0.4
+# 		# pc_mud_habitability = 0.4
+# 		# pc_frozen_desert_habitability = 0.4
+# 		# pc_glacial_habitability = 0.4
+# 		# pc_boreal_habitability = 0.4
+# 		# pc_mushroom_habitability = 0.4
+# 		# pc_antarctic_habitability = 0.4
+# 		# pc_snow_habitability = 0.4
+# 		# pc_geothermal_habitability = 0.4
+# 		# pc_biolumen_habitability = 0.4
+# 		# pc_karst_habitability = 0.4
+# 		# pc_primal_habitability = 0.4
+# 		# pc_salt_habitability = 0.4
+# 		# pc_coral_habitability = 0.4
+# 		# pc_storm_habitability = 0.4
+# 		# pc_megaflora_habitability = 0.4
+# 		# pc_irradiated_habitability = 0.4
+# 		# pc_megafloratol_habitability = 0.4
+# 		# pc_aquatic_habitability = 0.4
+# 		# pc_graveyard_habitability = 0.4
+# 		# pc_floating_habitability = 0.4
+# 		# pc_crystal_habitability = 0.4
+# 		# pc_technoorganic_habitability = 0.4
+# 		# pc_archive_habitability = 0.4
+# 		# pc_bioforge_habitability = 0.4
+# 		# pc_ecocity_habitability = 0.4
+# 		# pc_relic_habitability = 0.4
+# 		# pc_aquatichot_habitability = 0.4
+# 		# pc_aquaticcold_habitability = 0.4
+# 		# pc_aquaticcity_habitability = 0.4
+# 		# pc_pdfloraforge_habitability = 0.4
+# 		# pc_ammonia_habitability = 0.4
+# 		# pc_methane_habitability = 0.4
+# 		# pc_ash_habitability = 0.4
+# 		# pc_acid_habitability = 0.4
+# 		# pc_rogue_habitability = 0.4
+# 	}
+#     ai_weight = { weight = 0 }
+# }
 
 trait_pc_alderson_slice_gaia_preference = {
 	icon = "gfx/interface/icons/traits/trait_pc_ring_preference.dds"
@@ -1170,5 +1170,49 @@ trait_pc_alderson_slice_gaia_shattered_preference = {
 	}
 	ai_weight = {
 		weight = 0
+	}
+}
+
+## AUTOHAB TRAITS
+trait_auto_pc_alderson_slice_preference = {
+	# im not using the inline script since we only have 2 classes, not three
+	bound_to_planet_classes = {
+		pc_alderson_slice_gaia
+		pc_alderson_slice_gaia_shattered
+	}
+	icon = "gfx/interface/icons/traits/trait_pc_ring_preference.dds"
+	allowed_archetypes = { BIOLOGICAL PRESAPIENT LITHOID }
+	sorting_priority = 30
+	initial = no
+	randomized = no
+	hidden = yes
+	species_potential_add = {
+		has_trait = trait_auto_hab_preference
+	}
+	custom_tooltip = trait_auto_pc_alderson_slice_preference_tt
+	ai_weight = {
+		weight = 0
+	}
+
+	modifier = {
+		pc_desert_habitability = @auto_penalty
+		pc_arid_habitability =  @auto_penalty
+		pc_savannah_habitability = @auto_penalty
+		pc_tropical_habitability = @auto_penalty
+		pc_continental_habitability = @auto_penalty
+		pc_tundra_habitability = @auto_penalty
+		pc_arctic_habitability = @auto_penalty
+		pc_ocean_habitability = @auto_penalty
+		pc_alpine_habitability = @auto_penalty
+		pc_alderson_slice_gaia_habitability = 1
+		pc_alderson_slice_gaia_shattered_habitability = 1
+		pc_ringworld_habitable_habitability			= @auto_penalty
+		pc_shattered_ring_habitable_habitability	= @auto_penalty
+		pc_nuked_habitability 						= @auto_penalty
+		# Planetary Diversity
+		# NOOOOOOOO MORE PLANETARY DIVERSITY PLANET CLASSES :3 (thx gate <3)
+		
+		pc_superhabitable_habitability = @auto_penalty
+		pc_tidallylocked_habitability = @auto_penalty
 	}
 }

--- a/localisation/braz_por/giga_l_braz_por.yml
+++ b/localisation/braz_por/giga_l_braz_por.yml
@@ -3669,7 +3669,11 @@
   mod_pc_alderson_slice_gaia_habitability:0 "Habitabilidade de Gaia"
   trait_pc_alderson_slice_gaia_preference:0 "Preferência Gaia"
   trait_pc_alderson_slice_gaia_preference_desc:0 "§LPreferência de família é determinada no nível genético, por eras de evolução ou manipulação habilidosa.§!"
-  
+
+  trait_auto_pc_alderson_slice_preference: "$pc_alderson_slice_gaia$ Mutations"
+  trait_auto_pc_alderson_slice_preference_tt: "$pc_alderson_slice_gaia$ Habitability: §G100%§!\n$t$- $IDEAL_PREFERENCE_TT$"
+  trait_auto_pc_alderson_slice_preference_desc: "$trait_auto_hab_preference_desc$"
+
   mod_pc_alderson_slice_pc_habitability:0 "Habitabilidade Planetária do Computador"
   trait_pc_alderson_slice_pc_preference:0 "Preferência de computador planetário"
   trait_pc_alderson_slice_pc_preference_desc:0 "§LPreferência de família é determinada no nível genético, por eras de evolução ou manipulação habilidosa.§!"

--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -3670,6 +3670,10 @@
   trait_pc_alderson_slice_gaia_preference:0 "Gaia Preference"
   trait_pc_alderson_slice_gaia_preference_desc:0 "§LClimate preference is determined at the genetic level, by eons of evolution or skillful manipulation.§!"
 
+  trait_auto_pc_alderson_slice_preference: "$pc_alderson_slice_gaia$ Mutations"
+  trait_auto_pc_alderson_slice_preference_tt: "$pc_alderson_slice_gaia$ Habitability: §G100%§!\n$t$- $IDEAL_PREFERENCE_TT$"
+  trait_auto_pc_alderson_slice_preference_desc: "$trait_auto_hab_preference_desc$"
+
   mod_pc_alderson_slice_pc_habitability:0 "Planetary Computer Habitability"
   trait_pc_alderson_slice_pc_preference:0 "Planetary Computer Preference"
   trait_pc_alderson_slice_pc_preference_desc:0 "§LClimate preference is determined at the genetic level, by eons of evolution or skillful manipulation.§!"

--- a/localisation/french/giga_l_french.yml
+++ b/localisation/french/giga_l_french.yml
@@ -3669,7 +3669,11 @@
   mod_pc_alderson_slice_gaia_habitability:99 "Gaia Habitability"
   trait_pc_alderson_slice_gaia_preference:99 "Gaia Preference"
   trait_pc_alderson_slice_gaia_preference_desc:99 "§LClimate preference is determined at the genetic level, by eons of evolution or skillful manipulation.§!"
-  
+
+  trait_auto_pc_alderson_slice_preference: "$pc_alderson_slice_gaia$ Mutations"
+  trait_auto_pc_alderson_slice_preference_tt: "$pc_alderson_slice_gaia$ Habitability: §G100%§!\n$t$- $IDEAL_PREFERENCE_TT$"
+  trait_auto_pc_alderson_slice_preference_desc: "$trait_auto_hab_preference_desc$"
+
   mod_pc_alderson_slice_pc_habitability:99 "Planetary Computer Habitability"
   trait_pc_alderson_slice_pc_preference:99 "Planetary Computer Preference"
   trait_pc_alderson_slice_pc_preference_desc:99 "§LClimate preference is determined at the genetic level, by eons of evolution or skillful manipulation.§!"

--- a/localisation/german/giga_l_german.yml
+++ b/localisation/german/giga_l_german.yml
@@ -3669,7 +3669,11 @@
   mod_pc_alderson_slice_gaia_habitability:99 "Gaia Habitability"
   trait_pc_alderson_slice_gaia_preference:99 "Gaia Preference"
   trait_pc_alderson_slice_gaia_preference_desc:99 "§LClimate preference is determined at the genetic level, by eons of evolution or skillful manipulation.§!"
-  
+
+  trait_auto_pc_alderson_slice_preference: "$pc_alderson_slice_gaia$ Mutations"
+  trait_auto_pc_alderson_slice_preference_tt: "$pc_alderson_slice_gaia$ Habitability: §G100%§!\n$t$- $IDEAL_PREFERENCE_TT$"
+  trait_auto_pc_alderson_slice_preference_desc: "$trait_auto_hab_preference_desc$"
+
   mod_pc_alderson_slice_pc_habitability:99 "Planetary Computer Habitability"
   trait_pc_alderson_slice_pc_preference:99 "Planetary Computer Preference"
   trait_pc_alderson_slice_pc_preference_desc:99 "§LClimate preference is determined at the genetic level, by eons of evolution or skillful manipulation.§!"

--- a/localisation/polish/giga_l_polish.yml
+++ b/localisation/polish/giga_l_polish.yml
@@ -3669,7 +3669,11 @@
   mod_pc_alderson_slice_gaia_habitability:99 "Gaia Habitability"
   trait_pc_alderson_slice_gaia_preference:99 "Gaia Preference"
   trait_pc_alderson_slice_gaia_preference_desc:99 "§LClimate preference is determined at the genetic level, by eons of evolution or skillful manipulation.§!"
-  
+
+  trait_auto_pc_alderson_slice_preference: "$pc_alderson_slice_gaia$ Mutations"
+  trait_auto_pc_alderson_slice_preference_tt: "$pc_alderson_slice_gaia$ Habitability: §G100%§!\n$t$- $IDEAL_PREFERENCE_TT$"
+  trait_auto_pc_alderson_slice_preference_desc: "$trait_auto_hab_preference_desc$"
+
   mod_pc_alderson_slice_pc_habitability:99 "Planetary Computer Habitability"
   trait_pc_alderson_slice_pc_preference:99 "Planetary Computer Preference"
   trait_pc_alderson_slice_pc_preference_desc:99 "§LClimate preference is determined at the genetic level, by eons of evolution or skillful manipulation.§!"

--- a/localisation/replace/braz_por/giga_replace_l_braz_por.yml
+++ b/localisation/replace/braz_por/giga_replace_l_braz_por.yml
@@ -106,3 +106,7 @@
   behemoth_egg:99 "Behemoth Egg"
   behemoth_egg_DESC:99 "A giant organic vessel bearing a gestating §YBehemoth§!."
   behemoth_egg_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_psionics$\nThis structure supports the development of §YBehemoth eggs§!.\n§L$behemoth_egg_DESC$§!"
+
+  # Concept Override
+  # added alderson trait
+  concept_automodding_hab_preference_desc: "Regular:\n- ['trait:trait_auto_dry_preference']\n- ['trait:trait_auto_wet_preference']\n- ['trait:trait_auto_cold_preference']\n\nSpecial:\n- ['trait:trait_auto_pc_nuked_preference']\n- ['trait:trait_auto_pc_gaia_preference']\n- ['trait:trait_auto_pc_hive_preference']\n\nArtificial:\n- ['trait:trait_auto_pc_city_preference']\n- ['trait:trait_auto_pc_relic_preference']\n- ['trait:trait_auto_pc_habitat_preference']\n- ['trait:trait_auto_pc_ringworld_habitable_preference']\n- ['trait:trait_auto_pc_cosmogenesis_world_preference']\n- ['trait:trait_auto_pc_alderson_slice_preference']"

--- a/localisation/replace/english/giga_replace_l_english.yml
+++ b/localisation/replace/english/giga_replace_l_english.yml
@@ -106,3 +106,7 @@
   behemoth_egg: "Behemoth Egg"
   behemoth_egg_DESC: "A giant organic vessel bearing a gestating §YBehemoth§!."
   behemoth_egg_MEGASTRUCTURE_DETAILS: "$giga_list_category_kilostructure$ - $giga_list_category_psionics$\nThis structure supports the development of §YBehemoth eggs§!.\n§L$behemoth_egg_DESC$§!"
+
+  # Concept Override
+  # added alderson trait
+  concept_automodding_hab_preference_desc: "Regular:\n- ['trait:trait_auto_dry_preference']\n- ['trait:trait_auto_wet_preference']\n- ['trait:trait_auto_cold_preference']\n\nSpecial:\n- ['trait:trait_auto_pc_nuked_preference']\n- ['trait:trait_auto_pc_gaia_preference']\n- ['trait:trait_auto_pc_hive_preference']\n\nArtificial:\n- ['trait:trait_auto_pc_city_preference']\n- ['trait:trait_auto_pc_relic_preference']\n- ['trait:trait_auto_pc_habitat_preference']\n- ['trait:trait_auto_pc_ringworld_habitable_preference']\n- ['trait:trait_auto_pc_cosmogenesis_world_preference']\n- ['trait:trait_auto_pc_alderson_slice_preference']"

--- a/localisation/replace/french/giga_replace_l_french.yml
+++ b/localisation/replace/french/giga_replace_l_french.yml
@@ -106,3 +106,7 @@
   behemoth_egg:99 "Behemoth Egg"
   behemoth_egg_DESC:99 "A giant organic vessel bearing a gestating §YBehemoth§!."
   behemoth_egg_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_psionics$\nThis structure supports the development of §YBehemoth eggs§!.\n§L$behemoth_egg_DESC$§!"
+
+  # Concept Override
+  # added alderson trait
+  concept_automodding_hab_preference_desc: "Regular:\n- ['trait:trait_auto_dry_preference']\n- ['trait:trait_auto_wet_preference']\n- ['trait:trait_auto_cold_preference']\n\nSpecial:\n- ['trait:trait_auto_pc_nuked_preference']\n- ['trait:trait_auto_pc_gaia_preference']\n- ['trait:trait_auto_pc_hive_preference']\n\nArtificial:\n- ['trait:trait_auto_pc_city_preference']\n- ['trait:trait_auto_pc_relic_preference']\n- ['trait:trait_auto_pc_habitat_preference']\n- ['trait:trait_auto_pc_ringworld_habitable_preference']\n- ['trait:trait_auto_pc_cosmogenesis_world_preference']\n- ['trait:trait_auto_pc_alderson_slice_preference']"

--- a/localisation/replace/german/giga_replace_l_german.yml
+++ b/localisation/replace/german/giga_replace_l_german.yml
@@ -106,3 +106,7 @@
   behemoth_egg:99 "Behemoth Egg"
   behemoth_egg_DESC:99 "A giant organic vessel bearing a gestating §YBehemoth§!."
   behemoth_egg_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_psionics$\nThis structure supports the development of §YBehemoth eggs§!.\n§L$behemoth_egg_DESC$§!"
+
+  # Concept Override
+  # added alderson trait
+  concept_automodding_hab_preference_desc: "Regular:\n- ['trait:trait_auto_dry_preference']\n- ['trait:trait_auto_wet_preference']\n- ['trait:trait_auto_cold_preference']\n\nSpecial:\n- ['trait:trait_auto_pc_nuked_preference']\n- ['trait:trait_auto_pc_gaia_preference']\n- ['trait:trait_auto_pc_hive_preference']\n\nArtificial:\n- ['trait:trait_auto_pc_city_preference']\n- ['trait:trait_auto_pc_relic_preference']\n- ['trait:trait_auto_pc_habitat_preference']\n- ['trait:trait_auto_pc_ringworld_habitable_preference']\n- ['trait:trait_auto_pc_cosmogenesis_world_preference']\n- ['trait:trait_auto_pc_alderson_slice_preference']"

--- a/localisation/replace/polish/giga_replace_l_polish.yml
+++ b/localisation/replace/polish/giga_replace_l_polish.yml
@@ -106,3 +106,7 @@
   behemoth_egg:99 "Behemoth Egg"
   behemoth_egg_DESC:99 "A giant organic vessel bearing a gestating §YBehemoth§!."
   behemoth_egg_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_psionics$\nThis structure supports the development of §YBehemoth eggs§!.\n§L$behemoth_egg_DESC$§!"
+
+  # Concept Override
+  # added alderson trait
+  concept_automodding_hab_preference_desc: "Regular:\n- ['trait:trait_auto_dry_preference']\n- ['trait:trait_auto_wet_preference']\n- ['trait:trait_auto_cold_preference']\n\nSpecial:\n- ['trait:trait_auto_pc_nuked_preference']\n- ['trait:trait_auto_pc_gaia_preference']\n- ['trait:trait_auto_pc_hive_preference']\n\nArtificial:\n- ['trait:trait_auto_pc_city_preference']\n- ['trait:trait_auto_pc_relic_preference']\n- ['trait:trait_auto_pc_habitat_preference']\n- ['trait:trait_auto_pc_ringworld_habitable_preference']\n- ['trait:trait_auto_pc_cosmogenesis_world_preference']\n- ['trait:trait_auto_pc_alderson_slice_preference']"

--- a/localisation/replace/russian/giga_replace_l_russian.yml
+++ b/localisation/replace/russian/giga_replace_l_russian.yml
@@ -106,3 +106,7 @@
   behemoth_egg:99 "Behemoth Egg"
   behemoth_egg_DESC:99 "A giant organic vessel bearing a gestating §YBehemoth§!."
   behemoth_egg_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_psionics$\nThis structure supports the development of §YBehemoth eggs§!.\n§L$behemoth_egg_DESC$§!"
+
+  # Concept Override
+  # added alderson trait
+  concept_automodding_hab_preference_desc: "Regular:\n- ['trait:trait_auto_dry_preference']\n- ['trait:trait_auto_wet_preference']\n- ['trait:trait_auto_cold_preference']\n\nSpecial:\n- ['trait:trait_auto_pc_nuked_preference']\n- ['trait:trait_auto_pc_gaia_preference']\n- ['trait:trait_auto_pc_hive_preference']\n\nArtificial:\n- ['trait:trait_auto_pc_city_preference']\n- ['trait:trait_auto_pc_relic_preference']\n- ['trait:trait_auto_pc_habitat_preference']\n- ['trait:trait_auto_pc_ringworld_habitable_preference']\n- ['trait:trait_auto_pc_cosmogenesis_world_preference']\n- ['trait:trait_auto_pc_alderson_slice_preference']"

--- a/localisation/replace/simp_chinese/giga_replace_l_simp_chinese.yml
+++ b/localisation/replace/simp_chinese/giga_replace_l_simp_chinese.yml
@@ -106,3 +106,7 @@
   behemoth_egg:99 "Behemoth Egg"
   behemoth_egg_DESC:99 "A giant organic vessel bearing a gestating §YBehemoth§!."
   behemoth_egg_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_psionics$\nThis structure supports the development of §YBehemoth eggs§!.\n§L$behemoth_egg_DESC$§!"
+
+  # Concept Override
+  # added alderson trait
+  concept_automodding_hab_preference_desc: "Regular:\n- ['trait:trait_auto_dry_preference']\n- ['trait:trait_auto_wet_preference']\n- ['trait:trait_auto_cold_preference']\n\nSpecial:\n- ['trait:trait_auto_pc_nuked_preference']\n- ['trait:trait_auto_pc_gaia_preference']\n- ['trait:trait_auto_pc_hive_preference']\n\nArtificial:\n- ['trait:trait_auto_pc_city_preference']\n- ['trait:trait_auto_pc_relic_preference']\n- ['trait:trait_auto_pc_habitat_preference']\n- ['trait:trait_auto_pc_ringworld_habitable_preference']\n- ['trait:trait_auto_pc_cosmogenesis_world_preference']\n- ['trait:trait_auto_pc_alderson_slice_preference']"

--- a/localisation/replace/spanish/giga_replace_l_spanish.yml
+++ b/localisation/replace/spanish/giga_replace_l_spanish.yml
@@ -106,3 +106,7 @@
   behemoth_egg:99 "Behemoth Egg"
   behemoth_egg_DESC:99 "A giant organic vessel bearing a gestating §YBehemoth§!."
   behemoth_egg_MEGASTRUCTURE_DETAILS:99 "$giga_list_category_kilostructure$ - $giga_list_category_psionics$\nThis structure supports the development of §YBehemoth eggs§!.\n§L$behemoth_egg_DESC$§!"
+
+  # Concept Override
+  # added alderson trait
+  concept_automodding_hab_preference_desc: "Regular:\n- ['trait:trait_auto_dry_preference']\n- ['trait:trait_auto_wet_preference']\n- ['trait:trait_auto_cold_preference']\n\nSpecial:\n- ['trait:trait_auto_pc_nuked_preference']\n- ['trait:trait_auto_pc_gaia_preference']\n- ['trait:trait_auto_pc_hive_preference']\n\nArtificial:\n- ['trait:trait_auto_pc_city_preference']\n- ['trait:trait_auto_pc_relic_preference']\n- ['trait:trait_auto_pc_habitat_preference']\n- ['trait:trait_auto_pc_ringworld_habitable_preference']\n- ['trait:trait_auto_pc_cosmogenesis_world_preference']\n- ['trait:trait_auto_pc_alderson_slice_preference']"

--- a/localisation/russian/giga_l_russian.yml
+++ b/localisation/russian/giga_l_russian.yml
@@ -3669,7 +3669,11 @@
   mod_pc_alderson_slice_gaia_habitability:0 "Жители Gaia"
   trait_pc_alderson_slice_gaia_preference:0 "Предпочтение Gaia"
   trait_pc_alderson_slice_gaia_preference_desc:0 "§LКлиматические предпочтения определяются на генетическом уровне эпохами эволюции или умелыми манипуляциями.§!"
-  
+
+  trait_auto_pc_alderson_slice_preference: "$pc_alderson_slice_gaia$ Mutations"
+  trait_auto_pc_alderson_slice_preference_tt: "$pc_alderson_slice_gaia$ Habitability: §G100%§!\n$t$- $IDEAL_PREFERENCE_TT$"
+  trait_auto_pc_alderson_slice_preference_desc: "$trait_auto_hab_preference_desc$"
+
   mod_pc_alderson_slice_pc_habitability:0 "Жители планетарного компьютера"
   trait_pc_alderson_slice_pc_preference:0 "Предпочтение планетарный компьютер"
   trait_pc_alderson_slice_pc_preference_desc:0 "§LКлиматические предпочтения определяются на генетическом уровне эпохами эволюции или умелыми манипуляциями.§!"

--- a/localisation/simp_chinese/giga_l_simp_chinese.yml
+++ b/localisation/simp_chinese/giga_l_simp_chinese.yml
@@ -3669,7 +3669,11 @@
   mod_pc_alderson_slice_gaia_habitability:0 "盖亚宜居性"
   trait_pc_alderson_slice_gaia_preference:0 "盖亚偏好"
   trait_pc_alderson_slice_gaia_preference_desc:0 "§L气候偏好由基因水平决定，这是由世代进化或者人工操纵形成的。§!"
-  
+
+  trait_auto_pc_alderson_slice_preference: "$pc_alderson_slice_gaia$ Mutations"
+  trait_auto_pc_alderson_slice_preference_tt: "$pc_alderson_slice_gaia$ Habitability: §G100%§!\n$t$- $IDEAL_PREFERENCE_TT$"
+  trait_auto_pc_alderson_slice_preference_desc: "$trait_auto_hab_preference_desc$"
+
   mod_pc_alderson_slice_pc_habitability:0 "行星计算机宜居性"
   trait_pc_alderson_slice_pc_preference:0 "行星计算机偏好"
   trait_pc_alderson_slice_pc_preference_desc:0 "§L气候偏好由基因水平决定，这是由世代进化或者人工操纵形成的。§!"

--- a/localisation/spanish/giga_l_spanish.yml
+++ b/localisation/spanish/giga_l_spanish.yml
@@ -3669,7 +3669,11 @@
   mod_pc_alderson_slice_gaia_habitability:0 "Habitabilidad de Gaia"
   trait_pc_alderson_slice_gaia_preference:0 "Preferencia de Gaia"
   trait_pc_alderson_slice_gaia_preference_desc:0 "§LPreferecia climática es determinada a nivel genético, por eones de evolución o manipulación hábil.§!"
-  
+
+  trait_auto_pc_alderson_slice_preference: "$pc_alderson_slice_gaia$ Mutations"
+  trait_auto_pc_alderson_slice_preference_tt: "$pc_alderson_slice_gaia$ Habitability: §G100%§!\n$t$- $IDEAL_PREFERENCE_TT$"
+  trait_auto_pc_alderson_slice_preference_desc: "$trait_auto_hab_preference_desc$"
+
   mod_pc_alderson_slice_pc_habitability:0 "Habitabilidad de Computadora Planetaria"
   trait_pc_alderson_slice_pc_preference:0 "Preferencia de Computadora Planetaria"
   trait_pc_alderson_slice_pc_preference_desc:0 "§LPreferecia climática es determinada a nivel genético, por eones de evolución o manipulación hábil.§!"


### PR DESCRIPTION
Added ORs with both versions of psionics tradition where appropriate. Did not touch the Sirenalia stuff.

Added a mutagenic habitability subtrait that works for the alderson (both shattered and fixed)

Added a localization override to the mutagenic habitability concept to add the alderson trait to the list

Commented out the habitability traits for the disabled alderson types (since the planet classes were already commented out)