### PR TITLE
Misc Bugfixes

### DIFF
--- a/common/ascension_perks/giga_ascension_perk_medium_prio_overwrites.txt
+++ b/common/ascension_perks/giga_ascension_perk_medium_prio_overwrites.txt
@@ -30,6 +30,7 @@ ap_eternal_vigilance = {
 		shipclass_military_station_damage_mult = 0.25
 		starbase_defense_platform_capacity_add = 5
 		ship_military_station_small_upkeep_mult = -0.5
+		add_attunement_the_cradle_of_souls = @ascension_perk_attunement1
     }
 
 	triggered_modifier = {
@@ -84,8 +85,8 @@ ap_defender_of_the_galaxy = {
 			num_ascension_perks > 2
 		}
 	}
+	custom_tooltip = ap_defender_of_the_galaxy_modifier_desc
 	modifier = {
-		description = ap_defender_of_the_galaxy_modifier_desc
 		damage_vs_country_type_synth_queen_mult = 0.5
 		damage_vs_country_type_awakened_synth_queen_mult = 0.5
 		damage_vs_country_type_synth_queen_convoys_mult = 0.5
@@ -240,4 +241,3 @@ ap_defender_of_the_galaxy = {
 		}
 	}
 }
-

--- a/common/buildings/giga_elysium_capitals.txt
+++ b/common/buildings/giga_elysium_capitals.txt
@@ -20,6 +20,7 @@ building_giga_elysium_host_capital = {
 	can_be_ruined = no
 	can_be_disabled = no
 	position_priority = 0
+	capital_tier = 2
 
 	icon = building_capital
 
@@ -101,6 +102,7 @@ building_giga_elysium_host_major_capital = {
 	can_be_ruined = no
 	can_be_disabled = no
 	position_priority = 0
+	capital_tier = 3
 
 	icon = building_major_capital
 
@@ -234,6 +236,7 @@ building_giga_elysium_host_hive_capital = {
 	can_be_ruined = no
 	can_be_disabled = no
 	position_priority = 0
+	capital_tier = 2
 
 	icon = building_hive_capital
 
@@ -315,6 +318,7 @@ building_giga_elysium_host_hive_major_capital = {
 	can_be_ruined = no
 	can_be_disabled = no
 	position_priority = 0
+	capital_tier = 3
 
 	icon = building_hive_major_capital
 
@@ -438,6 +442,7 @@ building_giga_elysium_host_machine_capital = {
 	can_be_ruined = no
 	can_be_disabled = no
 	position_priority = 0
+	capital_tier = 2
 
 	icon = building_machine_capital
 
@@ -497,6 +502,7 @@ building_giga_elysium_host_machine_major_capital = {
 	can_be_ruined = no
 	can_be_disabled = no
 	position_priority = 0
+	capital_tier = 3
 
 	icon = building_machine_major_capital
 
@@ -585,4 +591,3 @@ building_giga_elysium_host_machine_major_capital = {
 
 	inline_script = buildings/on_all_capital_buildings
 }
-

--- a/common/buildings/giga_flusion_buildings.txt
+++ b/common/buildings/giga_flusion_buildings.txt
@@ -97,6 +97,7 @@ building_giga_flusion_capital = {
 	ai_weight = { weight = 0 }
 	base_buildtime = 720
 	position_priority = 0
+	capital_tier = 4
 
 	destroy_trigger = {
 		exists = owner
@@ -127,6 +128,7 @@ building_giga_katzen_capital = {
 	ai_weight = { weight = 0 }
 	#potential = { always = no }
 	position_priority = 0
+	capital_tier = 4
 
 	destroy_trigger = {
 		exists = owner
@@ -145,9 +147,9 @@ building_giga_katzen_capital = {
 	planet_modifier = {
 		job_politician_add = 200
 		planet_max_districts_add = 3
-		district_farming_max = 1
-		district_generator_max = 1
-		district_mining_max = 1
+		district_farming_max_add = 1
+		district_generator_max_add = 1
+		district_mining_max_add = 1
 		planet_housing_add = 2000
 		planet_amenities_add = 2000
 		planet_crime_add = -20

--- a/common/diplomatic_actions/99_giga_preftl_flag_overwrites.txt
+++ b/common/diplomatic_actions/99_giga_preftl_flag_overwrites.txt
@@ -105,7 +105,9 @@ action_reveal_presence = {
 					from = {
 						OR = {
 							has_country_flag = synthetic_empire
-							has_authority = auth_machine_intelligence
+							is_machine_empire = yes
+							is_individual_machine = yes
+
 						}
 					}
 				}
@@ -121,7 +123,9 @@ action_reveal_presence = {
 					from = { has_civic = civic_machine_terminator }
 					OR = {
 						has_country_flag = synthetic_empire
-						has_authority = auth_machine_intelligence
+						is_machine_empire = yes
+						is_individual_machine = yes
+
 					}
 				}
 			}
@@ -289,7 +293,9 @@ action_societal_enlightenment = {
 					from = {
 						OR = {
 							has_country_flag = synthetic_empire
-							has_authority = auth_machine_intelligence
+							is_machine_empire = yes
+							is_individual_machine = yes
+
 						}
 					}
 				}
@@ -305,7 +311,9 @@ action_societal_enlightenment = {
 					from = { has_civic = civic_machine_terminator }
 					OR = {
 						has_country_flag = synthetic_empire
-						has_authority = auth_machine_intelligence
+						is_machine_empire = yes
+						is_individual_machine = yes
+
 					}
 				}
 			}
@@ -326,6 +334,12 @@ action_societal_enlightenment = {
 				set_country_flag = preftl_societal_enlightenment_pact_with@root
 				capital_scope.observation_outpost = {
 					set_event_locked = yes
+				}
+			}
+			country_event = { # Patron Objective Counter: po_establish_diplomatic_pact
+				id = shroud.10430
+				scopes = {
+					from = from
 				}
 			}
 		}
@@ -434,7 +448,14 @@ action_open_technological_enlightenment = {
 		}
 		custom_tooltip = {
 			fail_text = "requires_recipient_not_tech_frozen"
-			from = { NOT = { has_country_flag =  tech_frozen } }
+			from = {
+				NOR = {
+					has_country_flag =  tech_frozen
+					capital_scope = {
+						is_planet_class = pc_habitat
+					}
+				}
+			}
 		}
 		custom_tooltip = {
 			fail_text = "requires_actor_not_fanatic_purifiers"
@@ -493,7 +514,8 @@ action_open_technological_enlightenment = {
 					from = {
 						OR = {
 							has_country_flag = synthetic_empire
-							has_authority = auth_machine_intelligence
+							is_machine_empire = yes
+							is_individual_machine = yes
 						}
 					}
 				}
@@ -509,7 +531,9 @@ action_open_technological_enlightenment = {
 					from = { has_civic = civic_machine_terminator }
 					OR = {
 						has_country_flag = synthetic_empire
-						has_authority = auth_machine_intelligence
+						is_machine_empire = yes
+						is_individual_machine = yes
+
 					}
 				}
 			}
@@ -523,7 +547,9 @@ action_open_technological_enlightenment = {
 					from = { has_civic = civic_machine_terminator }
 					OR = {
 						has_country_flag = synthetic_empire
-						has_authority = auth_machine_intelligence
+						is_machine_empire = yes
+						is_individual_machine = yes
+
 					}
 				}
 			}
@@ -554,6 +580,12 @@ action_open_technological_enlightenment = {
 				}
 				capital_scope.observation_outpost = {
 					set_event_locked = yes
+				}
+			}
+			country_event = { # Patron Objective Counter: po_establish_diplomatic_pact
+				id = shroud.10435
+				scopes = {
+					from = from
 				}
 			}
 		}
@@ -773,7 +805,8 @@ action_pre_ftl_trade = {
 					from = {
 						OR = {
 							has_country_flag = synthetic_empire
-							has_authority = auth_machine_intelligence
+							is_machine_empire = yes
+							is_individual_machine = yes
 						}
 					}
 				}
@@ -789,7 +822,9 @@ action_pre_ftl_trade = {
 					from = { has_civic = civic_machine_terminator }
 					OR = {
 						has_country_flag = synthetic_empire
-						has_authority = auth_machine_intelligence
+						is_machine_empire = yes
+						is_individual_machine = yes
+
 					}
 				}
 			}
@@ -813,6 +848,12 @@ action_pre_ftl_trade = {
 				}
 				capital_scope.observation_outpost = {
 					set_event_locked = yes
+				}
+			}
+			country_event = { # Patron Objective Counter: po_establish_trade_agreement / po_establish_diplomatic_pact
+				id = shroud.10360
+				scopes = {
+					from = from
 				}
 			}
 		}

--- a/common/espionage_operation_types/pre_ftl_operations.txt
+++ b/common/espionage_operation_types/pre_ftl_operations.txt
@@ -781,3 +781,64 @@ operation_infiltrate_hive = {
 		}
 	}
 }
+
+operation_evolutionary_predator_procure_dna_preftl = {
+	target = none
+	categories = { op_cat_subterfuge op_cat_government }
+	picture = GFX_evt_genetic_modification
+	desc = operation_evolutionary_predator_procure_dna_desc
+	stages = 3
+
+	resources = {
+		category = operations
+		cost = {
+			influence = 45
+		}
+		upkeep = {
+			energy = 6
+		}
+	}
+
+	spy_power_cost = 30
+	potential = {
+		owner = { has_origin = origin_evolutionary_predators }
+		target = {
+			is_primitive = yes
+			NOT = { has_country_flag = @espionage_flag }
+			is_synthetic_empire = no #Robots don't have DNA
+			species = { NOT = { is_same_species = root.owner.species } }
+		}
+	}
+	allow = {
+		custom_tooltip = {
+			is_running_espionage_operation = no
+			fail_text = operation_one_at_a_time
+		}
+	}
+	stage = { #Install operatives
+		difficulty = @diff_t1
+		icon = GFX_espionage_chapter_icon_surveillance
+		event = bio.1050
+	}
+	stage = { #Target identified
+		difficulty = @diff_t1
+		icon = GFX_espionage_chapter_icon_target
+		event = bio.1055
+	}
+	stage = { #Result
+		difficulty = @diff_t1
+		icon = GFX_espionage_chapter_icon_motion
+		event = bio.1060
+	}
+	on_roll_failed = {
+		pre_ftl_espionage_operation_on_roll_failed = { RANDOM_EVENTS = operation_random_events_pre_ftl }
+	}
+	on_create = {
+		target = {
+			set_timed_country_flag = {
+				flag = preftl_espionage_operation_targeted_by@root.owner #Used in random Spy Network events
+				days = @operationTargetedByTimer
+			}
+		}
+	}
+}

--- a/common/game_rules/giga_rules.txt
+++ b/common/game_rules/giga_rules.txt
@@ -162,6 +162,7 @@ can_orbital_bombard = {
 						is_ship_size = voidworms_titan
 					}
 				}
+				has_country_flag = revengeful_patron
 			}
 		}
 		AND = {
@@ -266,6 +267,7 @@ can_planet_support_orbital_station = {
 # This = country, Country that wants to get an external leader
 # From = country, country that we are trying to get from
 can_get_external_leader_pool_candidate = {
+	exists = from
 	OR = {
 		has_diplo_migration_treaty = from
 		is_in_federation_with = from

--- a/common/inline_scripts/pop_categories/social_classes_triggered_modifiers.txt
+++ b/common/inline_scripts/pop_categories/social_classes_triggered_modifiers.txt
@@ -99,16 +99,21 @@ triggered_pop_group_modifier = {
 
 triggered_pop_group_modifier = {
     potential = {
-        NOR = {
-            has_trait = trait_psionic
-            has_trait = trait_latent_psionic
-        }
+        has_psionic_species_trait = no
     }
     key = mod_pop_non_psionic_happiness
     pop_happiness = 1
     mult = modifier:pop_non_psionic_happiness
 }
 
+triggered_pop_group_modifier = {
+    potential = {
+        has_psionic_species_trait = yes
+    }
+    key = mod_pop_psionic_happiness
+    pop_happiness = 1
+    mult = modifier:pop_psionic_happiness
+}
 
 triggered_pop_group_modifier = {
     potential = {
@@ -221,10 +226,7 @@ triggered_pop_group_modifier = {
 # hypersiphon efficiency
 triggered_pop_group_modifier = {
     potential = {
-        OR = {
-            has_trait = trait_psionic
-            has_trait = trait_latent_psionic
-        }
+        has_psionic_species_trait = no
     }
     key = mod_psionic_pop_bonus_workforce_mult
     pop_bonus_workforce_mult = 1

--- a/common/script_values/giga_script_values.txt
+++ b/common/script_values/giga_script_values.txt
@@ -1028,22 +1028,23 @@ giga_jobs_per_district = {
 	}
 }
 
-mining_districts_value = {
-	complex_trigger_modifier = {
-		trigger = num_districts
-		parameters = {
-			type = district_mining
-		}
-		mode = add
-	}
-	complex_trigger_modifier = {
-		trigger = num_districts
-		parameters = {
-			type = district_mining_uncapped
-		}
-		mode = add
-	}
-}
+# This script value now exists in vanilla (05_script_values_wilderness.txt)
+# mining_districts_value = {
+# 	complex_trigger_modifier = {
+# 		trigger = num_districts
+# 		parameters = {
+# 			type = district_mining
+# 		}
+# 		mode = add
+# 	}
+# 	complex_trigger_modifier = {
+# 		trigger = num_districts
+# 		parameters = {
+# 			type = district_mining_uncapped
+# 		}
+# 		mode = add
+# 	}
+# }
 
 set_situation_progress = {
 	add = $NEW_PROGRESS$

--- a/common/scripted_effects/zzz_giga_overwrites.txt
+++ b/common/scripted_effects/zzz_giga_overwrites.txt
@@ -169,6 +169,7 @@ activate_behemoth_superweapon = { #Overwrite to not kill the bloody vester
 		limit = {
 			is_planet_class = pc_city
 		}
+		change_pc = pc_relic
 		relic_world_deposits = yes
 		validate_planet_buildings_and_districts = yes
 	}

--- a/common/scripted_triggers/03_giga_low_priority_overwrites.txt
+++ b/common/scripted_triggers/03_giga_low_priority_overwrites.txt
@@ -1,251 +1,250 @@
-has_upgraded_capital = {
-	hidden_trigger = { exists = owner }
-	if = {
-		limit = { has_modifier = resort_colony }
-		custom_tooltip = {
-			fail_text = "requires_building_resort_capital"
-			OR = {
-				has_building = building_resort_capital
-				has_building = building_resort_major_capital
-			}
-		}
-	}
-	else_if = {
-		limit = { has_modifier = slave_colony }
-		custom_tooltip = {
-			fail_text = "requires_building_slave_capital"
-			OR = {
-				has_building = building_slave_capital
-				has_building = building_slave_major_capital
-			}
-		}
-	}
-	else_if = {
-		limit = {
-			or = {
-				is_planet_class = pc_habitat
-				uses_habitat_capitals = yes
-			}
-		}
-		custom_tooltip = {
-			fail_text = "requires_building_hab_capital"
-			OR = {
-				has_building = building_hab_capital
-				has_building = building_hab_major_capital
-				has_building = building_hab_system_capital
-				has_building = building_imperial_capital
-				has_building = building_imperial_machine_capital
-				has_building = building_imperial_hive_capital
-			}
-		}
-	}
-	else_if = {
-		limit = { owner = { is_wilderness_empire = yes } }
-		custom_tooltip = {
-			fail_text = "requires_building_wilderness_capital"
-			OR = {
-				has_building = building_capital_wilderness
-				has_building = building_major_capital_wilderness
-				has_building = building_system_capital_wilderness
-				has_building = building_imperial_capital_wilderness
-			}
-		}
-	}
-	else_if = {
-		limit = { owner = { is_hive_empire = yes } } # excludes Wilderness, above
-		custom_tooltip = {
-			fail_text = "requires_building_hive_capital"
-			OR = {
-				has_building = building_hive_capital
-				has_building = building_hive_major_capital
-				has_building = building_imperial_hive_capital
-				has_building = building_giga_elysium_host_hive_major_capital
-			}
-		}
-	}
-	else_if = {
-		limit = { owner = { is_machine_empire = yes } }
-		custom_tooltip = {
-			fail_text = "requires_building_machine_capital"
-			OR = {
-				has_building = building_machine_capital
-				has_building = building_machine_major_capital
-				has_building = building_machine_system_capital
-				has_building = building_imperial_machine_capital
-				has_building = building_giga_elysium_host_machine_major_capital
-			}
-		}
-	}
-	else = {
-		custom_tooltip = {
-			fail_text = "requires_building_capital"
-			OR = {
-				has_building = building_capital
-				has_building = building_major_capital
-				has_building = building_system_capital
-				has_building = building_imperial_capital
-				has_building = building_giga_elysium_host_major_capital
-			}
-		}
-	}
-}
-
-has_major_upgraded_capital = {
-	hidden_trigger = { exists = owner }
-	if = {
-		limit = { has_modifier = resort_colony }
-		custom_tooltip = {
-			fail_text = "requires_building_resort_major_capital"
-			has_building = building_resort_major_capital
-		}
-	}
-	else_if = {
-		limit = { has_modifier = slave_colony }
-		custom_tooltip = {
-			fail_text = "requires_building_slave_major_capital"
-			has_building = building_slave_major_capital
-		}
-	}
-	else_if = {
-		limit = {
-			or = {
-				is_planet_class = pc_habitat
-				uses_habitat_capitals = yes
-			}
-		}
-		custom_tooltip = {
-			fail_text = "requires_building_hab_major_capital"
-			OR = {
-				has_building = building_hab_major_capital
-				has_building = building_hab_system_capital
-				has_building = building_imperial_capital
-				has_building = building_imperial_machine_capital
-				has_building = building_imperial_hive_capital
-			}
-		}
-	}
-	else_if = {
-		limit = { owner = { is_wilderness_empire = yes } }
-		custom_tooltip = {
-			fail_text = "requires_building_wilderness_major_capital"
-			OR = {
-				has_building = building_major_capital_wilderness
-				has_building = building_system_capital_wilderness
-				has_building = building_imperial_capital_wilderness
-			}
-		}
-	}
-	else_if = {
-		limit = { owner = { is_hive_empire = yes } } # excludes Wilderness, above
-		custom_tooltip = {
-			fail_text = "requires_building_major_hive_capital"
-			OR = {
-				has_building = building_hive_major_capital
-				has_building = building_imperial_hive_capital
-				has_building = building_giga_elysium_host_hive_major_capital
-			}
-		}
-	}
-	else_if = {
-		limit = { owner = { is_machine_empire = yes } }
-		custom_tooltip = {
-			fail_text = "requires_building_machine_major_capital"
-			OR = {
-				has_building = building_machine_major_capital
-				has_building = building_machine_system_capital
-				has_building = building_imperial_machine_capital
-				has_building = building_giga_elysium_host_machine_major_capital
-			}
-		}
-	}
-	else = {
-		custom_tooltip = {
-			fail_text = "requires_building_major_capital"
-			OR = {
-				has_building = building_major_capital
-				has_building = building_system_capital
-				has_building = building_imperial_capital
-				has_building = building_giga_elysium_host_major_capital
-			}
-		}
-	}
-}
-
-has_fully_upgraded_capital = {
-	hidden_trigger = { exists = owner }
-	if = {
-		limit = { has_modifier = resort_colony }
-		custom_tooltip = {
-			fail_text = "requires_building_resort_major_capital"
-			has_building = building_resort_major_capital
-		}
-	}
-	else_if = {
-		limit = { has_modifier = slave_colony }
-		custom_tooltip = {
-			fail_text = "requires_building_slave_major_capital"
-			has_building = building_slave_major_capital
-		}
-	}
-	else_if = {
-		limit = {
-			or = {
-				is_planet_class = pc_habitat
-				uses_habitat_capitals = yes
-			}
-		}
-		custom_tooltip = {
-			fail_text = "requires_building_hab_system_capital"
-			OR = {
-				has_building = building_hab_system_capital
-				has_building = building_imperial_capital
-				has_building = building_imperial_machine_capital
-				has_building = building_imperial_hive_capital
-			}
-		}
-	}
-	else_if = {
-		limit = { owner = { is_wilderness_empire = yes } }
-		custom_tooltip = {
-			fail_text = "requires_building_wilderness_system_capital"
-			OR = {
-				has_building = building_system_capital_wilderness
-				has_building = building_imperial_capital_wilderness
-			}
-		}
-	}
-	else_if = {
-		limit = { owner = { is_hive_empire = yes } } # excludes Wilderness, above
-		custom_tooltip = {
-			fail_text = "requires_building_major_hive_capital"
-			OR = {
-				has_building = building_hive_major_capital
-				has_building = building_imperial_hive_capital
-			}
-		}
-	}
-	else_if = {
-		limit = { owner = { is_machine_empire = yes } }
-		custom_tooltip = {
-			fail_text = "requires_building_machine_major_capital"
-			OR = {
-				has_building = building_machine_major_capital
-				has_building = building_machine_system_capital
-				has_building = building_imperial_machine_capital
-			}
-		}
-	}
-	else = {
-		custom_tooltip = {
-			fail_text = "requires_building_system_capital"
-			OR = {
-				has_building = building_system_capital
-				has_building = building_imperial_capital
-			}
-		}
-	}
-}
-
+# has_upgraded_capital = {
+# 	hidden_trigger = { exists = owner }
+# 	if = {
+# 		limit = { has_modifier = resort_colony }
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_resort_capital"
+# 			OR = {
+# 				has_building = building_resort_capital
+# 				has_building = building_resort_major_capital
+# 			}
+# 		}
+# 	}
+# 	else_if = {
+# 		limit = { has_modifier = slave_colony }
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_slave_capital"
+# 			OR = {
+# 				has_building = building_slave_capital
+# 				has_building = building_slave_major_capital
+# 			}
+# 		}
+# 	}
+# 	else_if = {
+# 		limit = {
+# 			or = {
+# 				is_planet_class = pc_habitat
+# 				uses_habitat_capitals = yes
+# 			}
+# 		}
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_hab_capital"
+# 			OR = {
+# 				has_building = building_hab_capital
+# 				has_building = building_hab_major_capital
+# 				has_building = building_hab_system_capital
+# 				has_building = building_imperial_capital
+# 				has_building = building_imperial_machine_capital
+# 				has_building = building_imperial_hive_capital
+# 			}
+# 		}
+# 	}
+# 	else_if = {
+# 		limit = { owner = { is_wilderness_empire = yes } }
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_wilderness_capital"
+# 			OR = {
+# 				has_building = building_capital_wilderness
+# 				has_building = building_major_capital_wilderness
+# 				has_building = building_system_capital_wilderness
+# 				has_building = building_imperial_capital_wilderness
+# 			}
+# 		}
+# 	}
+# 	else_if = {
+# 		limit = { owner = { is_hive_empire = yes } } # excludes Wilderness, above
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_hive_capital"
+# 			OR = {
+# 				has_building = building_hive_capital
+# 				has_building = building_hive_major_capital
+# 				has_building = building_imperial_hive_capital
+# 				has_building = building_giga_elysium_host_hive_major_capital
+# 			}
+# 		}
+# 	}
+# 	else_if = {
+# 		limit = { owner = { is_machine_empire = yes } }
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_machine_capital"
+# 			OR = {
+# 				has_building = building_machine_capital
+# 				has_building = building_machine_major_capital
+# 				has_building = building_machine_system_capital
+# 				has_building = building_imperial_machine_capital
+# 				has_building = building_giga_elysium_host_machine_major_capital
+# 			}
+# 		}
+# 	}
+# 	else = {
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_capital"
+# 			OR = {
+# 				has_building = building_capital
+# 				has_building = building_major_capital
+# 				has_building = building_system_capital
+# 				has_building = building_imperial_capital
+# 				has_building = building_giga_elysium_host_major_capital
+# 			}
+# 		}
+# 	}
+# }
+#
+# has_major_upgraded_capital = {
+# 	hidden_trigger = { exists = owner }
+# 	if = {
+# 		limit = { has_modifier = resort_colony }
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_resort_major_capital"
+# 			has_building = building_resort_major_capital
+# 		}
+# 	}
+# 	else_if = {
+# 		limit = { has_modifier = slave_colony }
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_slave_major_capital"
+# 			has_building = building_slave_major_capital
+# 		}
+# 	}
+# 	else_if = {
+# 		limit = {
+# 			or = {
+# 				is_planet_class = pc_habitat
+# 				uses_habitat_capitals = yes
+# 			}
+# 		}
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_hab_major_capital"
+# 			OR = {
+# 				has_building = building_hab_major_capital
+# 				has_building = building_hab_system_capital
+# 				has_building = building_imperial_capital
+# 				has_building = building_imperial_machine_capital
+# 				has_building = building_imperial_hive_capital
+# 			}
+# 		}
+# 	}
+# 	else_if = {
+# 		limit = { owner = { is_wilderness_empire = yes } }
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_wilderness_major_capital"
+# 			OR = {
+# 				has_building = building_major_capital_wilderness
+# 				has_building = building_system_capital_wilderness
+# 				has_building = building_imperial_capital_wilderness
+# 			}
+# 		}
+# 	}
+# 	else_if = {
+# 		limit = { owner = { is_hive_empire = yes } } # excludes Wilderness, above
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_major_hive_capital"
+# 			OR = {
+# 				has_building = building_hive_major_capital
+# 				has_building = building_imperial_hive_capital
+# 				has_building = building_giga_elysium_host_hive_major_capital
+# 			}
+# 		}
+# 	}
+# 	else_if = {
+# 		limit = { owner = { is_machine_empire = yes } }
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_machine_major_capital"
+# 			OR = {
+# 				has_building = building_machine_major_capital
+# 				has_building = building_machine_system_capital
+# 				has_building = building_imperial_machine_capital
+# 				has_building = building_giga_elysium_host_machine_major_capital
+# 			}
+# 		}
+# 	}
+# 	else = {
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_major_capital"
+# 			OR = {
+# 				has_building = building_major_capital
+# 				has_building = building_system_capital
+# 				has_building = building_imperial_capital
+# 				has_building = building_giga_elysium_host_major_capital
+# 			}
+# 		}
+# 	}
+# }
+#
+# has_fully_upgraded_capital = {
+# 	hidden_trigger = { exists = owner }
+# 	if = {
+# 		limit = { has_modifier = resort_colony }
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_resort_major_capital"
+# 			has_building = building_resort_major_capital
+# 		}
+# 	}
+# 	else_if = {
+# 		limit = { has_modifier = slave_colony }
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_slave_major_capital"
+# 			has_building = building_slave_major_capital
+# 		}
+# 	}
+# 	else_if = {
+# 		limit = {
+# 			or = {
+# 				is_planet_class = pc_habitat
+# 				uses_habitat_capitals = yes
+# 			}
+# 		}
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_hab_system_capital"
+# 			OR = {
+# 				has_building = building_hab_system_capital
+# 				has_building = building_imperial_capital
+# 				has_building = building_imperial_machine_capital
+# 				has_building = building_imperial_hive_capital
+# 			}
+# 		}
+# 	}
+# 	else_if = {
+# 		limit = { owner = { is_wilderness_empire = yes } }
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_wilderness_system_capital"
+# 			OR = {
+# 				has_building = building_system_capital_wilderness
+# 				has_building = building_imperial_capital_wilderness
+# 			}
+# 		}
+# 	}
+# 	else_if = {
+# 		limit = { owner = { is_hive_empire = yes } } # excludes Wilderness, above
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_major_hive_capital"
+# 			OR = {
+# 				has_building = building_hive_major_capital
+# 				has_building = building_imperial_hive_capital
+# 			}
+# 		}
+# 	}
+# 	else_if = {
+# 		limit = { owner = { is_machine_empire = yes } }
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_machine_major_capital"
+# 			OR = {
+# 				has_building = building_machine_major_capital
+# 				has_building = building_machine_system_capital
+# 				has_building = building_imperial_machine_capital
+# 			}
+# 		}
+# 	}
+# 	else = {
+# 		custom_tooltip = {
+# 			fail_text = "requires_building_system_capital"
+# 			OR = {
+# 				has_building = building_system_capital
+# 				has_building = building_imperial_capital
+# 			}
+# 		}
+# 	}
+# }
 
 has_blocked_random_devastating_pre_ftl_events = {
 	OR = {

--- a/common/scripted_triggers/03_giga_low_priority_overwrites.txt
+++ b/common/scripted_triggers/03_giga_low_priority_overwrites.txt
@@ -347,6 +347,7 @@ has_special_star_flag_trigger = {
 		has_star_flag = guardian
 		has_star_flag = sealed_system
 		has_star_flag = starlit_sealed_system
+		has_star_flag = exiled_system
 		# Megastructures
 		has_star_flag = abandoned_gateway
 		has_star_flag = ruined_mega_shipyard_system

--- a/common/scripted_triggers/zzz_overwrites.txt
+++ b/common/scripted_triggers/zzz_overwrites.txt
@@ -736,6 +736,7 @@ has_any_megastructure_in_empire = {
 				has_megastructure = mega_art_installation_3
 				has_megastructure = mega_art_installation_ruined
 				has_megastructure = mega_art_installation_restored
+				has_megastructure = mega_art_installation_restored_2
 
 				has_megastructure = interstellar_assembly_0
 				has_megastructure = interstellar_assembly_1
@@ -2161,8 +2162,6 @@ just_researched_fe_tech = {
 		last_increased_tech = tech_dark_matter_power_core
 		last_increased_tech = tech_dark_matter_propulsion
 		last_increased_tech = tech_cloaking_dark_matter
-		last_increased_tech = tech_enigmatic_encoder
-		last_increased_tech = tech_enigmatic_decoder
 		last_increased_tech = tech_fe_affluence_1
 		last_increased_tech = tech_fe_affluence_2
 		last_increased_tech = tech_fe_nourishment_1
@@ -2198,6 +2197,10 @@ just_researched_fe_tech = {
 		last_increased_tech = tech_cosmogenesis_escort
 		last_increased_tech = tech_cosmogenesis_battlecruiser
 		last_increased_tech = tech_cosmogenesis_FE_titan
+		last_increased_tech = tech_cosmogenesis_mauler
+		last_increased_tech = tech_cosmogenesis_weaver
+		last_increased_tech = tech_cosmogenesis_harbinger
+		last_increased_tech = tech_cosmogenesis_stinger
 
 		giga_just_researched_fe_tech = yes
 	}

--- a/common/scripted_triggers/zzz_overwrites.txt
+++ b/common/scripted_triggers/zzz_overwrites.txt
@@ -1760,6 +1760,17 @@ can_destroy_planet_with_PLANET_KILLER_NANOBOTS = {
 
 can_destroy_planet_with_PLANET_KILLER_DEVOLUTION = {
 	custom_tooltip = {
+		fail_text = is_ai_world_no_archaeoengineers
+		if = {
+			limit = {
+				is_planet_class = pc_ai
+			}
+			from.owner = {
+				has_ascension_perk = ap_archaeoengineers
+			}
+		}
+	}
+	custom_tooltip = {
 		fail_text = is_not_a_habitable_planet_or_megastructure
 		OR = {
 			is_a_habitable_planet_megastructure = yes

--- a/common/scripted_triggers/zzz_overwrites.txt
+++ b/common/scripted_triggers/zzz_overwrites.txt
@@ -78,6 +78,7 @@ has_no_non_gate_megastructure = {
 					is_megastructure_type = mega_art_installation_3
 					is_megastructure_type = mega_art_installation_ruined
 					is_megastructure_type = mega_art_installation_restored
+					is_megastructure_type = mega_art_installation_restored_2
 
 					is_megastructure_type = interstellar_assembly_0
 					is_megastructure_type = interstellar_assembly_1
@@ -355,11 +356,11 @@ has_no_non_gate_megastructure = {
 					is_megastructure_type = alderson_disk_0
 					is_megastructure_type = alderson_disk_1
 					is_megastructure_type = alderson_disk_2
-					is_megastructure_type = alderson_disk_2_ecu
+					# is_megastructure_type = alderson_disk_2_ecu
 					is_megastructure_type = alderson_disk_2_gaia
-					is_megastructure_type = alderson_disk_2_pc
-					is_megastructure_type = alderson_disk_2_hive
-					is_megastructure_type = alderson_disk_2_machine
+					# is_megastructure_type = alderson_disk_2_pc
+					# is_megastructure_type = alderson_disk_2_hive
+					# is_megastructure_type = alderson_disk_2_machine
 
 					is_megastructure_type = asteroid_manufactory_0
 					is_megastructure_type = asteroid_manufactory_platform_alloys
@@ -1005,11 +1006,11 @@ has_any_megastructure_in_empire = {
 				has_megastructure = alderson_disk_0
 				has_megastructure = alderson_disk_1
 				has_megastructure = alderson_disk_2
-				has_megastructure = alderson_disk_2_ecu
+				# has_megastructure = alderson_disk_2_ecu
 				has_megastructure = alderson_disk_2_gaia
-				has_megastructure = alderson_disk_2_pc
-				has_megastructure = alderson_disk_2_hive
-				has_megastructure = alderson_disk_2_machine
+				# has_megastructure = alderson_disk_2_pc
+				# has_megastructure = alderson_disk_2_hive
+				# has_megastructure = alderson_disk_2_machine
 
 				has_megastructure = asteroid_manufactory_0
 				has_megastructure = asteroid_manufactory_platform_alloys
@@ -1905,9 +1906,9 @@ uses_district_industrial = {
 
 has_any_industry_district = {
 	OR = {
-		has_district = district_industrial
-		has_district = district_hab_industrial
-		has_district = district_rw_industrial
+		# has_district = district_industrial
+		# has_district = district_hab_industrial
+		# has_district = district_rw_industrial
 		has_district = district_arcology_arms_industry
 		has_district = district_arcology_civilian_industry
 

--- a/common/starbase_modules/giga_orbital_ring_modules.txt
+++ b/common/starbase_modules/giga_orbital_ring_modules.txt
@@ -202,7 +202,7 @@ orbital_ring_giga_generator_district = {
 				}
 			}
 		}
-		district_generator_max = 2
+		district_generator_max_add = 2
 	}
 	triggered_planet_modifier = {
 		potential = {
@@ -383,4 +383,3 @@ orbital_ring_giga_farming_district = {
 		}
 	}
 }
-

--- a/common/starbase_types/01_giga_starbase_types_overwrites.txt
+++ b/common/starbase_types/01_giga_starbase_types_overwrites.txt
@@ -22,6 +22,12 @@ sorbital_ring = { # generic
             orbital_ring_shipyard = {
                 base = 0.0 # Generally better to use normal starbases for this
             }
+            orbital_ring_hatchery = {
+                base = 0.0 # Generally better to use normal starbases for this
+            }
+            orbital_ring_beastport = {
+                base = 0.0 # Generally better to use normal starbases for this
+            }
 
             orbital_ring_anchorage = {
                 base = 0.0 # Generally better to use normal starbases for this
@@ -80,6 +86,8 @@ sorbital_ring = { # generic
                             has_mining_designation = yes
                             has_building = building_mineral_purification_plant
                             has_building = building_mineral_purification_hub
+                            has_building = building_churning_tunnels_3
+                            has_building = building_churning_tunnels_4
                         }
                     }
                 }
@@ -94,6 +102,8 @@ sorbital_ring = { # generic
                             has_generator_designation = yes
                             has_building = building_energy_grid
                             has_building = building_energy_nexus
+                            has_building = building_bioelectric_stimulator_3
+                            has_building = building_bioelectric_stimulator_4
                         }
                     }
                 }
@@ -108,6 +118,7 @@ sorbital_ring = { # generic
                             has_farming_designation = yes
                             has_building = building_food_processing_facility
                             has_building = building_food_processing_center
+                            has_building = building_massive_growth_4
                         }
                     }
                 }
@@ -138,8 +149,11 @@ sorbital_ring = { # generic
                             has_foundry_designation = yes
                             has_industrial_designation = yes
                             has_building = building_foundry_1
+                            has_building = building_natural_furnace_1
                             has_building = building_foundry_2
+                            has_building = building_natural_furnace_2
                             has_building = building_foundry_3
+                            has_building = building_natural_furnace_3
                         }
                     }
                 }
@@ -238,6 +252,8 @@ sorbital_habitation = {
                             has_designation = col_mining
                             has_building = building_mineral_purification_plant
                             has_building = building_mineral_purification_hub
+                            has_building = building_churning_tunnels_3
+                            has_building = building_churning_tunnels_4
                         }
                     }
                 }
@@ -252,6 +268,8 @@ sorbital_habitation = {
                             has_designation = col_generator
                             has_building = building_energy_grid
                             has_building = building_energy_nexus
+                            has_building = building_bioelectric_stimulator_3
+                            has_building = building_bioelectric_stimulator_4
                         }
                     }
                 }
@@ -266,6 +284,7 @@ sorbital_habitation = {
                             has_designation = col_farming
                             has_building = building_food_processing_facility
                             has_building = building_food_processing_center
+                            has_building = building_massive_growth_4
                         }
                     }
                 }
@@ -296,8 +315,11 @@ sorbital_habitation = {
                             has_designation = col_industrial
                             has_designation = col_foundry
                             has_building = building_foundry_1
+                            has_building = building_natural_furnace_1
                             has_building = building_foundry_2
+                            has_building = building_natural_furnace_2
                             has_building = building_foundry_3
+                            has_building = building_natural_furnace_3
                         }
                     }
                 }

--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -17847,7 +17847,7 @@
   sm_orbital_ring_giga_farming_district_desc:0 "Automated factories produce vast quantities of fertilizer and distribute them to previously inhospitable parts of the planet's surface to permit agriculture.\n\n§YEfficiency is lower on Tomb Worlds and higher on Gaia Worlds. Does not function on Irradiated Desert Worlds.§!\n"
 
   sm_ring_giga_crystals_hub:0 "Laser Crystal Bore"
-  sm_ring_giga_crystals_hub_desc:0 "Immense laser drills cutting into the planet's crust to help planetside rare crystal mining. Other extracted materials supplement the crystal refining process.\n\n§TProvides §G+1§! £job_crystal_miner£ §YCrystal Mining§! Job per §G4§! £district£ §Y$district_mining_plural$§!.\n"
+  sm_ring_giga_crystals_hub_desc:0 "Immense laser drills cutting into the planet's crust to help planetside rare crystal mining. Other extracted materials supplement the crystal refining process.\n\n§TProvides §G+100§! £job_crystal_miner£ §YCrystal Mining§! Jobs per §G4§! £district£ §Y$district_mining_plural$§!.\n"
   ring_giga_crystals_hub_condition:99 "§RPlanet must have deposits of £rare_crystals£ §Y$rare_crystals$.§!"
 
   sm_ring_giga_motes_hub:0 "Hypersonic Mote Sifter"
@@ -17855,11 +17855,11 @@
   ring_giga_motes_hub_condition:99 "§RPlanet must have deposits of £volatile_motes£ §Y$volatile_motes$.§!"
 
   sm_ring_giga_gas_hub:0 "Atmospheric Gas Stabilizer"
-  sm_ring_giga_gas_hub_desc:0 "Chemical plants which inject stabilizing agents into the atmosphere near naturally-occurring gas deposits, making extraction safer and easier. As a side effect, local microbes can be more effectively utilised to refine gases from biomass.\n\n§TProvides §G+1§! £job_gas_extractor£ §YGas Extraction§! Job per §G4§! £district£ §Y$district_mining_plural$§!.\n"
+  sm_ring_giga_gas_hub_desc:0 "Chemical plants which inject stabilizing agents into the atmosphere near naturally-occurring gas deposits, making extraction safer and easier. As a side effect, local microbes can be more effectively utilised to refine gases from biomass.\n\n§TProvides §G+100§! £job_gas_extractor£ §YGas Extraction§! Jobs per §G4§! £district£ §Y$district_mining_plural$§!.\n"
   ring_giga_gas_hub_condition:99 "§RPlanet must have deposits of £exotic_gases£ §Y$exotic_gases$.§!"
 
   sm_ring_giga_iodizium_hub:0 "Field Isolation Grid"
-  sm_ring_giga_iodizium_hub_desc:0 "Shield projectors focused on Iodizium mining facilities ensure that explosive chain reactions are kept to a minimum, greatly improving the efficiency of planetside crystal handling.\n\n§TProvides §G+1§! £job_giga_iodizium_miner£ §YIodizium Mining§! Job per active £building£ §Y$building_giga_iodizium_mines$§! Building§!\n"
+  sm_ring_giga_iodizium_hub_desc:0 "Shield projectors focused on Iodizium mining facilities ensure that explosive chain reactions are kept to a minimum, greatly improving the efficiency of planetside crystal handling.\n\n§TProvides §G+100§! £job_giga_iodizium_miner£ §YIodizium Mining§! Jobs per active £building£ §Y$building_giga_iodizium_mines$§! Building§!\n"
   ring_giga_iodizium_hub_condition:0 "§RPlanet must be able to support at least one £building£ §Y$building_giga_iodizium_mines$§! Building.§!"
 
   sm_ring_giga_orbital_arcology:0 "Orbital Arcology"


### PR DESCRIPTION
- Updated overwrites to Eternal Vigilance and Defender of the Galaxy ascension perks

- Updated pre-FTL diplomatic action overwrites

- Updated pre-FTL operations types overwrite (Gigas fully overwrites the vanilla file and was missing the new "Procure DNA" operation

- Updated overwrites to `can_orbital_bombard` trigger

- Updated overwrites to `social_classes_triggered_modifiers` inline (now uses the new `has_psionic_species_trait` trigger, added missing triggered modifier

- Removed `mining_districts_value` script value, seems like a value of the same name was added to vanilla after it was initally added to Gigas, leading to conflicts, the Gigas version has been removed as the vanilla version is more accommodating

- Added missing planet class change to the behemoth superweapon overwrite

- Updated `can_destroy_planet_with_PLANET_KILLER_DEVOLUTION` trigger overwrite to prevent the devolution of AI worlds without the Archaeoengineers ascension perk

- Added `mega_art_installation_restored_2` to `has_any_megastructure_in_empire` and `has_no_non_gate_megastructure` triggers, commented out references to nonexistent Alderson variants, commented out references to nonexistent district types in `has_any_industry_district` trigger

- Added missing techs to `just_researched_fe_tech` trigger, removed vanilla techs not present in vanilla trigger

- Added missing flag to `has_special_star_flag_trigger` trigger

- Updated capital buildings to use `capital_tier = x` field, commented out upgraded capital trigger overwrites as the new `capital_tier` system renders them unncessary (Aeternite buildings have not been touched as they are being looked over on TTFT's branch)

- Updated starbase type overwrites

- Updated orbital ring SR building loc to reflect new job counts

- Fixed a district cap modifier that was missed in the orbital ring module update