### PR TITLE
alderson starting district fix to match vanilla origin

### DIFF
--- a/common/ascension_perks/giga_ascension_perk_medium_prio_overwrites.txt
+++ b/common/ascension_perks/giga_ascension_perk_medium_prio_overwrites.txt
@@ -97,6 +97,7 @@ ap_defender_of_the_galaxy = {
 		damage_vs_country_type_ai_empire_mult = 0.5
 		damage_vs_country_type_gray_goo_mult = 0.5
 		damage_vs_player_crisis_mult = 0.5
+		add_attunement_the_cradle_of_souls = @ascension_perk_attunement1
 		# Gigastructural Engineering & More
 		damage_vs_country_type_compound_empire_mult = 0.5
 		damage_vs_country_type_katzenartig_imperium_mult = 0.5
@@ -145,6 +146,13 @@ ap_defender_of_the_galaxy = {
 			damage_vs_country_type_voidworms_crisis_mult = @ap_defender_of_the_galaxy_voidworm_dmg_mult
 			damage_vs_country_type_voidworms_treasure_hunters_mult = @ap_defender_of_the_galaxy_voidworm_dmg_mult
 			damage_vs_country_type_frenzied_voidworms_mult = @ap_defender_of_the_galaxy_voidworm_dmg_mult
+			add_attunement_the_cradle_of_souls = @ascension_perk_attunement1
+			# Gigastructural Engineering & More
+			damage_vs_country_type_compound_empire_mult = 0.5
+			damage_vs_country_type_katzenartig_imperium_mult = 0.5
+			damage_vs_country_type_dormant_aeternum_mult = 0.5
+			damage_vs_country_type_blokkat_stripminers_mult = 0.5
+			damage_vs_country_type_giga_eawaf_sirens_mult = 0.5
 		}
 
 		on_enabled = {
@@ -163,6 +171,7 @@ ap_defender_of_the_galaxy = {
 			has_ascension_perk = ap_become_the_crisis
 			has_ascension_perk = ap_cosmogenesis
 			has_ascension_perk = ap_behemoths
+			has_origin = origin_endbringers # Endbringers are technically a crisis as well
 		}
 	}
 

--- a/events/giga_201_origins_alderson.txt
+++ b/events/giga_201_origins_alderson.txt
@@ -159,182 +159,97 @@ country_event = {
 				while = { count = 2 add_deposit = d_hibernating_lithoids }
 			}
 
-			#add_deposit = d_alderson_lost01
-			# no
+			#remove_all_districts = yes
+			#remove_all_buildings = yes
+				#im surpised no one complained about this before
+			
+			# i thought of doing something like (remove the districts and replace with uncapped versions while there are districts)
+			# but that doesnt work since the shattered alderson starts with no districts, not even the vanilla setup
+			# and even with "remove_all_districts" commented out
+			
+			# Tore out all the old district creation stuff
+			# using a vanilla origin that doesnt modify districts (doorstep):
+			# organic individualist gets 2 gen, 2 mine, 3 farm
+			# machine individualist gets 3 gen, 4 mine, 0 farm
+			# lithoid individualist gets 2 gen, 4 mine, 0 farm
+			#	 if organic subspecies                 +1 farm   (this is probably impossible to trigger without some bug branch civic)
+			# organic hive 			gets 2 gen, 2 mine, 3 farm
+			# lithoid hive 			gets 2 gen, 4 mine, 0 farm
+			#	 if organic subspecies (bodysnatchers) +1 farm
+			# machine gestalt 	    gets 3 gen, 4 mine, 0 farm
+			# assimilator /servitor                    +1 farm
+			
+			# not adding city/hive/nexus since vanilla handles it
 
-			remove_all_districts = yes
-			remove_all_buildings = yes
-
+			# individualist
 			if = {
 				limit = {
 					owner = { is_regular_empire = yes }
 				}
-	
-				# total - 24 jobs
-	
-				# 3 jobs
-				add_district_and_planet_size_if_needed_effect = {
-					district = district_city
-				}
-	
-				if = {
-					limit = {
-						owner = { NOT = { has_valid_civic = civic_agrarian_idyll } }
-					}
-					while = {
-						count = 2
-						add_district_and_planet_size_if_needed_effect = {
-							district = district_city
-						}
-					}
-				}
-				else = {
-					while = {
-						count = 2 
-						add_district_and_planet_size_if_needed_effect = {
-							district = district_farming_uncapped
-						}
-					}
-				}
-	
-				if = {
-					limit = { owner = { is_megacorp = yes } }
-					add_district_and_planet_size_if_needed_effect = {
-						district = district_city
-					}
-				}
-	
-				# 4 - 6 jobs
-				if = {
-					limit = {
-						owner = {
-							OR = {
-								is_lithoid_empire = no
-								has_country_flag = non_lithoid_subspecies
-							}
-						}
-					}
-					while = {
-						count = 2
-						add_district_and_planet_size_if_needed_effect = {
-							district = district_farming_uncapped
-						}
-					}
-					if = {
-						limit = {
-							owner = { has_origin = origin_default }
-						}
-						add_district_and_planet_size_if_needed_effect = {
-							district = district_farming_uncapped
-						}
-					}
-				}
-				else = {
-					while = {
-						count = 2
-						add_district_and_planet_size_if_needed_effect = {
-							district = district_mining_uncapped
-						}
-					}
-				}
-	
-				# 4 jobs
+				
+				# the base stuff, 2 gen, 2 mine
 				while = {
 					count = 2
 					add_district_and_planet_size_if_needed_effect = {
 						district = district_mining_uncapped
 					}
 				}
-	
-				# 2 jobs
-				# add_district_and_planet_size_if_needed_effect = {
-				# 	district = district_srw_commercial
-				# }
-				# immediately dies, so commented out
-	
-				# 4 jobs
-				add_district_and_planet_size_if_needed_effect = {
-					district = district_mining_uncapped
+				while = {
+					count = 2
+					add_district_and_planet_size_if_needed_effect = {
+						district = district_generator_uncapped
+					}
 				}
 	
-				# 3 jobs
-				add_building = building_capital
-	
-				# 2 jobs
-				add_building = {
-					zone = zone_research_unity 
-					building = building_bureaucratic_1
-				}
-	
-				# 2 jobs
+				# machine individual gets 1 gen, 2 mine
 				if = {
 					limit = {
 						owner = {
-							has_valid_civic = civic_reanimated_armies
+							is_individual_machine = yes
 						}
 					}
-					add_building = building_dread_encampment
-	
-					solar_system = { #Necromancers do not give engineering. So make sure there's some readily-accessible engineering
-						random_system_planet = {
-							limit = {
-								has_deposit_for = shipclass_research_station
-								has_deposit = d_engineering_5
-							}
-							# Total size 15 deposit as the Irreparable Damage is normally a size 5 and non-Shattered Ring starts get an additional two size 6 deposits.
-							add_deposit = d_engineering_10
+					while = {
+						count = 2
+						add_district_and_planet_size_if_needed_effect = {
+							district = district_mining_uncapped
 						}
 					}
-				}
-				else = {
-					add_building = {
-						zone = zone_research_unity 
-						building = building_research_lab_1
+					add_district_and_planet_size_if_needed_effect = {
+						district = district_generator_uncapped
 					}
 				}
-	
-				# 4-5 jobs
-				if = {
+				# lithoid gets 2 mines
+				else_if = {
 					limit = {
 						owner = {
-							NOT = { has_valid_civic = civic_agrarian_idyll }
+							is_lithoid_empire = yes
+						}
+					}
+					while = {
+						count = 2
+						add_district_and_planet_size_if_needed_effect = {
+							district = district_mining_uncapped
 						}
 					}
 					if = {
-						limit = {
-							owner = {
-								is_spiritualist = no
-								has_valid_civic = civic_pleasure_seekers
-							}
+						# +1 farm if bodysnatcher or other similar civic
+						limit = { 
+							owner = { 
+								has_country_flag = non_lithoid_subspecies
+							} 
 						}
-						add_building = building_holo_theatres
-					}
-					else_if = {
-						limit = {
-							owner = {
-								is_spiritualist = yes
-								has_valid_civic = civic_death_cult
-							}
-						}
-						add_building = {
-							zone = zone_research_unity 
-							building = building_sacrificial_temple_1
+						add_district_and_planet_size_if_needed_effect = {
+							district = district_farming_uncapped
 						}
 					}
-					else_if = {
-						limit = {
-							owner = {
-								is_megacorp = no
-								is_spiritualist = yes
-							}
+				}
+				# organic gets 3 farms
+				else = {	
+					while = {
+						count = 3
+						add_district_and_planet_size_if_needed_effect = {
+							district = district_farming_uncapped
 						}
-						add_building = {
-							zone = zone_research_unity 
-							building = building_temple
-						}
-					}
-					else = {
-						add_building = building_commercial_zone
 					}
 				}
 			}
@@ -343,166 +258,90 @@ country_event = {
 				limit = {
 					owner = { is_hive_empire = yes }
 				}
-	
-				# 9 jobs
-				while = {
-					count = 3
-					add_district_and_planet_size_if_needed_effect = {
-						district = district_hive
-					}
-				}
-	
-				# 6-9 jobs
-				if = {
-					limit = {
-						owner = { is_lithoid_empire = no }
-					}
-					while = {
-						count = 2
-						add_district_and_planet_size_if_needed_effect = {
-							district = district_farming_uncapped
-						}
-					}
-				}
-				else = {
-					while = {
-						count = 2
-						add_district_and_planet_size_if_needed_effect = {
-							district = district_mining_uncapped
-						}
-					}
-				}
-	
-				# 6 jobs
+
+				# the base stuff, 2 gen, 2 mine
 				while = {
 					count = 2
 					add_district_and_planet_size_if_needed_effect = {
 						district = district_mining_uncapped
 					}
 				}
-	
-				# 6 jobs
 				while = {
 					count = 2
 					add_district_and_planet_size_if_needed_effect = {
 						district = district_generator_uncapped
 					}
 				}
-	
-				# 2 jobs
-				add_district_and_planet_size_if_needed_effect = {
-					district = district_mining_uncapped
+
+
+				if = {
+					# give 2 min if lithoid
+					limit = {
+						owner = { is_lithoid_empire = yes }
+					}
+					while = {
+						count = 2
+						add_district_and_planet_size_if_needed_effect = {
+							district = district_mining_uncapped
+						}
+					}
+					if = {
+						# +1 farm if bodysnatcher or other similar civic
+						limit = { 
+							owner = { 
+								has_country_flag = non_lithoid_subspecies
+							} 
+						}
+						add_district_and_planet_size_if_needed_effect = {
+							district = district_farming_uncapped
+						}
+					}
 				}
-	
-				# 5 jobs
-				add_building = building_hive_capital
-	
-				# 2 jobs
-				add_building = {
-					zone = zone_research_unity 
-					building = building_research_lab_1
+				else = {
+					# 3 farms if not lithoid
+					while = {
+						count = 3
+						add_district_and_planet_size_if_needed_effect = {
+							district = district_farming_uncapped
+						}
+					}
 				}
-	
-				# 2 jobs
-				add_building = {
-					zone = zone_research_unity 
-					building = building_hive_node
-				}
-	
-				# 1 job
-				add_building = building_spawning_pool
 			}
 
 			if = {
+				# beep boop
 				limit = { owner = { is_machine_empire = yes } }
-	
-				# total - 27 jobs
-	
-				# 3 jobs
-				while = {
-					count = 2
-					add_district_and_planet_size_if_needed_effect = {
-						district = district_nexus
-					}
-				}
-	
-				# 2 jobs
-				add_district_and_planet_size_if_needed_effect = {
-					district = district_mining_uncapped
-				}
-	
-				# 6 jobs
-				add_building = building_machine_capital
-	
-				# 1 job
-				add_building = building_machine_assembly_plant
-	
-				# 2 job
-				add_building = {
-					zone = zone_research_unity 
-					building = building_uplink_node
-				}
-	
-				# 2 jobs 
-				add_building = {
-					zone = zone_research_unity 
-					building = building_research_lab_1
-				}
-	
-				# 4 jobs
-				add_district_and_planet_size_if_needed_effect = {
-					district = district_mining_uncapped
-				}
-	
-				# 8 jobs
+				
 				while = {
 					count = 4
+					add_district_and_planet_size_if_needed_effect = {
+						district = district_mining_uncapped
+					}
+				}
+				while = {
+					count = 3
 					add_district_and_planet_size_if_needed_effect = {
 						district = district_generator_uncapped
 					}
 				}
-	
-				#Assimilators
+
+
+				#Assimilators/servitors
 				if = {
-					limit = { owner = { has_civic = civic_machine_assimilator } }
-					remove_district = district_generator_uncapped
-					if = {
-						limit = { owner = { has_country_flag = lithoid_subspecies } }
-						add_district_and_planet_size_if_needed_effect = {
-							district = district_mining_uncapped
-						}
+					limit = { 
+						owner = { 
+							OR = {
+								has_civic = civic_machine_assimilator 
+								has_civic = civic_machine_servitor
+							}
+						} 
 					}
-					else = {
-						add_district_and_planet_size_if_needed_effect = {
-							district = district_farming_uncapped
-						}
-					}
-				}
-	
-				#Servitors
-				if = {
-					limit = { owner = { has_civic = civic_machine_servitor } }
-					if = {
-						limit = { owner = { has_country_flag = lithoid_subspecies } }
-						add_district_and_planet_size_if_needed_effect = {
-							district = district_mining_uncapped
-						}
-					}
-					else = {
-						add_district_and_planet_size_if_needed_effect = {
-							district = district_farming_uncapped
-						}
-					}
+					# only 1 farm
 					add_district_and_planet_size_if_needed_effect = {
-						district = district_nexus
-					}
-					add_building = {
-						zone = zone_research_unity 
-						building = building_organic_sanctuary
+						district = district_farming_uncapped
 					}
 				}
 			}
-			# i litcherally just copy pasted these from shattered ring
 
 			every_owned_pop_group = {
 				unemploy_pop = yes


### PR DESCRIPTION
tore out the alderson starting logic and made it more compatible

			# organic individualist gets 2 gen, 2 mine, 3 farm
			# machine individualist gets 3 gen, 4 mine, 0 farm
			# lithoid individualist gets 2 gen, 4 mine, 0 farm
			#	 if organic subspecies                 +1 farm   (this is probably impossible to trigger without some bug branch civic)
			# organic hive 			gets 2 gen, 2 mine, 3 farm
			# lithoid hive 			gets 2 gen, 4 mine, 0 farm
			#	 if organic subspecies (bodysnatchers) +1 farm
			# machine gestalt 	    gets 3 gen, 4 mine, 0 farm
			# assimilator /servitor                    +1 farm

this is 100% tested (the fact that there is only one default lithoid empire is kinda painful)