### PR TITLE
Bugfix Electric Boogaloo

### DIFF
--- a/common/scripted_variables/ehof_component_vars.txt
+++ b/common/scripted_variables/ehof_component_vars.txt
@@ -293,9 +293,9 @@
 @ehof_platform_reactor_power_2		= 1225
 @ehof_platform_reactor_power_3		= 1530
 
-@ehof_ion_reactor_power_1			= 1320
-@ehof_ion_reactor_power_2			= 1680
-@ehof_ion_reactor_power_3			= 2120
+@ehof_ion_reactor_power_1			= 2550 # matches battleship like vanilla
+@ehof_ion_reactor_power_2			= 3210
+@ehof_ion_reactor_power_3			= 3990
 
 # Cost Requires SM/QNM/DM
 @ehof_corvette_reactor_cost_1		= 10

--- a/events/giga_001_mega_events.txt
+++ b/events/giga_001_mega_events.txt
@@ -2286,84 +2286,172 @@ planet_event = {
 		save_event_target_as = planet_deploying_ships
 		planet_owner = { save_event_target_as = strike_fleet_owner }
 		planet_event = { id = giga_mega.7003 days = 10 }
-		create_fleet = {
-			name = "corvette_defense_squadron"
-			settings = {
-				spawn_debris = no
-				can_change_composition = no
-				is_boss = no
-				can_disband = no
-				can_upgrade = no
-				uses_naval_capacity = no
-				can_change_leader = no
-			}
-			effect = {
-				set_name = {
-					key = "corvette_defense_squadron"
-					variable_string = "[event_target:planet_deploying_ships.GetName]"
-				}
-				set_owner = event_target:strike_fleet_owner
-				while = {
-					count = event_target:planet_deploying_ships.giga_nexus_ship_count
-					create_ship = {
-						name = "Strike Corvette"
-						graphical_culture = event_target:strike_fleet_owner
-						random_existing_design = corvette
-						effect = {
-							add_modifier = {
-								modifier = giga_strike_corvette_modifier
-								days = -1
-							}
-							if = {
-								limit = { event_target:strike_fleet_owner = { has_ascension_perk = ap_eternal_vigilance } }
-								add_modifier = {
-									modifier = giga_strike_corvette_vigilance_ap
-									days = -1
-								}
-							}
-							if = {
-								limit = { event_target:strike_fleet_owner = { has_technology = giga_tech_defense_nexus_damage_1 } }
-								add_modifier = {
-									modifier = giga_strike_corvette_buff_tech_1
-									days = -1
-								}
-							}
-							if = {
-								limit = { event_target:strike_fleet_owner = { has_technology = giga_tech_defense_nexus_damage_2 } }
-								add_modifier = {
-									modifier = giga_strike_corvette_buff_tech_2
-									days = -1
-								}
-							}
-							if = {
-								limit = { event_target:planet_deploying_ships = { is_giga_maginot_world = yes } }
-								add_modifier = {
-									modifier = giga_strike_corvette_buff_maginot
-									days = -1
-								}
-							}
-						}
-					}
-				}
-				set_fleet_stance = aggressive
-				set_fleet_flag = giga_yard_entity_@ROOT
-				fleet_event = { id = giga_mega.7002 days = 30 }
-				set_formation_scale = 1
-				set_location = {
-					target = ROOT
-					distance = 0
-					angle = 0
-				}
-				ROOT = {
-					set_planet_flag = giga_yard_entity_fleet_@PREV
-					set_planet_flag = defence_squadron_deployed
-					set_timed_planet_flag = {
-						flag = giga_defence_squadron_cooldown
-						days = 90
-					}
-				}
-			}
-		}
+        if = { # for the mechanical ships
+            limit = {
+                owner = { country_uses_bio_ships = no }
+            }
+            create_fleet = {
+                name = "corvette_defense_squadron"
+                settings = {
+                    spawn_debris = no
+                    can_change_composition = no
+                    is_boss = no
+                    can_disband = no
+                    can_upgrade = no
+                    uses_naval_capacity = no
+                    can_change_leader = no
+                }
+                effect = {
+                    set_name = {
+                        key = "corvette_defense_squadron"
+                        variable_string = "[event_target:planet_deploying_ships.GetName]"
+                    }
+                    set_owner = event_target:strike_fleet_owner
+                    while = {
+                        count = event_target:planet_deploying_ships.giga_nexus_ship_count
+                        create_ship = {
+                            name = "Strike Corvette"
+                            graphical_culture = event_target:strike_fleet_owner
+                            random_existing_design = corvette
+                            effect = {
+                                add_modifier = {
+                                    modifier = giga_strike_corvette_modifier
+                                    days = -1
+                                }
+                                if = {
+                                    limit = { event_target:strike_fleet_owner = { has_ascension_perk = ap_eternal_vigilance } }
+                                    add_modifier = {
+                                        modifier = giga_strike_corvette_vigilance_ap
+                                        days = -1
+                                    }
+                                }
+                                if = {
+                                    limit = { event_target:strike_fleet_owner = { has_technology = giga_tech_defense_nexus_damage_1 } }
+                                    add_modifier = {
+                                        modifier = giga_strike_corvette_buff_tech_1
+                                        days = -1
+                                    }
+                                }
+                                if = {
+                                    limit = { event_target:strike_fleet_owner = { has_technology = giga_tech_defense_nexus_damage_2 } }
+                                    add_modifier = {
+                                        modifier = giga_strike_corvette_buff_tech_2
+                                        days = -1
+                                    }
+                                }
+                                if = {
+                                    limit = { event_target:planet_deploying_ships = { is_giga_maginot_world = yes } }
+                                    add_modifier = {
+                                        modifier = giga_strike_corvette_buff_maginot
+                                        days = -1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    set_fleet_stance = aggressive
+                    set_fleet_flag = giga_yard_entity_@ROOT
+                    fleet_event = { id = giga_mega.7002 days = 30 }
+                    set_formation_scale = 1
+                    set_location = {
+                        target = ROOT
+                        distance = 0
+                        angle = 0
+                    }
+                    ROOT = {
+                        set_planet_flag = giga_yard_entity_fleet_@PREV
+                        set_planet_flag = defence_squadron_deployed
+                        set_timed_planet_flag = {
+                            flag = giga_defence_squadron_cooldown
+                            days = 90
+                        }
+                    }
+                }
+            }
+        }
+        if = { # for bioships
+            limit = {
+                owner = { country_uses_bio_ships = yes }
+            }
+            create_fleet = {
+                name = "mauler_defense_squadron"
+                settings = {
+                    spawn_debris = no
+                    can_change_composition = no
+                    is_boss = no
+                    can_disband = no
+                    can_upgrade = no
+                    uses_naval_capacity = no
+                    can_change_leader = no
+                }
+                effect = {
+                    set_name = {
+                        key = "mauler_defense_squadron"
+                        variable_string = "[event_target:planet_deploying_ships.GetName]"
+                    }
+                    set_owner = event_target:strike_fleet_owner
+                    while = {
+                        count = event_target:planet_deploying_ships.giga_nexus_ship_count
+                        create_ship = {
+                            name = "Strike Mauler"
+                            graphical_culture = event_target:strike_fleet_owner
+                            random_existing_design = mauler_stage_2
+                            effect = {
+                                add_modifier = {
+                                    modifier = giga_strike_corvette_modifier
+                                    days = -1
+                                }
+                                if = {
+                                    limit = { event_target:strike_fleet_owner = { has_ascension_perk = ap_eternal_vigilance } }
+                                    add_modifier = {
+                                        modifier = giga_strike_corvette_vigilance_ap
+                                        days = -1
+                                    }
+                                }
+                                if = {
+                                    limit = { event_target:strike_fleet_owner = { has_technology = giga_tech_defense_nexus_damage_1 } }
+                                    add_modifier = {
+                                        modifier = giga_strike_corvette_buff_tech_1
+                                        days = -1
+                                    }
+                                }
+                                if = {
+                                    limit = { event_target:strike_fleet_owner = { has_technology = giga_tech_defense_nexus_damage_2 } }
+                                    add_modifier = {
+                                        modifier = giga_strike_corvette_buff_tech_2
+                                        days = -1
+                                    }
+                                }
+                                if = {
+                                    limit = { event_target:planet_deploying_ships = { is_giga_maginot_world = yes } }
+                                    add_modifier = {
+                                        modifier = giga_strike_corvette_buff_maginot
+                                        days = -1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    set_fleet_stance = aggressive
+                    set_fleet_flag = giga_yard_entity_@ROOT
+                    fleet_event = { id = giga_mega.7002 days = 30 }
+                    set_formation_scale = 1
+                    set_location = {
+                        target = ROOT
+                        distance = 0
+                        angle = 0
+                    }
+                    ROOT = {
+                        set_planet_flag = giga_yard_entity_fleet_@PREV
+                        set_planet_flag = defence_squadron_deployed
+                        set_timed_planet_flag = {
+                            flag = giga_defence_squadron_cooldown
+                            days = 90
+                        }
+                    }
+                }
+            }
+        }
 	}
 }
 

--- a/events/giga_018_celestial_printers.txt
+++ b/events/giga_018_celestial_printers.txt
@@ -187,13 +187,6 @@ country_event = {
 		multiply_variable = { which = giga_system_dismantle_cost_energy value = giga_system_dismantle_cost_mult }
 	}
 
-	option = { #No
-		name = "giga_printer.1005.b"
-		hidden_effect = {
-			remove_country_flag = giga_considering_dismantling_system
-		}
-	}
-
 	option = { #Yes
 		name = "giga_printer.1005.a"
 		custom_tooltip = "giga_printer.1005.a.tooltip"
@@ -229,6 +222,14 @@ country_event = {
 			}
 		}
 	}
+
+    option = { #No
+        name = "giga_printer.1005.b"
+        hidden_effect = {
+            remove_country_flag = giga_considering_dismantling_system
+        }
+        default_hide_option = yes
+    }
 }
 
 #Dumping Mass

--- a/events/giga_020_asteroid_artillery.txt
+++ b/events/giga_020_asteroid_artillery.txt
@@ -473,6 +473,7 @@ country_event = {
 
 	option = { #Good, good.
 		name = "giga_artillery.1000.a"
+        default_hide_option = yes
 		hidden_effect = {
 			remove_global_flag = upgrading_ast_art
 		}

--- a/localisation/braz_por/giga_l_braz_por.yml
+++ b/localisation/braz_por/giga_l_braz_por.yml
@@ -15856,7 +15856,8 @@
   planetary_drive_yard_fortress_modifier_desc:99 "A Planetary Defense Nexus above this world is providing its inhabitants with plenty of military occupations and extensive protection from orbital bombardment."
   
   corvette_defense_squadron:99 "[event_target:planet_deploying_ships.GetName] Defense Squadron"
-  
+  mauler_defense_squadron:99 "[event_target:planet_deploying_ships.GetName] Defense Squadron"
+
   sm_planetary_drive_yard_uplink:99 "Planetary Dockyard Uplink"
   sm_planetary_drive_yard_uplink_desc:99 "Connects this Starbase to every §YPlanetary Dockyard§! within its star system. The effects stack up to §Y20§! Planetary Dockyards.\nBuild cost reduction is capped at §Y-30%§!."
   already_have_pd_uplink:99 "We already have a Planetary Dockyard Uplink."

--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -15856,6 +15856,7 @@
   planetary_drive_yard_fortress_modifier_desc:0 "A Planetary Defense Nexus above this world is providing its inhabitants with plenty of military occupations and extensive protection from orbital bombardment."
 
   corvette_defense_squadron:0 "[event_target:planet_deploying_ships.GetName] Defense Squadron"
+  mauler_defense_squadron:0 "[event_target:planet_deploying_ships.GetName] Defense Squadron"
 
   sm_planetary_drive_yard_uplink:0 "Planetary Dockyard Uplink"
   sm_planetary_drive_yard_uplink_desc:0 "Connects this Starbase to every §YPlanetary Dockyard§! within its star system. The effects stack up to §Y20§! Planetary Dockyards.\nBuild cost reduction is capped at §Y-30%§!."

--- a/localisation/french/giga_l_french.yml
+++ b/localisation/french/giga_l_french.yml
@@ -15856,6 +15856,7 @@
   planetary_drive_yard_fortress_modifier_desc:99 "A Planetary Defense Nexus above this world is providing its inhabitants with plenty of military occupations and extensive protection from orbital bombardment."
   
   corvette_defense_squadron:99 "[event_target:planet_deploying_ships.GetName] Defense Squadron"
+  mauler_defense_squadron:99 "[event_target:planet_deploying_ships.GetName] Defense Squadron"
   
   sm_planetary_drive_yard_uplink:99 "Planetary Dockyard Uplink"
   sm_planetary_drive_yard_uplink_desc:99 "Connects this Starbase to every §YPlanetary Dockyard§! within its star system. The effects stack up to §Y20§! Planetary Dockyards.\nBuild cost reduction is capped at §Y-30%§!."

--- a/localisation/german/giga_l_german.yml
+++ b/localisation/german/giga_l_german.yml
@@ -15856,6 +15856,7 @@
   planetary_drive_yard_fortress_modifier_desc:99 "A Planetary Defense Nexus above this world is providing its inhabitants with plenty of military occupations and extensive protection from orbital bombardment."
   
   corvette_defense_squadron:99 "[event_target:planet_deploying_ships.GetName] Defense Squadron"
+  mauler_defense_squadron:99 "[event_target:planet_deploying_ships.GetName] Defense Squadron"
   
   sm_planetary_drive_yard_uplink:99 "Planetary Dockyard Uplink"
   sm_planetary_drive_yard_uplink_desc:99 "Connects this Starbase to every §YPlanetary Dockyard§! within its star system. The effects stack up to §Y20§! Planetary Dockyards.\nBuild cost reduction is capped at §Y-30%§!."

--- a/localisation/polish/giga_l_polish.yml
+++ b/localisation/polish/giga_l_polish.yml
@@ -15856,6 +15856,7 @@
   planetary_drive_yard_fortress_modifier_desc:99 "A Planetary Defense Nexus above this world is providing its inhabitants with plenty of military occupations and extensive protection from orbital bombardment."
   
   corvette_defense_squadron:99 "[event_target:planet_deploying_ships.GetName] Defense Squadron"
+  mauler_defense_squadron:99 "[event_target:planet_deploying_ships.GetName] Defense Squadron"
   
   sm_planetary_drive_yard_uplink:99 "Planetary Dockyard Uplink"
   sm_planetary_drive_yard_uplink_desc:99 "Connects this Starbase to every §YPlanetary Dockyard§! within its star system. The effects stack up to §Y20§! Planetary Dockyards.\nBuild cost reduction is capped at §Y-30%§!."

--- a/localisation/russian/giga_l_russian.yml
+++ b/localisation/russian/giga_l_russian.yml
@@ -15856,6 +15856,7 @@
   planetary_drive_yard_fortress_modifier_desc:0 "Нексус Планетарной Защиты над этим миром предоставляет его обитателям множество военных занятий и обширную защиту от орбитальной бомбардировки."
   
   corvette_defense_squadron:99 "[event_target:planet_deploying_ships.GetName] Defense Squadron"
+  mauler_defense_squadron:99 "[event_target:planet_deploying_ships.GetName] Defense Squadron"
   
   sm_planetary_drive_yard_uplink:0 "Канал связи планетарной верфи"
   sm_planetary_drive_yard_uplink_desc:0 "Соединяет эту звездную базу с каждой §Yпланетарной верфью§! в своей звездной системе. Эффекты суммируются максимум от §Y20§! планетарных верфей.\nСнижение стоимости строительства ограничено §Y-30%§!."

--- a/localisation/simp_chinese/giga_l_simp_chinese.yml
+++ b/localisation/simp_chinese/giga_l_simp_chinese.yml
@@ -15856,6 +15856,7 @@
   planetary_drive_yard_fortress_modifier_desc:0 "该星球上的行星防御枢纽给它的居民提供了大量军人类职业以及对轨道轰炸的全面防护。"
   
   corvette_defense_squadron:0 "[event_target:planet_deploying_ships.GetName]防御中队"
+  mauler_defense_squadron:0 "[event_target:planet_deploying_ships.GetName]防御中队"
   
   sm_planetary_drive_yard_uplink:0 "行星船坞上行链路"
   sm_planetary_drive_yard_uplink_desc:0 "将这一恒星基地与本星系中的所有§Y行星船坞§!链接。最多有§Y20§!个行星船坞可以起效。\n建造花费最高可减少§Y-30%§!。"

--- a/localisation/spanish/giga_l_spanish.yml
+++ b/localisation/spanish/giga_l_spanish.yml
@@ -15856,6 +15856,7 @@
   planetary_drive_yard_fortress_modifier_desc:0 "Un Nexo de Defensa Planetaria sobre este mundo está proporcionando a sus habitantes abundantes ocupaciones militares y extensa protección contra el bombardeo orbital."
   
   corvette_defense_squadron:0 "[event_target:planet_deploying_ships.GetName] Escuadrón de Defensa"
+  mauler_defense_squadron:0 "[event_target:planet_deploying_ships.GetName] Escuadrón de Defensa"
   
   sm_planetary_drive_yard_uplink:0 "Enlace del Astillero Planetario"
   sm_planetary_drive_yard_uplink_desc:0 "Conecta esta Base estelar con cada §YAstillero Planetario§! dentro de su sistema estelar. Los efectos se acumulan hasta §Y20§! Astilleros Planetarios.\nLa reducción del costo de construcción está limitada a §Y-30%§!."


### PR DESCRIPTION

# Stuff for Changelog
 - Fixed Planetary Defense Nexus not working with bioships, uses Maulers now.
 - Fixed power numbers for Ion Cannon EHOF reactors.
 - Set the default choice of the Asteroid Artillery upgrade event to be to close the menu.

# Under the Hood
- Undid https://github.com/Pouchkinn-s-Gigastructures/Gigastructures/commit/a777b06ae42fe0d1a21629b7a51baa6d4778b24b, but refixed it using the more elegant method of `default_hide_option`