### PR TITLE
fixes and whatnot

### DIFF
--- a/common/buildings/giga_asteroid_industry_buildings.txt
+++ b/common/buildings/giga_asteroid_industry_buildings.txt
@@ -60,6 +60,7 @@ building_giga_asteroid_factory_alloys = {
             inline_script = {
                 script = planet/alloys/giga_foundry_job_swap
                 jobs = @asteroid_industry_job_count
+                description = 0
             }
         "
     }
@@ -87,6 +88,7 @@ building_giga_asteroid_factory_alloys_one_planet = {
             inline_script = {
                 script = planet/alloys/giga_foundry_job_swap
                 jobs = @asteroid_industry_job_count
+                description = 0
                 multiplier_string = \"multiplier = value:giga_asteroid_industry_building_job_mult|modifier|building_giga_asteroid_factory_alloys_country_max|\"
             }
 
@@ -111,6 +113,7 @@ building_giga_asteroid_factory_consumer_goods = {
         modifiers = "
             triggered_planet_modifier = {
                 potential = {
+                    industrial_jobs_are_catalytic_trigger = no
                     solar_system = {
                         any_system_megastructure = {
                             is_megastructure_type = asteroid_manufactory_consumer_goods
@@ -126,6 +129,44 @@ building_giga_asteroid_factory_consumer_goods = {
             inline_script = {
                 script = planet/consumer_goods/giga_artisan_job_swap
                 jobs = @asteroid_industry_job_count
+                description = 0
+            }
+            triggered_planet_modifier = {
+                potential = {
+                    industrial_jobs_are_catalytic_trigger = yes
+                    exists = planet
+                    planet = {
+                        artisan_is_pearl_diver_trigger = no
+                    }
+                    solar_system = {
+                        any_system_megastructure = {
+                            is_megastructure_type = asteroid_manufactory_consumer_goods
+                        }
+                    }
+                }
+                planet_artisans_food_upkeep_add = -1.5
+                planet_artisans_energy_upkeep_add = 0.5
+
+                multiplier = value:giga_job_scaling_plus_base
+            }
+            triggered_planet_modifier = {
+                potential = {
+                    industrial_jobs_are_catalytic_trigger = yes
+                    exists = planet
+                    planet = {
+                        artisan_is_pearl_diver_trigger = yes
+                    }
+                    solar_system = {
+                        any_system_megastructure = {
+                            is_megastructure_type = asteroid_manufactory_consumer_goods
+                        }
+                    }
+                }
+                planet_artisans_minerals_upkeep_add = -0.5
+                planet_artisans_food_upkeep_add = -1
+                planet_artisans_energy_upkeep_add = 0.5
+
+                multiplier = value:giga_job_scaling_plus_base
             }
         "
     }
@@ -153,6 +194,7 @@ building_giga_asteroid_factory_consumer_goods_one_planet = {
             inline_script = {
                 script = planet/consumer_goods/giga_artisan_job_swap
                 jobs = @asteroid_industry_job_count
+                description = 0
                 multiplier_string = \"multiplier = value:giga_asteroid_industry_building_job_mult|modifier|building_giga_asteroid_factory_consumer_goods_country_max|\"
             }
 
@@ -190,6 +232,7 @@ building_giga_asteroid_factory_energy = {
             inline_script = {
                 script = planet/energy/giga_technician_job_swap
                 jobs = @asteroid_industry_job_count
+                description = 0
             }
         "
     }
@@ -216,6 +259,7 @@ building_giga_asteroid_factory_energy_one_planet = {
             inline_script = {
                 script = planet/energy/giga_technician_job_swap
                 jobs = @asteroid_industry_job_count
+                description = 0
                 multiplier_string = \"multiplier = value:giga_asteroid_industry_building_job_mult|modifier|building_giga_asteroid_factory_energy_country_max|\"
             }
 
@@ -247,12 +291,20 @@ building_giga_asteroid_factory_food = {
                 }
                 planet_farmers_produces_mult = 0.05
             }
-
             triggered_planet_modifier = {
                 potential = {
                     exists = owner
-                    owner = {
-                        is_anglers_empire = yes
+                    planet = {
+                        artisan_is_pearl_diver_trigger = yes
+                    }
+                    not = {
+                        industrial_jobs_are_catalytic_trigger = yes
+                        planet = { has_building = building_giga_asteroid_factory_consumer_goods }
+                        solar_system = {
+                            any_system_megastructure = {
+                                is_megastructure_type = asteroid_manufactory_consumer_goods
+                            }
+                        }
                     }
                     solar_system = {
                         any_system_megastructure = {
@@ -262,10 +314,32 @@ building_giga_asteroid_factory_food = {
                 }
                 planet_artisans_food_upkeep_mult = -0.1
             }
+            triggered_planet_modifier = {
+                potential = {
+                    exists = owner
+                    industrial_jobs_are_catalytic_trigger = yes
+                    planet = {
+                        artisan_is_pearl_diver_trigger = yes
+                    }
+                    planet = { has_building = building_giga_asteroid_factory_consumer_goods }
+                    solar_system = {
+                        any_system_megastructure = {
+                            is_megastructure_type = asteroid_manufactory_consumer_goods
+                        }
+                    }
+                    solar_system = {
+                        any_system_megastructure = {
+                            is_megastructure_type = asteroid_manufactory_food
+                        }
+                    }
+                }
+                planet_artisans_food_upkeep_mult = -0.05
+            }
 
             inline_script = {
                 script = planet/food/giga_farmer_job_swap
                 jobs = @asteroid_industry_job_count
+                description = 0
             }
 
             triggered_desc = {
@@ -296,6 +370,7 @@ building_giga_asteroid_factory_food_one_planet = {
             inline_script = {
                 script = planet/food/giga_farmer_job_swap
                 jobs = @asteroid_industry_job_count
+                description = 0
                 multiplier_string = \"multiplier = value:giga_asteroid_industry_building_job_mult|modifier|building_giga_asteroid_factory_food_country_max|\"
             }
 
@@ -342,6 +417,7 @@ building_giga_asteroid_factory_supertensiles = {
             inline_script = {
                 script = planet/supertensiles/giga_megaengineer_job_swap
                 jobs = @asteroid_industry_job_count
+                description = 0
             }
         "
     }
@@ -370,6 +446,7 @@ building_giga_asteroid_factory_supertensiles_one_planet = {
             inline_script = {
                 script = planet/supertensiles/giga_megaengineer_job_swap
                 jobs = @asteroid_industry_job_count
+                description = 0
                 multiplier_string = \"multiplier = value:giga_asteroid_industry_building_job_mult|modifier|building_giga_asteroid_factory_supertensiles_country_max|\"
             }
 

--- a/common/buildings/giga_buildings.txt
+++ b/common/buildings/giga_buildings.txt
@@ -562,7 +562,7 @@ building_giga_shroud_conduit = {
 	}
 
 	triggered_planet_modifier = {
-		giga_psionic_pop_bonus_workforce_mult = 0.05
+		psionic_pop_bonus_workforce_mult = 0.05
 		multiplier = value:giga_psychic_hypersiphon_job_efficency
 	}
 

--- a/common/decisions/giga_decisions.txt
+++ b/common/decisions/giga_decisions.txt
@@ -535,166 +535,166 @@ decision_systemcraft_crew = {
 }
 
 # Ringworld Arcology Project
-decision_ringworld_arcology_project = {
-	owned_planets_only = yes
-	icon = decision_arcology_project
-	ai_weight = { weight = 0 }
-	enactment_time = 5400
-
-	resources = {
-		category = decisions
-		cost = { trigger = { has_planet_flag = giga_ringworld_tit }	minerals = 40000 }
-		cost = { trigger = { has_planet_flag = giga_ringworld_beh }	minerals = 40000 }
-		cost = { trigger = { has_planet_flag = giga_ringworld_gar }	minerals = 40000 }
-		cost = {													minerals = 40000 influence = 300 }
-	}
-
-	potential = {
-		NOR = {
-			is_planet_class = pc_ringworld_city
-			has_modifier = resort_colony
-			has_modifier = penal_colony
-			has_modifier = slave_colony
-			ag_is_ancient_ringworld = yes
-			has_global_flag = cityring_disabled
-		}
-		is_planet_class = pc_ringworld_habitable
-		exists = owner
-		owner = { has_ascension_perk = ap_arcology_project }
-	}
-
-	allow = {
-		if = {
-			limit = { has_planet_flag = giga_ringworld_gar }
-			owner = { resource_stockpile_compare = { resource = influence value >= 300 } }
-			owner = { resource_stockpile_compare = { resource = minerals value >= 160000 } }
-		}
-		else_if = {
-			limit = { has_planet_flag = giga_ringworld_beh }
-			owner = { resource_stockpile_compare = { resource = influence value >= 300 } }
-			owner = { resource_stockpile_compare = { resource = minerals value >= 120000 } }
-		}
-		else_if = {
-			limit = { has_planet_flag = giga_ringworld_tit }
-			owner = { resource_stockpile_compare = { resource = influence value >= 300 } }
-			owner = { resource_stockpile_compare = { resource = minerals value >= 80000 } }
-		}
-		else = {
-			owner = { resource_stockpile_compare = { resource = influence value >= 300 } }
-			owner = { resource_stockpile_compare = { resource = minerals value >= 40000 } }
-		}
-		custom_tooltip = {
-			fail_text = "decision_ringworld_arcology_project_requirements"
-			free_district_slots < 1
-			num_districts = { type = district_rw_generator value < 1 }
-			num_districts = { type = district_rw_commercial value < 1 }
-			num_districts = { type = district_rw_science value < 1 }
-			num_districts = { type = district_rw_farming value < 1 }
-		}
-	}
-
-	effect = {
-		# Make city-planet
-		custom_tooltip = "decision_ringworld_arcology_project_effects"
-		hidden_effect = {
-			clear_deposits = yes
-			export_trigger_value_to_variable = {
-				trigger = num_districts
-				parameters = { type = district_rw_industrial  }
-				variable = giga_rw_arc_num_industrial
-			}
-			multiply_variable = { which = giga_rw_arc_num_industrial value = 0.66 }
-			floor_variable = giga_rw_arc_num_industrial
-			change_variable = { which = giga_rw_arc_num_industrial value = 1 }
-			change_pc = pc_ringworld_city
-			set_planet_flag = giga_archology
-			switch = {
-				trigger = has_designation
-				col_foundry = {
-					while = {
-						count = giga_rw_arc_num_industrial
-						add_district = district_rw_alloys
-					}
-				}
-				col_capital_foundry = {
-					while = {
-						count = giga_rw_arc_num_industrial
-						add_district = district_rw_alloys
-					}
-				}
-				col_factory = {
-					while = {
-						count = giga_rw_arc_num_industrial
-						add_district = district_rw_consumer
-					}
-				}
-				col_capital_factory = {
-					while = {
-						count = giga_rw_arc_num_industrial
-						add_district = district_rw_consumer
-					}
-				}
-				default = {
-					multiply_variable = { which = giga_rw_arc_num_industrial value = 0.5 }
-					floor_variable = giga_rw_arc_num_industrial
-					while = {
-						count = giga_rw_arc_num_industrial
-						add_district = district_rw_consumer
-					}
-					while = {
-						count = giga_rw_arc_num_industrial
-						add_district = district_rw_alloys
-					}
-					add_district = district_rw_alloys
-				}
-			}
-			solar_system = { save_event_target_as = giga_system }
-			save_event_target_as = giga_planet
-			planet_event = { id = giga_dialog.2401 }	# Notification
-			owner = {
-				if = {
-					limit = { prev = { has_planet_flag = giga_ringworld_gar } }
-					giga_set_ringworld_graphical_culture = {
-						TARGET = prev
-						SOURCE = this
-						SIZE = gargantuan
-						TYPE = ecu_habitable
-					}
-				}
-				else_if = {
-					limit = { prev = { has_planet_flag = giga_ringworld_beh } }
-					giga_set_ringworld_graphical_culture = {
-						TARGET = prev
-						SOURCE = this
-						SIZE = behemoth
-						TYPE = ecu_habitable
-					}
-				}
-				else_if = {
-					limit = { prev = { has_planet_flag = giga_ringworld_tit } }
-					giga_set_ringworld_graphical_culture = {
-						TARGET = prev
-						SOURCE = this
-						SIZE = titanic
-						TYPE = ecu_habitable
-					}
-				}
-				else = {
-					giga_set_ringworld_graphical_culture = {
-						TARGET = prev
-						SOURCE = this
-						SIZE = vanilla
-						TYPE = ecu_habitable
-						VANILLA_TYPE = habitable
-					}
-				}
-			}
-			if = {		limit = { exists = owner owner = { is_regular_empire = yes } }	while = { count = 3 remove_district = district_rw_city } }
-			else_if = {	limit = { exists = owner owner = { is_hive_empire = yes } }		while = { count = 3 remove_district = district_rw_hive } }
-			else_if = {	limit = { exists = owner owner = { is_machine_empire = yes } }	while = { count = 3 remove_district = district_rw_nexus } }
-		}
-	}
-}
+# decision_ringworld_arcology_project = {
+# 	owned_planets_only = yes
+# 	icon = decision_arcology_project
+# 	ai_weight = { weight = 0 }
+# 	enactment_time = 5400
+#
+# 	resources = {
+# 		category = decisions
+# 		cost = { trigger = { has_planet_flag = giga_ringworld_tit }	minerals = 40000 }
+# 		cost = { trigger = { has_planet_flag = giga_ringworld_beh }	minerals = 40000 }
+# 		cost = { trigger = { has_planet_flag = giga_ringworld_gar }	minerals = 40000 }
+# 		cost = {													minerals = 40000 influence = 300 }
+# 	}
+#
+# 	potential = {
+# 		NOR = {
+# 			is_planet_class = pc_ringworld_city
+# 			has_modifier = resort_colony
+# 			has_modifier = penal_colony
+# 			has_modifier = slave_colony
+# 			ag_is_ancient_ringworld = yes
+# 			has_global_flag = cityring_disabled
+# 		}
+# 		is_planet_class = pc_ringworld_habitable
+# 		exists = owner
+# 		owner = { has_ascension_perk = ap_arcology_project }
+# 	}
+#
+# 	allow = {
+# 		if = {
+# 			limit = { has_planet_flag = giga_ringworld_gar }
+# 			owner = { resource_stockpile_compare = { resource = influence value >= 300 } }
+# 			owner = { resource_stockpile_compare = { resource = minerals value >= 160000 } }
+# 		}
+# 		else_if = {
+# 			limit = { has_planet_flag = giga_ringworld_beh }
+# 			owner = { resource_stockpile_compare = { resource = influence value >= 300 } }
+# 			owner = { resource_stockpile_compare = { resource = minerals value >= 120000 } }
+# 		}
+# 		else_if = {
+# 			limit = { has_planet_flag = giga_ringworld_tit }
+# 			owner = { resource_stockpile_compare = { resource = influence value >= 300 } }
+# 			owner = { resource_stockpile_compare = { resource = minerals value >= 80000 } }
+# 		}
+# 		else = {
+# 			owner = { resource_stockpile_compare = { resource = influence value >= 300 } }
+# 			owner = { resource_stockpile_compare = { resource = minerals value >= 40000 } }
+# 		}
+# 		custom_tooltip = {
+# 			fail_text = "decision_ringworld_arcology_project_requirements"
+# 			free_district_slots < 1
+# 			num_districts = { type = district_rw_generator value < 1 }
+# 			num_districts = { type = district_rw_commercial value < 1 }
+# 			num_districts = { type = district_rw_science value < 1 }
+# 			num_districts = { type = district_rw_farming value < 1 }
+# 		}
+# 	}
+#
+# 	effect = {
+# 		# Make city-planet
+# 		custom_tooltip = "decision_ringworld_arcology_project_effects"
+# 		hidden_effect = {
+# 			clear_deposits = yes
+# 			export_trigger_value_to_variable = {
+# 				trigger = num_districts
+# 				parameters = { type = district_rw_industrial  }
+# 				variable = giga_rw_arc_num_industrial
+# 			}
+# 			multiply_variable = { which = giga_rw_arc_num_industrial value = 0.66 }
+# 			floor_variable = giga_rw_arc_num_industrial
+# 			change_variable = { which = giga_rw_arc_num_industrial value = 1 }
+# 			change_pc = pc_ringworld_city
+# 			set_planet_flag = giga_archology
+# 			switch = {
+# 				trigger = has_designation
+# 				col_foundry = {
+# 					while = {
+# 						count = giga_rw_arc_num_industrial
+# 						add_district = district_rw_alloys
+# 					}
+# 				}
+# 				col_capital_foundry = {
+# 					while = {
+# 						count = giga_rw_arc_num_industrial
+# 						add_district = district_rw_alloys
+# 					}
+# 				}
+# 				col_factory = {
+# 					while = {
+# 						count = giga_rw_arc_num_industrial
+# 						add_district = district_rw_consumer
+# 					}
+# 				}
+# 				col_capital_factory = {
+# 					while = {
+# 						count = giga_rw_arc_num_industrial
+# 						add_district = district_rw_consumer
+# 					}
+# 				}
+# 				default = {
+# 					multiply_variable = { which = giga_rw_arc_num_industrial value = 0.5 }
+# 					floor_variable = giga_rw_arc_num_industrial
+# 					while = {
+# 						count = giga_rw_arc_num_industrial
+# 						add_district = district_rw_consumer
+# 					}
+# 					while = {
+# 						count = giga_rw_arc_num_industrial
+# 						add_district = district_rw_alloys
+# 					}
+# 					add_district = district_rw_alloys
+# 				}
+# 			}
+# 			solar_system = { save_event_target_as = giga_system }
+# 			save_event_target_as = giga_planet
+# 			planet_event = { id = giga_dialog.2401 }	# Notification
+# 			owner = {
+# 				if = {
+# 					limit = { prev = { has_planet_flag = giga_ringworld_gar } }
+# 					giga_set_ringworld_graphical_culture = {
+# 						TARGET = prev
+# 						SOURCE = this
+# 						SIZE = gargantuan
+# 						TYPE = ecu_habitable
+# 					}
+# 				}
+# 				else_if = {
+# 					limit = { prev = { has_planet_flag = giga_ringworld_beh } }
+# 					giga_set_ringworld_graphical_culture = {
+# 						TARGET = prev
+# 						SOURCE = this
+# 						SIZE = behemoth
+# 						TYPE = ecu_habitable
+# 					}
+# 				}
+# 				else_if = {
+# 					limit = { prev = { has_planet_flag = giga_ringworld_tit } }
+# 					giga_set_ringworld_graphical_culture = {
+# 						TARGET = prev
+# 						SOURCE = this
+# 						SIZE = titanic
+# 						TYPE = ecu_habitable
+# 					}
+# 				}
+# 				else = {
+# 					giga_set_ringworld_graphical_culture = {
+# 						TARGET = prev
+# 						SOURCE = this
+# 						SIZE = vanilla
+# 						TYPE = ecu_habitable
+# 						VANILLA_TYPE = habitable
+# 					}
+# 				}
+# 			}
+# 			if = {		limit = { exists = owner owner = { is_regular_empire = yes } }	while = { count = 3 remove_district = district_rw_city } }
+# 			else_if = {	limit = { exists = owner owner = { is_hive_empire = yes } }		while = { count = 3 remove_district = district_rw_hive } }
+# 			else_if = {	limit = { exists = owner owner = { is_machine_empire = yes } }	while = { count = 3 remove_district = district_rw_nexus } }
+# 		}
+# 	}
+# }
 
 # Ringworld Upgrade
 decision_ringworld_upgrade = {
@@ -704,10 +704,10 @@ decision_ringworld_upgrade = {
 
 	resources = {
 		category = decisions
-		cost = { trigger = { has_planet_flag = giga_ringworld_tit }	alloys = 10000 }
-		cost = { trigger = { has_planet_flag = giga_ringworld_beh }	alloys = 10000 }
-		cost = { trigger = { has_planet_flag = giga_ringworld_gar }	alloys = 10000 }
-		cost = {													alloys = 10000 influence = 50 }
+		cost = { trigger = { has_planet_flag = giga_ringworld_tit } alloys = 10000 }
+		cost = { trigger = { has_planet_flag = giga_ringworld_beh } alloys = 10000 }
+		cost = { trigger = { has_planet_flag = giga_ringworld_gar } alloys = 10000 }
+		cost = { alloys = 10000 influence = 50 }
 	}
 
 	potential = {
@@ -745,10 +745,10 @@ decision_ringworld_upgrade = {
 
 	effect = {
 		custom_tooltip = giga_ringworld_upgrade_tt
-		if = {		limit = { has_planet_flag = giga_ringworld_gar }	add_modifier = { modifier = "ringworld_upgrade_timer" days = 3600 } }
-		else_if = {	limit = { has_planet_flag = giga_ringworld_beh }	add_modifier = { modifier = "ringworld_upgrade_timer" days = 2700 } }
-		else_if = {	limit = { has_planet_flag = giga_ringworld_tit }	add_modifier = { modifier = "ringworld_upgrade_timer" days = 1800 } }
-		else = {														add_modifier = { modifier = "ringworld_upgrade_timer" days = 900 } }
+		if = { limit = { has_planet_flag = giga_ringworld_gar } add_modifier = { modifier = "ringworld_upgrade_timer" days = 3600 } }
+		else_if = { limit = { has_planet_flag = giga_ringworld_beh } add_modifier = { modifier = "ringworld_upgrade_timer" days = 2700 } }
+		else_if = { limit = { has_planet_flag = giga_ringworld_tit } add_modifier = { modifier = "ringworld_upgrade_timer" days = 1800 } }
+		else = { add_modifier = { modifier = "ringworld_upgrade_timer" days = 900 } }
 		hidden_effect = { planet_event = { id = giga_mega.101 } }
 	}
 }

--- a/common/governments/civics/ehof_origin.txt
+++ b/common/governments/civics/ehof_origin.txt
@@ -5,9 +5,9 @@ origin_incohesive = {
 
 	#starting_colony = pc_ll_temperate
 
-	initializers = {
-		ehof_origin_init
-	}
+	# initializers = {
+	# 	ehof_origin_init
+	# }
 
 	description = origin_incohesive_effect_desc
 

--- a/common/governments/civics/frameworld_origins.txt
+++ b/common/governments/civics/frameworld_origins.txt
@@ -1,70 +1,72 @@
-# origin_frameworld = {
-#   is_origin = yes
-  
-#   icon = "gfx/interface/icons/origins/origin_frameworld.dds"
-#   picture = GFX_origin_frameworld
-#   flags = { custom_start_screen }
-  
-#   description = origin_tooltip_frameworld_effects
-  
-#   starting_colony = pc_giga_frameworld
-#   preferred_planet_class_neighbor = no
+origin_frameworld = {
+    is_origin = yes
 
-#   modifier = {
-#     # it's SO beneficial for frame that it should probably be nerfed real hard
-#     planetary_ascension_effect_mult = -0.5
-#     planetary_ascension_cost_mult = 1
-#   }
-  
-#   initializers = { giga_frameworld_system }
-  
-#   swap_type = {
-#     trigger = {
-#       is_scope_valid = yes
-#       has_authority = auth_machine_intelligence
-#       nor = {
-#         has_country_flag = driven_memory_aggregator
-#         has_country_flag = driven_neural_chorus
-#       }
-#     }
-#     modifier = {
-#       colony_start_num_pops_add = -1
-#     }
-#   }
-  
-#   possible = {
-#     civics = {
-#       not = {
-#         value = civic_agrarian_idyll
-#       }
-#       nor = {
-#         text = giga_civic_tooltip_not_environmental_architects
-#         value = civic_environmental_architects
-#         value = civic_environmental_architects_megacorp
-#         value = civic_environmental_architects_hive
-#         value = civic_environmental_architects_machine
-#       }
-#       nor = {
-#         text = civic_tooltip_not_idyllic_bloom
-#         value = civic_idyllic_bloom
-#         value = civic_hive_idyllic_bloom
-#       }
-#       nor = {
-#         text = civic_tooltip_not_relentless_industrialists
-#         value = civic_relentless_industrialists
-#         value = civic_corporate_relentless_industrialists
-#       }
-#       nor = {
-#         text = civic_tooltip_not_guided
-#         value = civic_guided_sapience
-#         value = civic_corporate_guided_sapience
-#         value = civic_hive_guided_sapience
-#         value = civic_machine_guided_sapience
-#       }
-#     }
-#   }
-  
-#   random_weight = {
-#     base = 1 # half shattered ring but not limited to just one
-#   }
-# }
+    icon = "gfx/interface/icons/origins/origin_frameworld.dds"
+    picture = GFX_origin_frameworld
+    flags = { custom_start_screen }
+
+    description = origin_tooltip_frameworld_effects
+
+    starting_colony = pc_giga_frameworld
+    preferred_planet_class_neighbor = no
+
+    modifier = {
+        # it's SO beneficial for frame that it should probably be nerfed real hard
+        planetary_ascension_effect_mult = -0.5
+        planetary_ascension_cost_mult = 1
+    }
+
+    initializers = { giga_frameworld_system }
+
+    swap_type = {
+        trigger = {
+            is_scope_valid = yes
+            has_authority = auth_machine_intelligence
+            nor = {
+                has_country_flag = driven_memory_aggregator
+                has_country_flag = driven_neural_chorus
+            }
+        }
+        modifier = {
+            colony_start_num_pops_add = -1
+        }
+    }
+
+    possible = {
+        always = no
+        text = "Disabled for 4.0"
+        # civics = {
+        #     not = {
+        #         value = civic_agrarian_idyll
+        #     }
+        #     nor = {
+        #         text = giga_civic_tooltip_not_environmental_architects
+        #         value = civic_environmental_architects
+        #         value = civic_environmental_architects_megacorp
+        #         value = civic_environmental_architects_hive
+        #         value = civic_environmental_architects_machine
+        #     }
+        #     nor = {
+        #         text = civic_tooltip_not_idyllic_bloom
+        #         value = civic_idyllic_bloom
+        #         value = civic_hive_idyllic_bloom
+        #     }
+        #     nor = {
+        #         text = civic_tooltip_not_relentless_industrialists
+        #         value = civic_relentless_industrialists
+        #         value = civic_corporate_relentless_industrialists
+        #     }
+        #     nor = {
+        #         text = civic_tooltip_not_guided
+        #         value = civic_guided_sapience
+        #         value = civic_corporate_guided_sapience
+        #         value = civic_hive_guided_sapience
+        #         value = civic_machine_guided_sapience
+        #     }
+        # }
+    }
+
+    random_weight = {
+        base = 1 # half shattered ring but not limited to just one
+    }
+}

--- a/common/governments/civics/giga_origins.txt
+++ b/common/governments/civics/giga_origins.txt
@@ -6,31 +6,33 @@ origin_pangalactic = {
 }
 
 #4.0 broke it all this is bandaid
-# origin_birch = {
-# 	is_origin = yes
-# 	icon = "gfx/interface/icons/origins/origins_birch_world.dds"
-# 	picture = GFX_origin_birch
-# 	description = "origin_birch_effects"
-# 	starting_colony = pc_origin_dummy_birch
-# 	habitability_preference = pc_birch
-# 	preferred_planet_class_neighbor = no
-# 	max_once_global = yes
-# 	flags = { custom_start_screen }
-# 	initializers = { giga_birch_start }
+origin_birch = {
+	is_origin = yes
+	icon = "gfx/interface/icons/origins/origins_birch_world.dds"
+	picture = GFX_origin_birch
+	description = "origin_birch_effects"
+	starting_colony = pc_origin_dummy_birch
+	habitability_preference = pc_birch
+	preferred_planet_class_neighbor = no
+	max_once_global = yes
+	flags = { custom_start_screen }
+	initializers = { giga_birch_start }
 
-# 	possible = {
-# 		civics = {
-# 			nor = {
-# 				text = civic_tooltip_not_idyllic_bloom
-# 				value = civic_idyllic_bloom
-# 				value = civic_hive_idyllic_bloom
-# 			}
-# 		}
-# 	}
-# 	random_weight = {
-# 		base = 0
-# 	}
-# }
+	possible = {
+		always = no
+		text = "Disabled for 4.0"
+		# civics = {
+		# 	nor = {
+		# 		text = civic_tooltip_not_idyllic_bloom
+		# 		value = civic_idyllic_bloom
+		# 		value = civic_hive_idyllic_bloom
+		# 	}
+		# }
+	}
+	random_weight = {
+		base = 0
+	}
+}
 
 origin_alderson = {
 	is_origin = yes
@@ -57,52 +59,37 @@ origin_great_ring = {
 	possible = { civics = { NOT = { value = civic_agrarian_idyll } } }
 }
 
-# origin_interstellar_ring = {
-# 	is_origin = yes
-# 	icon = "gfx/interface/icons/origins/origins_interstellar_ring.dds"
-# 	picture = GFX_origin_interstellar_ring
-# 	description = "origin_tooltip_interstellar_ring_effects"
-# 	starting_colony = pc_interstellar_ringworld_habitable
-# 	habitability_preference = pc_interstellar_ringworld_habitable
-# 	preferred_planet_class_neighbor = no
-# 	initializers = { giga_interstellar_system }
-# 	max_once_global = yes
-# 	possible = { 
-# 		#civics = { NOT = { value = civic_agrarian_idyll } } 
+origin_interstellar_ring = {
+	is_origin = yes
+	icon = "gfx/interface/icons/origins/origins_interstellar_ring.dds"
+	picture = GFX_origin_interstellar_ring
+	description = "origin_tooltip_interstellar_ring_effects"
+	starting_colony = pc_interstellar_ringworld_habitable
+	habitability_preference = pc_interstellar_ringworld_habitable
+	preferred_planet_class_neighbor = no
+	initializers = { giga_interstellar_system }
+	max_once_global = yes
+	possible = {
+		always = no
+		text = giga_pending_rework
+	}
+}
 
-# 		civics = {
-# 			or = {
-# 				text = giga_pending_rework
-# 				value = civic_ancient_caches_of_technology
-# 				value = civic_revanchist_fervor
-# 			}
-# 		}
-# 	}
-
-# }
-
-# origin_penrose_ring = {
-# 	is_origin = yes
-# 	icon = "gfx/interface/icons/origins/origins_penrose_ring.dds"
-# 	picture = GFX_origin_penrose_ring
-# 	description = "origin_tooltip_penrose_ring_effects"
-# 	starting_colony = pc_giga_penrose_habitable
-# 	habitability_preference = pc_giga_penrose_habitable
-# 	preferred_planet_class_neighbor = no
-# 	initializers = { giga_penrose_system }
-# 	max_once_global = yes
-# 	possible = { 
-# 		#civics = { NOT = { value = civic_agrarian_idyll } } 
-
-# 		civics = {
-# 			or = {
-# 				text = giga_pending_rework
-# 				value = civic_ancient_caches_of_technology
-# 				value = civic_revanchist_fervor
-# 			}
-# 		}
-# 	}
-# }
+origin_penrose_ring = {
+	is_origin = yes
+	icon = "gfx/interface/icons/origins/origins_penrose_ring.dds"
+	picture = GFX_origin_penrose_ring
+	description = "origin_tooltip_penrose_ring_effects"
+	starting_colony = pc_giga_penrose_habitable
+	habitability_preference = pc_giga_penrose_habitable
+	preferred_planet_class_neighbor = no
+	initializers = { giga_penrose_system }
+	max_once_global = yes
+	possible = {
+		always = no
+		text = giga_pending_rework
+	}
+}
 
 origin_flat_world = {
 	is_origin = yes
@@ -207,42 +194,44 @@ origin_planetary_computer = {
 # 	playable = { always = no }
 # }
 
-# origin_elysium = {
-# 	is_origin = yes
-# 	icon = gfx/interface/icons/origins/origin_elysium.dds
-# 	picture = GFX_origin_elysium
-# 	description = origin_elysium_effects
-# 	possible = {
-# 		ethics = { 
-# 			NOR = {
-# 				text = civic_tooltip_not_egalitarian
-# 				value = ethic_egalitarian
-# 				value = ethic_fanatic_egalitarian
-# 			}
-# 			NOR = {
-# 				text = civic_tooltip_not_cooperative
-# 				value = ethic_cooperative
-# 				value = ethic_fanatic_cooperative
-# 			}
-# 		}
-# 		civics = {
-# 			NOT = { value = civic_machine_servitor }
-# 			nor = {
-# 				text = civic_tooltip_not_idyllic_bloom
-# 				value = civic_idyllic_bloom
-# 				value = civic_hive_idyllic_bloom
-# 			}
-# 			nor = {
-# 				text = civic_tooltip_not_relentless_industrialists
-# 				value = civic_relentless_industrialists
-# 				value = civic_corporate_relentless_industrialists
-# 			}
-# 		}
-# 	}
-# 	modifier = {
-# 		ship_colonizer_alloys_cost_add = 400
-# 	}
-# }
+origin_elysium = {
+	is_origin = yes
+	icon = gfx/interface/icons/origins/origin_elysium.dds
+	picture = GFX_origin_elysium
+	description = origin_elysium_effects
+	possible = {
+		always = no
+		text = "Disabled for 4.0"
+		# ethics = {
+		# 	NOR = {
+		# 		text = civic_tooltip_not_egalitarian
+		# 		value = ethic_egalitarian
+		# 		value = ethic_fanatic_egalitarian
+		# 	}
+		# 	NOR = {
+		# 		text = civic_tooltip_not_cooperative
+		# 		value = ethic_cooperative
+		# 		value = ethic_fanatic_cooperative
+		# 	}
+		# }
+		# civics = {
+		# 	NOT = { value = civic_machine_servitor }
+		# 	nor = {
+		# 		text = civic_tooltip_not_idyllic_bloom
+		# 		value = civic_idyllic_bloom
+		# 		value = civic_hive_idyllic_bloom
+		# 	}
+		# 	nor = {
+		# 		text = civic_tooltip_not_relentless_industrialists
+		# 		value = civic_relentless_industrialists
+		# 		value = civic_corporate_relentless_industrialists
+		# 	}
+		# }
+	}
+	modifier = {
+		ship_colonizer_alloys_cost_add = 400
+	}
+}
 
 # origin_squareworld = {
 # 	is_origin = yes

--- a/common/inline_scripts/planet/food/parts/giga_farmer_job_swap.txt
+++ b/common/inline_scripts/planet/food/parts/giga_farmer_job_swap.txt
@@ -110,7 +110,7 @@ inline_script = {
     condition = "
         owner = {
             is_gestalt = yes
-            is_wilderness_empire = no
+            # is_wilderness_empire = no
         }
         $condition$
     "

--- a/common/inline_scripts/pop_categories/social_classes_triggered_modifiers.txt
+++ b/common/inline_scripts/pop_categories/social_classes_triggered_modifiers.txt
@@ -222,13 +222,3 @@ triggered_pop_group_modifier = {
     pop_happiness = 1
     mult = modifier:pop_robot_slave_happiness
 }
-
-# hypersiphon efficiency
-triggered_pop_group_modifier = {
-    potential = {
-        has_psionic_species_trait = yes
-    }
-    key = mod_psionic_pop_bonus_workforce_mult
-    pop_bonus_workforce_mult = 1
-    mult = planet.modifier:giga_psionic_pop_bonus_workforce_mult
-}

--- a/common/inline_scripts/pop_categories/social_classes_triggered_modifiers.txt
+++ b/common/inline_scripts/pop_categories/social_classes_triggered_modifiers.txt
@@ -226,7 +226,7 @@ triggered_pop_group_modifier = {
 # hypersiphon efficiency
 triggered_pop_group_modifier = {
     potential = {
-        has_psionic_species_trait = no
+        has_psionic_species_trait = yes
     }
     key = mod_psionic_pop_bonus_workforce_mult
     pop_bonus_workforce_mult = 1

--- a/common/megastructures/zz_e_ring_world.txt
+++ b/common/megastructures/zz_e_ring_world.txt
@@ -627,5 +627,17 @@ ring_world_restored = {
 			remove_star_flag = ring_32
 		}
 		remove_megastructure = fromfrom
+		# Fix for ruined ring systems not being able to add layers
+		if = {
+			limit = {
+				not = {
+					has_star_flag = ring_world_built
+					any_system_megastructure = {
+						is_megastructure_type = ring_world_ruined
+					}
+				}
+			}
+			set_star_flag = ring_world_built
+		}
 	}
 }

--- a/common/megastructures/zz_e_titanic_ringworld.txt
+++ b/common/megastructures/zz_e_titanic_ringworld.txt
@@ -53,6 +53,7 @@ ringworld_titanic_0 = {
 			custom_tooltip = {
 				fail_text = "already_have_tit_ringworld"
 				hidden:solar_system = { NOT = { has_star_flag = giga_has_titanic_ring } }
+				hidden:solar_system = { not = { any_system_megastructure = { is_megastructure_type = ring_world_titanic_ruined  } } }
 			}
 		}
 	}
@@ -648,5 +649,17 @@ ring_world_titanic_restored = {
 			remove_star_flag = ring_32
 		}
 		remove_megastructure = fromfrom
+		# Fix for ruined ring systems not being able to add layers
+		if = {
+			limit = {
+				not = {
+					has_star_flag = giga_has_titanic_ring
+					any_system_megastructure = {
+						is_megastructure_type = ring_world_titanic_ruined
+					}
+				}
+			}
+			set_star_flag = giga_has_titanic_ring
+		}
 	}
 }

--- a/common/megastructures/zz_i_behemoth_ringworld.txt
+++ b/common/megastructures/zz_i_behemoth_ringworld.txt
@@ -53,7 +53,11 @@ ringworld_behemoth_0 = {
 					not = { has_star_flag = matrioshka_brain_o_built }
 				} 
 			}
-			custom_tooltip = { fail_text = "already_have_beh_ringworld"		hidden:solar_system = { NOT = { has_star_flag = giga_has_behemoth_ring } } }
+			custom_tooltip = {
+				fail_text = "already_have_beh_ringworld"
+				hidden:solar_system = { NOT = { has_star_flag = giga_has_behemoth_ring } }
+				hidden:solar_system = { not = { any_system_megastructure = { is_megastructure_type = ring_world_behemoth_ruined  } } }
+			}
 		}
 	}
 
@@ -671,5 +675,17 @@ ring_world_behemoth_restored = {
 			remove_star_flag = ring_32
 		}
 		remove_megastructure = fromfrom
+		# Fix for ruined ring systems not being able to add layers
+		if = {
+			limit = {
+				not = {
+					has_star_flag = giga_has_behemoth_ring
+					any_system_megastructure = {
+						is_megastructure_type = ring_world_behemoth_ruined
+					}
+				}
+			}
+			set_star_flag = giga_has_behemoth_ring
+		}
 	}
 }

--- a/common/megastructures/zz_i_gargantuan_ringworld.txt
+++ b/common/megastructures/zz_i_gargantuan_ringworld.txt
@@ -47,7 +47,11 @@ ringworld_gargantuan_0 = {
 			custom_tooltip = { fail_text = "must_build_around_star"			is_star = yes }
 			custom_tooltip = { fail_text = "requires_no_anomaly"			has_anomaly = no }
 			custom_tooltip = { fail_text = "requires_base_ringworld_two"	hidden:solar_system = { has_star_flag = ring_world_built_two } }
-			custom_tooltip = { fail_text = "already_have_gar_ringworld"		hidden:solar_system = { NOT = { has_star_flag = giga_has_gargantuan_ring } } }
+			custom_tooltip = {
+				fail_text = "already_have_gar_ringworld"
+				hidden:solar_system = { NOT = { has_star_flag = giga_has_gargantuan_ring } }
+				hidden:solar_system = { not = { any_system_megastructure = { is_megastructure_type = ring_world_gargantuan_ruined   } } }
+			}
 		}
 	}
 
@@ -673,5 +677,17 @@ ring_world_gargantuan_restored = {
 			remove_star_flag = ring_32
 		}
 		remove_megastructure = fromfrom
+		# Fix for ruined ring systems not being able to add layers
+		if = {
+			limit = {
+				not = {
+					has_star_flag = giga_has_gargantuan_ring
+					any_system_megastructure = {
+						is_megastructure_type = ring_world_gargantuan_ruined
+					}
+				}
+			}
+			set_star_flag = giga_has_gargantuan_ring
+		}
 	}
 }

--- a/common/planet_classes/giga_city_rings.txt
+++ b/common/planet_classes/giga_city_rings.txt
@@ -1,87 +1,87 @@
-pc_ringworld_city = {
-	is_artificial_planet = yes
-	ringworld = yes				# <<< This if for the preview entity, (ringworld = yes means there is no atmosphere background for preview)
-	entity = "vanilla_ecu_habitable"
-	icon = GFX_planet_type_ringworld
-	entity_scale = 1.0
-	enable_tilt = no
-	fixed_entity_scale = yes
-	atmosphere_color 		= hsv { 0.0 0.0 1.0 }
-	atmosphere_intensity 	= 1.0
-	atmosphere_width 		= 0.5
-	show_city = yes
-	fixed_city_level = 6
-	city_color_lut = "gfx/portraits/misc/colorcorrection_continental.dds"
-	modifier = {
-		planet_jobs_produces_mult = 0.20
-		logistic_growth_mult = 0.50
-	}
-	chance_of_ring = 0.0
-	planet_size = 10
-	moon_size = 1
-	colonizable = yes
-	ideal = yes
-	starting_planet = no
-	orbit_lines = no
-	has_colonization_influence_cost = no
-	district_set = ring_world
-}
+# pc_ringworld_city = {
+# 	is_artificial_planet = yes
+# 	ringworld = yes				# <<< This if for the preview entity, (ringworld = yes means there is no atmosphere background for preview)
+# 	entity = "vanilla_ecu_habitable"
+# 	icon = GFX_planet_type_ringworld
+# 	entity_scale = 1.0
+# 	enable_tilt = no
+# 	fixed_entity_scale = yes
+# 	atmosphere_color 		= hsv { 0.0 0.0 1.0 }
+# 	atmosphere_intensity 	= 1.0
+# 	atmosphere_width 		= 0.5
+# 	show_city = yes
+# 	fixed_city_level = 6
+# 	city_color_lut = "gfx/portraits/misc/colorcorrection_continental.dds"
+# 	modifier = {
+# 		planet_jobs_produces_mult = 0.20
+# 		logistic_growth_mult = 0.50
+# 	}
+# 	chance_of_ring = 0.0
+# 	planet_size = 10
+# 	moon_size = 1
+# 	colonizable = yes
+# 	ideal = yes
+# 	starting_planet = no
+# 	orbit_lines = no
+# 	has_colonization_influence_cost = no
+# 	district_set = ring_world
+# }
 
-pc_ringworld_machine = {
-	is_artificial_planet = yes
-	ringworld = yes				# <<< This if for the preview entity, (ringworld = yes means there is no atmosphere background for preview)
-	entity = "vanilla_machine_habitable"
-	icon = GFX_planet_type_ringworld
-	entity_scale = 1.0
-	enable_tilt = no
-	fixed_entity_scale = yes
-	atmosphere_color 		= hsv { 0.09 0.8 0.7 }
-	atmosphere_intensity 	= 0.4
-	atmosphere_width 		= 1.0
-	show_city = no
-	city_color_lut = "gfx/portraits/misc/colorcorrection_neutral.dds"
-	modifier = {
-		planet_jobs_produces_mult = 0.10
-		pop_housing_usage_mult = -0.10
-		pop_environment_tolerance = 0.0
-	}
-	chance_of_ring = 0.0
-	planet_size = 10
-	moon_size = 1
-	colonizable = yes
-	ideal = yes
-	starting_planet = no
-	orbit_lines = no
-	has_colonization_influence_cost = no
-	district_set = ring_world
-}
-
-pc_ringworld_hive = {
-	is_artificial_planet = yes
-	ringworld = yes				# <<< This if for the preview entity, (ringworld = yes means there is no atmosphere background for preview)
-	entity = "vanilla_hive_habitable"
-	icon = GFX_planet_type_ringworld
-	entity_scale = 1.0
-	enable_tilt = no
-	fixed_entity_scale = yes
-
-	atmosphere_color 		= hsv { 0.75 0.2 0.7 }
-	atmosphere_intensity 	= 0.1
-	atmosphere_width 		= 1.2
-
-	city_color_lut = "gfx/portraits/misc/colorcorrection_neutral.dds"
-
-	modifier = {
-		planet_jobs_produces_mult = 0.10
-	}
-	chance_of_ring = 0.0
-	planet_size = 10
-	moon_size = 1
-	colonizable = yes
-	ideal = yes
-	starting_planet = no
-	orbit_lines = no
-	has_colonization_influence_cost = no
-	show_city = no
-	district_set = ring_world
-}
+# pc_ringworld_machine = {
+# 	is_artificial_planet = yes
+# 	ringworld = yes				# <<< This if for the preview entity, (ringworld = yes means there is no atmosphere background for preview)
+# 	entity = "vanilla_machine_habitable"
+# 	icon = GFX_planet_type_ringworld
+# 	entity_scale = 1.0
+# 	enable_tilt = no
+# 	fixed_entity_scale = yes
+# 	atmosphere_color 		= hsv { 0.09 0.8 0.7 }
+# 	atmosphere_intensity 	= 0.4
+# 	atmosphere_width 		= 1.0
+# 	show_city = no
+# 	city_color_lut = "gfx/portraits/misc/colorcorrection_neutral.dds"
+# 	modifier = {
+# 		planet_jobs_produces_mult = 0.10
+# 		pop_housing_usage_mult = -0.10
+# 		pop_environment_tolerance = 0.0
+# 	}
+# 	chance_of_ring = 0.0
+# 	planet_size = 10
+# 	moon_size = 1
+# 	colonizable = yes
+# 	ideal = yes
+# 	starting_planet = no
+# 	orbit_lines = no
+# 	has_colonization_influence_cost = no
+# 	district_set = ring_world
+# }
+#
+# pc_ringworld_hive = {
+# 	is_artificial_planet = yes
+# 	ringworld = yes				# <<< This if for the preview entity, (ringworld = yes means there is no atmosphere background for preview)
+# 	entity = "vanilla_hive_habitable"
+# 	icon = GFX_planet_type_ringworld
+# 	entity_scale = 1.0
+# 	enable_tilt = no
+# 	fixed_entity_scale = yes
+#
+# 	atmosphere_color 		= hsv { 0.75 0.2 0.7 }
+# 	atmosphere_intensity 	= 0.1
+# 	atmosphere_width 		= 1.2
+#
+# 	city_color_lut = "gfx/portraits/misc/colorcorrection_neutral.dds"
+#
+# 	modifier = {
+# 		planet_jobs_produces_mult = 0.10
+# 	}
+# 	chance_of_ring = 0.0
+# 	planet_size = 10
+# 	moon_size = 1
+# 	colonizable = yes
+# 	ideal = yes
+# 	starting_planet = no
+# 	orbit_lines = no
+# 	has_colonization_influence_cost = no
+# 	show_city = no
+# 	district_set = ring_world
+# }

--- a/common/scripted_effects/z_giga_new_ehof_effects_1.txt
+++ b/common/scripted_effects/z_giga_new_ehof_effects_1.txt
@@ -62,7 +62,7 @@ ehof_giga_new_initialize_system_2 = {
 			min_distance >= $min_distance$
 			max_distance <= $max_distance$
 			hyperlane = no
-			initializer = "ehof_origin_cohesive_cluster"
+			initializer = "special_init_01"
 			effect = {
 				save_event_target_as = giga_last_ehof_spawn
 			}

--- a/common/scripted_modifiers/giga_scripted_modifiers.txt
+++ b/common/scripted_modifiers/giga_scripted_modifiers.txt
@@ -246,10 +246,3 @@ giga_katzen_upkeep_discount_mult = {
 	category = country
 	percentage = yes
 }
-
-giga_psionic_pop_bonus_workforce_mult = {
-	icon = mod_planet_psionic_jobs_produces_mult
-	percentage = yes
-	good = yes
-	category = pop_group
-}

--- a/common/terraform/giga_terraform_links.txt
+++ b/common/terraform/giga_terraform_links.txt
@@ -306,310 +306,310 @@ terraform_link = {
 }
 
 # Ringworlds
-terraform_link = {
-	from = "pc_ringworld_machine"
-	to = "pc_ringworld_habitable"
-	resources = {
-		category = terraforming
-
-		inline_script = {
-			script = terraform/triggered_costs
-			ENERGY_COST = 10000
-			BIOMASS_COST = 5000
-		}
-	}
-	inline_script = {
-		script = terraform/wilderness_biomass
-	}
-	duration = 1800
-
-	condition = {
-		has_technology = tech_climate_restoration
-	}
-
-	ai_weight = {
-		weight = 5
-		modifier = { factor = 0 has_authority = auth_machine_intelligence }
-	}
-
-	potential = {
-		always = no #disabled 4.0 rework
-	}
-
-	effect = {
-		from = { remove_planet_flag = giga_rw_machine }
-
-		if = {
-			limit = { from = { has_planet_flag = giga_ringworld_gar } }
-			giga_set_ringworld_graphical_culture = {
-				TARGET = from
-				SOURCE = this
-				SIZE = gargantuan
-				TYPE = gaia_habitable
-			}
-		}
-		else_if = {
-			limit = { from = { has_planet_flag = giga_ringworld_beh } }
-			giga_set_ringworld_graphical_culture = {
-				TARGET = from
-				SOURCE = this
-				SIZE = behemoth
-				TYPE = gaia_habitable
-			}
-		}
-		else_if = {
-			limit = { from = { has_planet_flag = giga_ringworld_tit } }
-			giga_set_ringworld_graphical_culture = {
-				TARGET = from
-				SOURCE = this
-				SIZE = titanic
-				TYPE = gaia_habitable
-			}
-		}
-		else = {
-			giga_set_ringworld_graphical_culture = {
-				TARGET = from
-				SOURCE = this
-				SIZE = vanilla
-				TYPE = gaia_habitable
-				VANILLA_TYPE = habitable
-			}
-		}
-	}
-}
-
-terraform_link = {
-	from = "pc_ringworld_habitable"
-	to = "pc_ringworld_machine"
-	resources = {
-		category = terraforming
-		cost = { energy = 10000 alloys = 5000 }
-	}
-	inline_script = {
-		script = terraform/wilderness_biomass
-	}
-	duration = 1800
-
-	condition = {
-		has_ascension_perk = "ap_machine_worlds"
-	}
-
-	potential = {
-		is_machine_empire = yes
-		NOT = { has_global_flag = machinering_disabled }
-	}
-	potential = {
-		always = no #disabled 4.0 rework
-	}
-	ai_weight = {
-		weight = 20
-		modifier = {
-			factor = 0
-			from = {
-				any_owned_pop_group = {
-					NOR = {
-						has_trait = trait_machine_unit
-						has_trait = trait_mechanical
-					}
-				}
-			}
-		}
-		modifier = {
-			factor = 0
-			from = {
-				is_colony = no
-			}
-		}
-	}
-
-	effect = {
-		from = { set_planet_flag = giga_rw_machine }
-
-		if = {
-			limit = { from = { has_planet_flag = giga_ringworld_gar } }
-			giga_set_ringworld_graphical_culture = {
-				TARGET = from
-				SOURCE = this
-				SIZE = gargantuan
-				TYPE = machine_habitable
-			}
-		}
-		else_if = {
-			limit = { from = { has_planet_flag = giga_ringworld_beh } }
-			giga_set_ringworld_graphical_culture = {
-				TARGET = from
-				SOURCE = this
-				SIZE = behemoth
-				TYPE = machine_habitable
-			}
-		}
-		else_if = {
-			limit = { from = { has_planet_flag = giga_ringworld_tit } }
-			giga_set_ringworld_graphical_culture = {
-				TARGET = from
-				SOURCE = this
-				SIZE = titanic
-				TYPE = machine_habitable
-			}
-		}
-		else = {
-			giga_set_ringworld_graphical_culture = {
-				TARGET = from
-				SOURCE = this
-				SIZE = vanilla
-				TYPE = machine_habitable
-				VANILLA_TYPE = habitable
-			}
-		}
-	}
-}
-
-terraform_link = {
-	from = "pc_ringworld_habitable"
-	to = "pc_ringworld_hive"
-	resources = {
-		category = terraforming
-		cost = { energy = 10000 food = 5000 }
-	}
-	inline_script = {
-		script = terraform/wilderness_biomass
-	}
-	duration = 1800
-
-	condition = {
-		has_ascension_perk = "ap_hive_worlds"
-	}
-
-	potential = {
-		is_hive_empire = yes
-		NOT = { has_global_flag = hivering_disabled }
-	}
-	potential = {
-		always = no #disabled 4.0 rework
-	}
-	ai_weight = {
-		weight = 20
-		modifier = {
-			factor = 0
-			from = { any_owned_pop_group = { NOT = { has_trait = trait_hive_mind } } }
-		}
-		modifier = {
-			factor = 0
-			from = { is_colony = no }
-		}
-	}
-
-	effect = {
-		from = { set_planet_flag = giga_rw_hive }
-
-		if = {
-			limit = { from = { has_planet_flag = giga_ringworld_gar } }
-			giga_set_ringworld_graphical_culture = {
-				TARGET = from
-				SOURCE = this
-				SIZE = gargantuan
-				TYPE = hive_habitable
-			}
-		}
-		else_if = {
-			limit = { from = { has_planet_flag = giga_ringworld_beh } }
-			giga_set_ringworld_graphical_culture = {
-				TARGET = from
-				SOURCE = this
-				SIZE = behemoth
-				TYPE = hive_habitable
-			}
-		}
-		else_if = {
-			limit = { from = { has_planet_flag = giga_ringworld_tit } }
-			giga_set_ringworld_graphical_culture = {
-				TARGET = from
-				SOURCE = this
-				SIZE = titanic
-				TYPE = hive_habitable
-			}
-		}
-		else = {
-			giga_set_ringworld_graphical_culture = {
-				TARGET = from
-				SOURCE = this
-				SIZE = vanilla
-				TYPE = hive_habitable
-				VANILLA_TYPE = habitable
-			}
-		}
-	}
-}
-
-terraform_link = {
-	from = "pc_ringworld_hive"
-	to = "pc_ringworld_habitable"
-	resources = {
-		category = terraforming
-
-		inline_script = {
-			script = terraform/triggered_costs
-			ENERGY_COST = 10000
-			BIOMASS_COST = 5000
-		}
-	}
-	inline_script = {
-		script = terraform/wilderness_biomass
-	}
-	duration = 1800
-
-	condition = {
-		has_technology = tech_climate_restoration
-	}
-	potential = {
-		always = no #disabled 4.0 rework
-	}
-	ai_weight = {
-		weight = 5
-		modifier = { factor = 0 has_authority = auth_hive_mind }
-	}
-
-	effect = {
-		from = { remove_planet_flag = giga_rw_hive }
-
-		if = {
-			limit = { from = { has_planet_flag = giga_ringworld_gar } }
-			giga_set_ringworld_graphical_culture = {
-				TARGET = from
-				SOURCE = this
-				SIZE = gargantuan
-				TYPE = gaia_habitable
-			}
-		}
-		else_if = {
-			limit = { from = { has_planet_flag = giga_ringworld_beh } }
-			giga_set_ringworld_graphical_culture = {
-				TARGET = from
-				SOURCE = this
-				SIZE = behemoth
-				TYPE = gaia_habitable
-			}
-		}
-		else_if = {
-			limit = { from = { has_planet_flag = giga_ringworld_tit } }
-			giga_set_ringworld_graphical_culture = {
-				TARGET = from
-				SOURCE = this
-				SIZE = titanic
-				TYPE = gaia_habitable
-			}
-		}
-		else = {
-			giga_set_ringworld_graphical_culture = {
-				TARGET = from
-				SOURCE = this
-				SIZE = vanilla
-				TYPE = gaia_habitable
-				VANILLA_TYPE = habitable
-			}
-		}
-	}
-}
+# terraform_link = {
+# 	from = "pc_ringworld_machine"
+# 	to = "pc_ringworld_habitable"
+# 	resources = {
+# 		category = terraforming
+#
+# 		inline_script = {
+# 			script = terraform/triggered_costs
+# 			ENERGY_COST = 10000
+# 			BIOMASS_COST = 5000
+# 		}
+# 	}
+# 	inline_script = {
+# 		script = terraform/wilderness_biomass
+# 	}
+# 	duration = 1800
+#
+# 	condition = {
+# 		has_technology = tech_climate_restoration
+# 	}
+#
+# 	ai_weight = {
+# 		weight = 5
+# 		modifier = { factor = 0 has_authority = auth_machine_intelligence }
+# 	}
+#
+# 	potential = {
+# 		always = no #disabled 4.0 rework
+# 	}
+#
+# 	effect = {
+# 		from = { remove_planet_flag = giga_rw_machine }
+#
+# 		if = {
+# 			limit = { from = { has_planet_flag = giga_ringworld_gar } }
+# 			giga_set_ringworld_graphical_culture = {
+# 				TARGET = from
+# 				SOURCE = this
+# 				SIZE = gargantuan
+# 				TYPE = gaia_habitable
+# 			}
+# 		}
+# 		else_if = {
+# 			limit = { from = { has_planet_flag = giga_ringworld_beh } }
+# 			giga_set_ringworld_graphical_culture = {
+# 				TARGET = from
+# 				SOURCE = this
+# 				SIZE = behemoth
+# 				TYPE = gaia_habitable
+# 			}
+# 		}
+# 		else_if = {
+# 			limit = { from = { has_planet_flag = giga_ringworld_tit } }
+# 			giga_set_ringworld_graphical_culture = {
+# 				TARGET = from
+# 				SOURCE = this
+# 				SIZE = titanic
+# 				TYPE = gaia_habitable
+# 			}
+# 		}
+# 		else = {
+# 			giga_set_ringworld_graphical_culture = {
+# 				TARGET = from
+# 				SOURCE = this
+# 				SIZE = vanilla
+# 				TYPE = gaia_habitable
+# 				VANILLA_TYPE = habitable
+# 			}
+# 		}
+# 	}
+# }
+#
+# terraform_link = {
+# 	from = "pc_ringworld_habitable"
+# 	to = "pc_ringworld_machine"
+# 	resources = {
+# 		category = terraforming
+# 		cost = { energy = 10000 alloys = 5000 }
+# 	}
+# 	inline_script = {
+# 		script = terraform/wilderness_biomass
+# 	}
+# 	duration = 1800
+#
+# 	condition = {
+# 		has_ascension_perk = "ap_machine_worlds"
+# 	}
+#
+# 	potential = {
+# 		is_machine_empire = yes
+# 		NOT = { has_global_flag = machinering_disabled }
+# 	}
+# 	potential = {
+# 		always = no #disabled 4.0 rework
+# 	}
+# 	ai_weight = {
+# 		weight = 20
+# 		modifier = {
+# 			factor = 0
+# 			from = {
+# 				any_owned_pop_group = {
+# 					NOR = {
+# 						has_trait = trait_machine_unit
+# 						has_trait = trait_mechanical
+# 					}
+# 				}
+# 			}
+# 		}
+# 		modifier = {
+# 			factor = 0
+# 			from = {
+# 				is_colony = no
+# 			}
+# 		}
+# 	}
+#
+# 	effect = {
+# 		from = { set_planet_flag = giga_rw_machine }
+#
+# 		if = {
+# 			limit = { from = { has_planet_flag = giga_ringworld_gar } }
+# 			giga_set_ringworld_graphical_culture = {
+# 				TARGET = from
+# 				SOURCE = this
+# 				SIZE = gargantuan
+# 				TYPE = machine_habitable
+# 			}
+# 		}
+# 		else_if = {
+# 			limit = { from = { has_planet_flag = giga_ringworld_beh } }
+# 			giga_set_ringworld_graphical_culture = {
+# 				TARGET = from
+# 				SOURCE = this
+# 				SIZE = behemoth
+# 				TYPE = machine_habitable
+# 			}
+# 		}
+# 		else_if = {
+# 			limit = { from = { has_planet_flag = giga_ringworld_tit } }
+# 			giga_set_ringworld_graphical_culture = {
+# 				TARGET = from
+# 				SOURCE = this
+# 				SIZE = titanic
+# 				TYPE = machine_habitable
+# 			}
+# 		}
+# 		else = {
+# 			giga_set_ringworld_graphical_culture = {
+# 				TARGET = from
+# 				SOURCE = this
+# 				SIZE = vanilla
+# 				TYPE = machine_habitable
+# 				VANILLA_TYPE = habitable
+# 			}
+# 		}
+# 	}
+# }
+#
+# terraform_link = {
+# 	from = "pc_ringworld_habitable"
+# 	to = "pc_ringworld_hive"
+# 	resources = {
+# 		category = terraforming
+# 		cost = { energy = 10000 food = 5000 }
+# 	}
+# 	inline_script = {
+# 		script = terraform/wilderness_biomass
+# 	}
+# 	duration = 1800
+#
+# 	condition = {
+# 		has_ascension_perk = "ap_hive_worlds"
+# 	}
+#
+# 	potential = {
+# 		is_hive_empire = yes
+# 		NOT = { has_global_flag = hivering_disabled }
+# 	}
+# 	potential = {
+# 		always = no #disabled 4.0 rework
+# 	}
+# 	ai_weight = {
+# 		weight = 20
+# 		modifier = {
+# 			factor = 0
+# 			from = { any_owned_pop_group = { NOT = { has_trait = trait_hive_mind } } }
+# 		}
+# 		modifier = {
+# 			factor = 0
+# 			from = { is_colony = no }
+# 		}
+# 	}
+#
+# 	effect = {
+# 		from = { set_planet_flag = giga_rw_hive }
+#
+# 		if = {
+# 			limit = { from = { has_planet_flag = giga_ringworld_gar } }
+# 			giga_set_ringworld_graphical_culture = {
+# 				TARGET = from
+# 				SOURCE = this
+# 				SIZE = gargantuan
+# 				TYPE = hive_habitable
+# 			}
+# 		}
+# 		else_if = {
+# 			limit = { from = { has_planet_flag = giga_ringworld_beh } }
+# 			giga_set_ringworld_graphical_culture = {
+# 				TARGET = from
+# 				SOURCE = this
+# 				SIZE = behemoth
+# 				TYPE = hive_habitable
+# 			}
+# 		}
+# 		else_if = {
+# 			limit = { from = { has_planet_flag = giga_ringworld_tit } }
+# 			giga_set_ringworld_graphical_culture = {
+# 				TARGET = from
+# 				SOURCE = this
+# 				SIZE = titanic
+# 				TYPE = hive_habitable
+# 			}
+# 		}
+# 		else = {
+# 			giga_set_ringworld_graphical_culture = {
+# 				TARGET = from
+# 				SOURCE = this
+# 				SIZE = vanilla
+# 				TYPE = hive_habitable
+# 				VANILLA_TYPE = habitable
+# 			}
+# 		}
+# 	}
+# }
+#
+# terraform_link = {
+# 	from = "pc_ringworld_hive"
+# 	to = "pc_ringworld_habitable"
+# 	resources = {
+# 		category = terraforming
+#
+# 		inline_script = {
+# 			script = terraform/triggered_costs
+# 			ENERGY_COST = 10000
+# 			BIOMASS_COST = 5000
+# 		}
+# 	}
+# 	inline_script = {
+# 		script = terraform/wilderness_biomass
+# 	}
+# 	duration = 1800
+#
+# 	condition = {
+# 		has_technology = tech_climate_restoration
+# 	}
+# 	potential = {
+# 		always = no #disabled 4.0 rework
+# 	}
+# 	ai_weight = {
+# 		weight = 5
+# 		modifier = { factor = 0 has_authority = auth_hive_mind }
+# 	}
+#
+# 	effect = {
+# 		from = { remove_planet_flag = giga_rw_hive }
+#
+# 		if = {
+# 			limit = { from = { has_planet_flag = giga_ringworld_gar } }
+# 			giga_set_ringworld_graphical_culture = {
+# 				TARGET = from
+# 				SOURCE = this
+# 				SIZE = gargantuan
+# 				TYPE = gaia_habitable
+# 			}
+# 		}
+# 		else_if = {
+# 			limit = { from = { has_planet_flag = giga_ringworld_beh } }
+# 			giga_set_ringworld_graphical_culture = {
+# 				TARGET = from
+# 				SOURCE = this
+# 				SIZE = behemoth
+# 				TYPE = gaia_habitable
+# 			}
+# 		}
+# 		else_if = {
+# 			limit = { from = { has_planet_flag = giga_ringworld_tit } }
+# 			giga_set_ringworld_graphical_culture = {
+# 				TARGET = from
+# 				SOURCE = this
+# 				SIZE = titanic
+# 				TYPE = gaia_habitable
+# 			}
+# 		}
+# 		else = {
+# 			giga_set_ringworld_graphical_culture = {
+# 				TARGET = from
+# 				SOURCE = this
+# 				SIZE = vanilla
+# 				TYPE = gaia_habitable
+# 				VANILLA_TYPE = habitable
+# 			}
+# 		}
+# 	}
+# }
 
 # Other
 terraform_link = {

--- a/events/ehof_origin_startup.txt
+++ b/events/ehof_origin_startup.txt
@@ -13,13 +13,13 @@ event = {
 			limit = {
 				has_origin = origin_incohesive
 			}
-			# if = { AI can now do a crime :)
+			# if = { # AI can now do a crime :) # Who let the ai crime >:(
 			# 	limit = { is_ai = yes }
 			# 	capital_scope.solar_system = { 
 			# 		set_star_flag = gigas_new_planets 
 			# 		set_star_flag = ehof_ai_reset
 			# 	}
-			# 	country_event = { id = ehof_incohesive.8} #dummy event to fix scope
+			# 	country_event = { id = ehof_incohesive.8 } # dummy event to fix scope
 			# }
 			set_country_flag = ehof_precursor_spawned
 			set_country_flag = starting_event			# go away
@@ -36,6 +36,7 @@ event = {
 # MAIN EVENT - should hopefully scope correctly if multiple ppl have the origin
 # It's on you if you play MP with 8+ people all using this origin, though.
 # DO NOT FIRE THIS EVENT MANUALLY
+# None of this should matter anymore, the move_system effect is too powerful.
 country_event = {
 	id = ehof_incohesive.2
 	hide_window = yes
@@ -51,415 +52,11 @@ country_event = {
 		country_event = {
 			id = ehof_incohesive.3
 		}
-		country_event = {
-			id = ehof_incohesive.6
-			days = 5
-		}
-		# so help you God if it takes you longer than 5 days to set your giga settings.
-		random_owned_leader = {
-			limit = {
-				leader_class = official
-			}
-			unassign_leader = this
-			save_global_event_target_as = ehofo_governor
-		}
-		capital_scope = {
-			save_global_event_target_as = ehofo_old_world
-			solar_system = {
-				save_global_event_target_as = ehofo_old_system
-			}
-			sector = {
-				set_name = ""				# hide from galaxy map?
-			}
-		}
-		# New System name changes to Old System name
-		# Old Star name changes to New Star name
-		# New Star name changes to New System name
-		# Old System name changes to Old Star name
-		# New Capital name changes to Old Capital name
-		event_target:ehofo_new_system = {
-			set_name = {
-				key = "ehofo_new_system_name"
-				variable_string = "[ehofo_old_system.GetName]"
-			}
-		}
-		event_target:ehofo_old_system = {
-			system_star = {
-				set_name = {
-					key = "ehofo_old_star_name"
-					variable_string = "[ehofo_new_system.system_star.GetName]"
-				}
-			}
-		}
-		event_target:ehofo_new_system = {
-			system_star = {
-				set_name = {
-					key = "ehofo_new_star_name"
-					variable_string = "[ehofo_new_system.GetName]"
-				}
-			}
-			every_system_planet = {
-				#ehofo_name_new_barren = yes DO NOT ASK ME WHY THIS DOESN'T WORK AS A SCRIPTED EFFECT BUT IT DOESN'T - Bread (Now frustrated)
-				random_list = {
-					0 = {
-						set_name = {
-							key = "ehofo_NEW_planet_1"
-							variable_string = "[solar_system.GetName]"
-						}
-						modifier = { add = 1 check_variable = { value = 1 which = ehof_origin_planet_count } }
-					}
-					0 = {
-						set_name = {
-							key = "ehofo_NEW_planet_2"
-							variable_string = "[solar_system.GetName]"
-						}
-						modifier = { add = 1 check_variable = { value = 2 which = ehof_origin_planet_count } }
-					}
-					0 = {
-						set_name = {
-							key = "ehofo_NEW_planet_3"
-							variable_string = "[solar_system.GetName]"
-						}
-						modifier = { add = 1 check_variable = { value = 3 which = ehof_origin_planet_count } }
-					}
-					0 = {
-						set_name = {
-							key = "ehofo_NEW_planet_4"
-							variable_string = "[solar_system.GetName]"
-						}
-						modifier = { add = 1 check_variable = { value = 4 which = ehof_origin_planet_count } }
-					}
-					0 = {
-						set_name = {
-							key = "ehofo_NEW_planet_5"
-							variable_string = "[solar_system.GetName]"
-						}
-						modifier = { add = 1 check_variable = { value = 5 which = ehof_origin_planet_count } }
-					}
-					0 = {
-						set_name = {
-							key = "ehofo_NEW_planet_6"
-							variable_string = "[solar_system.GetName]"
-						}
-						modifier = { add = 1 check_variable = { value = 6 which = ehof_origin_planet_count } }
-					}
-					0 = {
-						set_name = {
-							key = "ehofo_NEW_planet_7"
-							variable_string = "[solar_system.GetName]"
-						}
-						modifier = { add = 1 check_variable = { value = 7 which = ehof_origin_planet_count } }
-					}
-					0 = {
-						set_name = {
-							key = "ehofo_NEW_planet_8"
-							variable_string = "[solar_system.GetName]"
-						}
-						modifier = { add = 1 check_variable = { value = 8 which = ehof_origin_planet_count } }
-					}
-					0 = {
-						set_name = {
-							key = "ehofo_NEW_planet_9"
-							variable_string = "[solar_system.GetName]"
-						}
-						modifier = { add = 1 check_variable = { value = 9 which = ehof_origin_planet_count } }
-					}
-					0 = {
-						set_name = {
-							key = "ehofo_NEW_planet_10"
-							variable_string = "[solar_system.GetName]"
-						}
-						modifier = { add = 1 check_variable = { value = 10 which = ehof_origin_planet_count } }
-					}
-				}
-				every_moon = {
-					prev = {
-						save_global_event_target_as = ehofo_previous_planet
-					}
-					set_name = {
-						key = "ehofo_NEW_moon"
-						variable_string = "[ehofo_previous_planet.GetName]"
-					}
-					# This initialiser should only have 1 moon per each planet.
-					# dont change
-					clear_global_event_target = ehofo_previous_planet
-				}
-			}
-		}
-		event_target:ehofo_old_system = {
-			set_name = {
-				key = "ehofo_old_system_name"
-				variable_string = "[ehofo_old_system.system_star.GetName]"
-			}
-		}
-		event_target:ehofo_new_system = {
-			if = {
-				limit = {
-					any_system_planet = {
-						is_star = no
-						is_asteroid = no
-						is_colonizable = yes
-					}
-				}
-				random_system_planet = {
-					limit = {
-						is_star = no
-						is_asteroid = no
-						is_colonizable = yes
-					}
-					set_planet_flag = forbid_guillis_planet_modifiers
-					#
-					clear_deposits = yes
-					change_pc = pc_ll_temperate
-					create_colony = {
-						owner = root
-					}
-					save_global_event_target_as = ehofo_new_world
-					clear_planet_modifiers = yes
-					set_name = {
-						key = "ehofo_new_capital_name"
-						variable_string = "[ehofo_old_world.GetName]"
-					}
-				}
-			}
-			else = {
-				random_system_planet = {
-					limit = {
-						is_star = no
-						is_asteroid = no
-					}
-					set_planet_flag = forbid_guillis_planet_modifiers
-					#
-					clear_deposits = yes
-					change_pc = pc_ll_temperate
-					create_colony = {
-						owner = root
-					}
-					save_global_event_target_as = ehofo_new_world
-					clear_planet_modifiers = yes
-					set_name = {
-						key = "ehofo_new_capital_name"
-						variable_string = "[ehofo_old_world.GetName]"
-					}
-				}
-			}
-			save_event_target_as = ehof_color_system_name
-		}
-		country_event = {
-			id = ehof_systems.005
-		}		# Generate System Color
-		event_target:ehofo_new_system = {
-			create_starbase = {
-				size = "starbase_starport"
-				module = "shipyard"
-				building = "crew_quarters"
-				owner = root
-				effect = {
-					save_global_event_target_as = ehofo_starbase
-				}
-			}
-			# AFTER system colour, so the starbase is named with the colour of the system (:
-			# Beastmasters fix
-			if = {
-				limit = {
-					owner = { is_beastmasters_empire = yes} 
-				}
-				remove_starbase_module = { module = shipyard }
-				set_starbase_module = {
-					slot = 1
-					module = beastport
-				}
-			}
-		}
-		event_target:ehofo_old_system = {
-			random_system_planet = {
-				limit = {
-					has_planet_flag = ehof_origin_planet_1
-				}
-				set_name = {
-					key = "ehofo_old_planet_name_1"
-					variable_string = "[solar_system.GetName]"
-				}
-			}
-			random_system_planet = {
-				limit = {
-					has_planet_flag = ehof_origin_planet_2
-				}
-				set_name = {
-					key = "ehofo_old_planet_name_2"
-					variable_string = "[solar_system.GetName]"
-				}
-			}
-		}
-		capital_scope = {
-			solar_system = {
-				starbase = {
-					fleet = {
-						destroy_fleet = this
-					}
-				}
-			}
-			random_owned_pop_group = {
-				limit = {
-					root.owner_main_species = {
-						NOT = {
-							is_same_species = prev.species
-						}
-					}
-				}
-				save_global_event_target_as = ehofo_secondary_species
-			}
-		}
-		every_owned_fleet = {
-			limit = {
-				any_owned_ship = {
-					OR = {
-						ehof_is_construction_ship = yes
-						ehof_is_science_ship = yes
-						is_ship_class = shipclass_military #Covers Cordyceptic military
-					}
-				}
-			}
-			set_location = event_target:ehofo_starbase.orbit
-			if = {
-				limit = { any_owned_ship = { is_ship_class = shipclass_military } }
-				set_home_base = event_target:ehofo_starbase
-			}
-		}
-		event_target:ehofo_new_world = {
-			change_pc = event_target:ehofo_old_world
-			generate_start_deposits_and_blockers = yes
-			root.owner_main_species = {
-				set_species_homeworld = prev
-			}
-			#generate_start_buildings_and_districts = yes Moving this to be later to enable inbuilt compatability with PD
-			generate_start_pops = yes
-			if = {
-				limit = {
-					exists = event_target:ehofo_secondary_species
-				}
-				every_owned_pop_group = {
-					limit = {
-						species = {
-							NOT = {
-								root.owner_main_species = {
-									is_same_species = prev
-								}
-							}
-						}
-					}
-					change_species = event_target:ehofo_secondary_species
-				}
-			}
-			set_planet_size = 20
-			set_capital = yes
-			if = {
-				limit = {
-					ROOT = { is_ascensionist_empire = yes }
-				}
-				set_planetary_ascension_tier = 1
-			}
-			if = {
-				limit = {
-					ROOT = { is_guided_sapience_empire = yes }
-				}
-				spawn_presapient_species_randomizer_homeworld_effect = yes
-				add_deposit = d_genesis_preserve
-				set_planet_flag = pre_sapient_planet
-			}
-			if = {
-				limit = {
-					ROOT = { is_dark_consortium_empire = yes }
-				}
-				system_star = {
-					add_deposit = d_dark_matter_deposit_1
-				}
-				event_target:ehofo_old_world = {
-					random_system_planet = {
-						limit = {
-							has_deposit = d_dark_matter_deposit_1
-						}
-						remove_deposit = d_dark_matter_deposit_1
-					}
-				}
-			}
-		}
-		event_target:ehofo_old_world = {
-			destroy_colony = yes
-			clear_deposits = yes
-			remove_all_buildings = yes
-			remove_all_districts = yes
-			change_pc = pc_barren_cold
-			#remove_planet = yes # not required
-		}
-		country_event = {
-			id = ehof_incohesive.4
-		}
-		event_target:ehofo_new_world = {
-			sector.sector_capital = {
-				assign_leader = event_target:ehofo_governor
-			}
-		}
-		# create_fleet = {
-		# 	effect = {
-		# 		set_owner = prev
-		# 		create_ship = {
-		# 			name = random
-		# 			random_existing_design = science
-		# 		}
-		# 		set_fleet_stance = evasive
-		# 		#set_location = prev.capital_star
-		# 		set_location = event_target:ehofo_new_system
-		# 		set_leader = event_target:ehofo_scientist
-		# 	}
-		# }
-		# create_fleet = {
-		# 	effect = {
-		# 		set_owner = prev
-		# 		create_ship = {
-		# 			name = random
-		# 			random_existing_design = constructor
-		# 		}
-		# 		set_fleet_stance = evasive
-		# 		set_location = event_target:ehofo_new_system
-		# 	}
-		# }
-		# create_fleet = {
-		# 	set_take_point = yes
-		# 	effect = {
-		# 		set_owner = prev
-		# 		while = {
-		# 			count = 3
-		# 			create_ship = {
-		# 				name = random
-		# 				random_existing_design = corvette
-		# 			}
-		# 		}
-		# 		set_location = event_target:ehofo_new_system
-		# 	}
-		# }
-		clear_global_event_target = ehofo_old_world
-		clear_global_event_target = ehofo_old_system
-		clear_global_event_target = ehofo_new_world
-		clear_global_event_target = ehofo_new_system
-		clear_global_event_target = ehofo_starbase
-		clear_global_event_target = ehofo_governor
-		if = {
-			limit = {
-				exists = event_target:ehofo_secondary_species
-			}
-			clear_global_event_target = ehofo_secondary_species
-		}
-		country_event = {
-			id = ehof_incohesive.5
-		}
-		#add_modifier = {
-		#	modifier = mod_ehof_origin_sensorrange_debug
-		#}
 	}
 }
 
 # Generate new ehof cluster to use
+# Generates just the black hole, to move the capital to later
 country_event = {
 	id = ehof_incohesive.3
 	hide_window = yes
@@ -509,186 +106,204 @@ country_event = {
 					ehof_init_min_angle = @ehof_50_taken_min_angle
 					ehof_init_max_angle = @ehof_50_taken_max_angle
 				}
-		}
-			#1 = {
-			#	modifier = { factor = 0 has_global_flag = ehof_70_taken }
-			#	set_global_flag = ehof_70_taken
-		# ehof_giga_new_initialize_system = {
-		#	ehof_init_min_angle = @ehof_70_taken_min_angle
-		#	ehof_init_max_angle = @ehof_70_taken_max_angle
-		#}
-			#}
-			#1 = {
-		#
-		#
-		#
-		#	modifier = { factor = 0 has_global_flag = ehof_90_taken }
-		#	set_global_flag = ehof_90_taken
-		# ehof_giga_new_initialize_system = {
-		#	ehof_init_min_angle = @ehof_90_taken_min_angle
-		#	ehof_init_max_angle = @ehof_90_taken_max_angle
-		#}
-		#}
-		#1 = {
-		#	modifier = { factor = 0 has_global_flag = ehof_110_taken }
-		#	set_global_flag = ehof_110_taken
-				# ehof_giga_new_initialize_system = {
-		#	ehof_init_min_angle = @ehof_110_taken_min_angle
-		#	ehof_init_max_angle = @ehof_110_taken_max_angle
-		#}
-		#}
-		1 = {
-			modifier = {
-				factor = 0
-				has_global_flag = ehof_130_taken
 			}
-			set_global_flag = ehof_130_taken
-			ehof_giga_new_initialize_system = {
-				ehof_init_min_angle = @ehof_130_taken_min_angle
-				ehof_init_max_angle = @ehof_130_taken_max_angle
+			# 1 = {
+			# 	modifier = { factor = 0 has_global_flag = ehof_70_taken }
+			# 	set_global_flag = ehof_70_taken
+			# 	ehof_giga_new_initialize_system = {
+			# 		ehof_init_min_angle = @ehof_70_taken_min_angle
+			# 		ehof_init_max_angle = @ehof_70_taken_max_angle
+			# 	}
+			# }
+			# 1 = {
+			#
+			#
+			# 	modifier = { factor = 0 has_global_flag = ehof_90_taken }
+			# 	set_global_flag = ehof_90_taken
+			# 	ehof_giga_new_initialize_system = {
+			# 		ehof_init_min_angle = @ehof_90_taken_min_angle
+			# 		ehof_init_max_angle = @ehof_90_taken_max_angle
+			# 	}
+			# }
+			# 1 = {
+			# 	modifier = { factor = 0 has_global_flag = ehof_110_taken }
+			# 	set_global_flag = ehof_110_taken
+			# 	ehof_giga_new_initialize_system = {
+			# 		ehof_init_min_angle = @ehof_110_taken_min_angle
+			# 		ehof_init_max_angle = @ehof_110_taken_max_angle
+			# 	}
+			# }
+			1 = {
+				modifier = {
+					factor = 0
+					has_global_flag = ehof_130_taken
+				}
+				set_global_flag = ehof_130_taken
+				ehof_giga_new_initialize_system = {
+					ehof_init_min_angle = @ehof_130_taken_min_angle
+					ehof_init_max_angle = @ehof_130_taken_max_angle
+				}
 			}
-		}
-		1 = {
-			modifier = {
-				factor = 0
-				has_global_flag = ehof_150_taken
+			1 = {
+				modifier = {
+					factor = 0
+					has_global_flag = ehof_150_taken
+				}
+				set_global_flag = ehof_150_taken
+				ehof_giga_new_initialize_system = {
+					ehof_init_min_angle = @ehof_150_taken_min_angle
+					ehof_init_max_angle = @ehof_150_taken_max_angle
+				}
 			}
-			set_global_flag = ehof_150_taken
-			ehof_giga_new_initialize_system = {
-				ehof_init_min_angle = @ehof_150_taken_min_angle
-				ehof_init_max_angle = @ehof_150_taken_max_angle
+			1 = {
+				modifier = {
+					factor = 0
+					has_global_flag = ehof_170_taken
+				}
+				set_global_flag = ehof_170_taken
+				ehof_giga_new_initialize_system = {
+					ehof_init_min_angle = @ehof_170_taken_min_angle
+					ehof_init_max_angle = @ehof_170_taken_max_angle
+				}
 			}
-		}
-		1 = {
-			modifier = {
-				factor = 0
-				has_global_flag = ehof_170_taken
+			1 = {
+				modifier = {
+					factor = 0
+					has_global_flag = ehof_190_taken
+				}
+				set_global_flag = ehof_190_taken
+				ehof_giga_new_initialize_system = {
+					ehof_init_min_angle = @ehof_190_taken_min_angle
+					ehof_init_max_angle = @ehof_190_taken_max_angle
+				}
 			}
-			set_global_flag = ehof_170_taken
-			ehof_giga_new_initialize_system = {
-				ehof_init_min_angle = @ehof_170_taken_min_angle
-				ehof_init_max_angle = @ehof_170_taken_max_angle
+			1 = {
+				modifier = {
+					factor = 0
+					has_global_flag = ehof_210_taken
+				}
+				set_global_flag = ehof_210_taken
+				ehof_giga_new_initialize_system = {
+					ehof_init_min_angle = @ehof_210_taken_min_angle
+					ehof_init_max_angle = @ehof_210_taken_max_angle
+				}
 			}
-		}
-		1 = {
-			modifier = {
-				factor = 0
-				has_global_flag = ehof_190_taken
+			1 = {
+				modifier = {
+					factor = 0
+					has_global_flag = ehof_230_taken
+				}
+				set_global_flag = ehof_230_taken
+				ehof_giga_new_initialize_system = {
+					ehof_init_min_angle = @ehof_230_taken_min_angle
+					ehof_init_max_angle = @ehof_230_taken_max_angle
+				}
 			}
-			set_global_flag = ehof_190_taken
-			ehof_giga_new_initialize_system = {
-				ehof_init_min_angle = @ehof_190_taken_min_angle
-				ehof_init_max_angle = @ehof_190_taken_max_angle
+			# 1 = {
+			# 	modifier = { factor = 0 has_global_flag = ehof_250_taken }
+			# 	set_global_flag = ehof_250_taken
+			# 	ehof_giga_new_initialize_system = {
+			# 		ehof_init_min_angle = @ehof_250_taken_min_angle
+			# 		ehof_init_max_angle = @ehof_250_taken_max_angle
+			# 	}
+			# }
+			# 1 = {
+			# 	modifier = { factor = 0 has_global_flag = ehof_270_taken }
+			# 	set_global_flag = ehof_270_taken
+			# 	ehof_giga_new_initialize_system = {
+			# 		ehof_init_min_angle = @ehof_270_taken_min_angle
+			# 		ehof_init_max_angle = @ehof_270_taken_max_angle
+			# 	}
+			# }
+			# 1 = {
+			# 	modifier = { factor = 0 has_global_flag = ehof_290_taken }
+			# 	set_global_flag = ehof_290_taken
+			# 	ehof_giga_new_initialize_system = {
+			# 		ehof_init_min_angle = @ehof_290_taken_min_angle
+			# 		ehof_init_max_angle = @ehof_290_taken_max_angle
+			# 	}
+			# }
+			1 = {
+				modifier = {
+					factor = 0
+					has_global_flag = ehof_310_taken
+				}
+				set_global_flag = ehof_310_taken
+				ehof_giga_new_initialize_system = {
+					ehof_init_min_angle = @ehof_310_taken_min_angle
+					ehof_init_max_angle = @ehof_310_taken_max_angle
+				}
 			}
-		}
-		1 = {
-			modifier = {
-				factor = 0
-				has_global_flag = ehof_210_taken
+			1 = {
+				modifier = {
+					factor = 0
+					has_global_flag = ehof_330_taken
+				}
+				set_global_flag = ehof_330_taken
+				ehof_giga_new_initialize_system = {
+					ehof_init_min_angle = @ehof_330_taken_min_angle
+					ehof_init_max_angle = @ehof_330_taken_max_angle
+				}
 			}
-			set_global_flag = ehof_210_taken
-			ehof_giga_new_initialize_system = {
-				ehof_init_min_angle = @ehof_210_taken_min_angle
-				ehof_init_max_angle = @ehof_210_taken_max_angle
+			1 = {
+				modifier = {
+					factor = 0
+					has_global_flag = ehof_350_taken
+				}
+				set_global_flag = ehof_350_taken
+				ehof_giga_new_initialize_system = {
+					ehof_init_min_angle = @ehof_350_taken_min_angle
+					ehof_init_max_angle = @ehof_350_taken_max_angle
+				}
 			}
-		}
-		1 = {
-			modifier = {
-				factor = 0
-				has_global_flag = ehof_230_taken
-			}
-			set_global_flag = ehof_230_taken
-			ehof_giga_new_initialize_system = {
-				ehof_init_min_angle = @ehof_230_taken_min_angle
-				ehof_init_max_angle = @ehof_230_taken_max_angle
-			}
-		}
-		#1 = {
-		#	modifier = { factor = 0 has_global_flag = ehof_250_taken }
-		#	set_global_flag = ehof_250_taken
-		# ehof_giga_new_initialize_system = {
-		#	ehof_init_min_angle = @ehof_250_taken_min_angle
-		#	ehof_init_max_angle = @ehof_250_taken_max_angle
-		#}
-		#}
-		#1 = {
-		#	modifier = { factor = 0 has_global_flag = ehof_270_taken }
-		#	set_global_flag = ehof_270_taken
-		# ehof_giga_new_initialize_system = {
-		#	ehof_init_min_angle = @ehof_270_taken_min_angle
-		#	ehof_init_max_angle = @ehof_270_taken_max_angle
-		#}
-		#}
-		#1 = {
-		#	modifier = { factor = 0 has_global_flag = ehof_290_taken }
-		#	set_global_flag = ehof_290_taken
-		# ehof_giga_new_initialize_system = {
-		#	ehof_init_min_angle = @ehof_290_taken_min_angle
-		#	ehof_init_max_angle = @ehof_290_taken_max_angle
-		#}
-		#}
-		1 = {
-
-			modifier = {
-				factor = 0
-				has_global_flag = ehof_310_taken
-			}
-			set_global_flag = ehof_310_taken
-			ehof_giga_new_initialize_system = {
-				ehof_init_min_angle = @ehof_310_taken_min_angle
-				ehof_init_max_angle = @ehof_310_taken_max_angle
-			}
-
-		}
-		1 = {
-
-			modifier = {
-				factor = 0
-				has_global_flag = ehof_330_taken
-			}
-			set_global_flag = ehof_330_taken
-			ehof_giga_new_initialize_system = {
-				ehof_init_min_angle = @ehof_330_taken_min_angle
-				ehof_init_max_angle = @ehof_330_taken_max_angle
-			}
-		}
-		1 = {
-			modifier = {
-				factor = 0
-				has_global_flag = ehof_350_taken
-			}
-			set_global_flag = ehof_350_taken
-			ehof_giga_new_initialize_system = {
-				ehof_init_min_angle = @ehof_350_taken_min_angle
-				ehof_init_max_angle = @ehof_350_taken_max_angle
-			}
-		}
 		}
 
 		country_event = {
 			id = ehof_systems.001
 		}		# Generate Flags
-		#country_event = { id = ehof_systems.002 }	# Generate Weather
-		#country_event = { id = ehof_systems.006 }	# Generate Deposits
-		# disabled deposits, will use generate_home_system_resources instead
 		last_created_system = {
 			log = "Scoping to last_created_system"
-			# Create PGate
-			if = {
+			save_global_event_target_as = ehofo_new_system
+			# Setup ehof system
+			system_star = {
+				#prevent_anomaly = yes
+				giga_set_has_mega_flag = yes
+				clear_deposits = yes
+				giga_field_debris = yes
+			}
+			save_event_target_as = ehof_color_system_name
+			set_name = {
+				key = "ehof_standard_name"
+				variable_string = "[ehof_color_system_name.GetName]"
+			}
+			every_system_planet = {
 				limit = {
-					NOT = {
-						root = {
-							has_country_flag = first_ehof_system_spawned
-						}
-					}
+					is_primary_star = yes
 				}
-				root = {
-					set_country_flag = first_ehof_system_spawned
-					set_timed_country_flag = {
-						flag = ehof_recently_spawned_guardian
-						years = 2
-					}					# delay leviathans
+				save_event_target_as = ehof_color_star_name
+				set_name = {
+					key = "ehof_standard_star_name"
+					variable_string = "[ehof_color_star_name.GetName]"
 				}
+			}
+			set_star_flag = empire_cluster
+			set_star_flag = ruined_ehof_system
+			spawn_megastructure = {
+				type = "ehof_megastructure_ruined_origin"
+			}
+			giga_field_system_debris = yes
+		}
+		# Move Homeworld
+		capital_scope.solar_system = {
+			spawn_system = {
+				initializer = random
+				min_distance = 0.1
+				max_distance = 0.2
+				hyperlane = yes
+				authorize_spawn_on_galactic_core = no
+			} # Replacement system to restore hyperlanes
+			last_created_system = {
+				save_event_target_as = replacement_system
 				if = {
 					limit = {
 						any_megastructure = {
@@ -709,138 +324,74 @@ country_event = {
 						orbit_distance = 35
 						owner = root
 					}
+				} # Spawn Pillar
+			}
+			every_neighbor_system = {
+				add_hyperlane = {
+					from = this
+					to = event_target:replacement_system
 				}
-			}
-			save_global_event_target_as = ehofo_new_system
-		}
-	}
-}
-
-# Generate neighbouring blackhole system
-country_event = {
-	id = ehof_incohesive.4
-	hide_window = yes
-	is_triggered_only = yes
-	trigger = {
-		has_origin = origin_incohesive
-	}
-	immediate = {
-		# Set current system creator
-		if = {
-			limit = {
-				exists = event_target:current_system_creator
-			}
-			clear_global_event_target = current_system_creator
-		}
-		save_global_event_target_as = current_system_creator
-		event_target:ehofo_new_system = {
-			spawn_system = {
-				min_distance >= 20
-				max_distance <= 30
+			} # Replace hyperlanes
+			move_system = {
+				target = event_target:giga_last_ehof_spawn
+				min_distance >= 10
+				max_distance <= 15
+				max_jumps = 0
 				hyperlane = no
-				initializer = "special_init_01"
-			}
-		}
-		last_created_system = {
-			system_star = {
-				#prevent_anomaly = yes
-				giga_set_has_mega_flag = yes
-				clear_deposits = yes
-				giga_field_debris = yes
-			}
-			save_event_target_as = ehof_color_system_name
-			set_star_flag = empire_cluster
-			add_hyperlane_safe = {
-				from = event_target:ehofo_new_system
-				to = this
-			}
-			set_star_flag = ruined_ehof_system
-			spawn_megastructure = {
-				type = "ehof_megastructure_ruined_origin"
-			}
-			giga_field_system_debris = yes
-		}
-		country_event = {
-			id = ehof_systems.001
-		}		# Generate Flags
-		country_event = {
-			id = ehof_systems.002
-		}		# Generate Weather
-		#country_event = { id = ehof_systems.004 }	# Generate Megastructures
-		country_event = {
-			id = ehof_systems.006
-		}		# Generate Deposits
-		#country_event = { id = ehof_systems.007 }	# Generate Hostiles
-		country_event = {
-			id = ehof_systems.005
-		}		# Generate System Color
-	}
-}
-
-# Set homeworld
-country_event = {
-	id = ehof_incohesive.5
-	hide_window = yes
-	is_triggered_only = yes
-	trigger = {
-		has_origin = origin_incohesive
-	}
-	immediate = {
-		capital_scope = {
-			planet = {
-				remove_all_buildings = yes
-					# need this to remove duplicate capital building
-				save_global_event_target_as = ehof_origin_species_homeworld_fix
-				generate_start_buildings_and_districts = yes 
-			}
-		}
-		species = {
-			set_species_homeworld = event_target:ehof_origin_species_homeworld_fix
-		}
-		every_owned_pop_species = {
-			set_species_homeworld = event_target:ehof_origin_species_homeworld_fix
-		}
-		giga_set_all_leaders_homeworld = {
-			planet = event_target:ehof_origin_species_homeworld_fix
-		}
-		clear_global_event_target = ehof_origin_species_homeworld_fix
-	}
-}
-
-# FIX - Stop connecting to galaxy
-country_event = {
-	id = ehof_incohesive.6
-	hide_window = yes
-	is_triggered_only = yes
-	trigger = {
-		has_origin = origin_incohesive
-	}
-	immediate = {
-		set_spawn_system_batch = begin
-		every_system = {
-			limit = {
-				has_star_flag = cohesive_system
-				any_system = {
-					has_hyperlane_to = prev
-					NOT = {
-						has_star_flag = cohesive_system
+				reset_terra_incognita = yes
+			} # Move capital to the cluster (event_target:giga_last_ehof_spawn)
+			from = {
+				set_country_flag = first_ehof_system_spawned
+				set_timed_country_flag = {
+					flag = ehof_recently_spawned_guardian
+					years = 2
+				} # Delay leviathans
+				capital_scope.solar_system = {
+					set_star_flag = cohesive_system
+					set_star_flag = ehof_system_created_by_@root.owner
+					save_event_target_as = ehof_color_system_name
+					set_name = {
+						key = "ehof_standard_name"
+						variable_string = "[ehof_color_system_name.GetName]"
+					}
+					every_system_planet = {
+						limit = {
+							is_primary_star = yes
+						}
+						save_event_target_as = ehof_color_star_name
+						set_name = {
+							key = "ehof_standard_star_name"
+							variable_string = "[ehof_color_star_name.GetName]"
+						}
 					}
 				}
 			}
-			every_system = {
+			if = {
 				limit = {
-					has_hyperlane_to = prev
-					NOT = {
-						has_star_flag = cohesive_system
+					any_megastructure = {
+						is_megastructure_type = ehof_pgate_gateway
 					}
 				}
-				remove_hyperlane_safe = {
-					to = this
-					from = prev
+				spawn_megastructure = {
+					type = "ehof_pgate_gateway"
+					orbit_angle = 110
+					orbit_distance = 35
+					owner = root
 				}
 			}
+			else = {
+				spawn_megastructure = {
+					type = "ehof_pgate_unknown"
+					orbit_angle = 110
+					orbit_distance = 35
+					owner = root
+				}
+			} # Pillar in new home system
+			add_hyperlane_safe = {
+				from = event_target:giga_last_ehof_spawn
+				to = this.solar_system
+			} # Connect home system to ehof black hole
 		}
-		set_spawn_system_batch = end
 	}
 }
 
@@ -849,7 +400,7 @@ system_event = {
 	id = ehof_incohesive.7
 	hide_window = yes
 	is_triggered_only = yes
-	trigger = {#don't remove survey data if owned (it means an AI was reset)
+	trigger = { # Don't remove survey data if owned (it means an AI was reset)
 		NOT = { exists = space_owner }
 	}
 
@@ -864,6 +415,7 @@ system_event = {
 		}
 	}
 }
+# Shouldn't matter but I'll leave it here
 
 country_event = {
 	id = ehof_incohesive.8
@@ -878,4 +430,4 @@ country_event = {
 		giga_reset_ai_start = yes
 	}
 }
-
+# Shouldn't matter but I'll leave it here

--- a/events/giga_013_psychic_beacon.txt
+++ b/events/giga_013_psychic_beacon.txt
@@ -794,6 +794,8 @@ country_event = {
 		any_owned_leader = {
 			has_any_chosen_one_leader_trait = yes
 		}
+		has_any_megastructure_dlc = yes
+		NOT = { has_global_flag = psychic_beacon_disabled } # Lmao
 	}
 
 	immediate = {

--- a/events/giga_017_aeternum.txt
+++ b/events/giga_017_aeternum.txt
@@ -63,6 +63,10 @@ country_event = {
 					days = -1
 				}
 			}
+			add_modifier = { # Stop instakilling the Aeternum with bullshit guys cmon
+				modifier = mindwarden_aura_immunity
+				days = -1
+			}
 		}
 		event_target:aeternum_birch_world = {
 			solar_system = { random_system_planet = { limit = { is_planet_class = pc_core_black_hole } set_name = "Aiondiaukko" } }

--- a/events/giga_017_aeternum.txt
+++ b/events/giga_017_aeternum.txt
@@ -63,10 +63,13 @@ country_event = {
 					days = -1
 				}
 			}
-			add_modifier = { # Stop instakilling the Aeternum with bullshit guys cmon
-				modifier = mindwarden_aura_immunity
-				days = -1
-			}
+			if = {
+				limit = { has_shroud_dlc = yes }
+				add_modifier = { # Stop instakilling the Aeternum with bullshit guys cmon
+					modifier = mindwarden_aura_immunity
+					days = -1
+				}
+			} # Until they get their own aura
 		}
 		event_target:aeternum_birch_world = {
 			solar_system = { random_system_planet = { limit = { is_planet_class = pc_core_black_hole } set_name = "Aiondiaukko" } }


### PR DESCRIPTION
changes the ehof origin to use the move_system effect
updates asteroid industry for catalytic-anglers to use proper upkeep (and nerfs the food industry artisan upkeep reduction if you have both it and the consumer good buff on the same planet)
fixes farmer job inline not giving agri drones to wilderness empires
fixes being unable to make larger size rings in systems with ruined rings
fixes? being able to double up on rings in systems with ruined rings
makes aeternum immune to psionic auras
enabled all origins with text to show that they are disabled for 4.0 (or pending rework in the case of interstellar and penrose rings)
commented out the ringworld ecu upgrade
commented out terraforming links for alternate ringworld classes
commented out alternate ringworld planet classes
fixed hypersiphon not giving psionic pop efficiency