### PR TITLE
Fixes 2 part 2 (mainly alderson)

### DIFF
--- a/common/component_templates/giga_frameworld_components.txt
+++ b/common/component_templates/giga_frameworld_components.txt
@@ -1,118 +1,118 @@
-utility_component_template = {
-	key = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_1" # starport
-	size = small
-	icon = "GFX_ship_part_reactor_1"
-	icon_frame = 1
-	power = 5000
-	component_set = "power_core"
-	size_restriction = { frameworld_defensive_station }
-
-	upgrades_to = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_2"
-
-	modifier = {
-		
-	}
-
-	ai_weight = {
-		weight = 10000
-	}
-}
-
-utility_component_template = {
-	key = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_2" # starhold
-	size = small
-	icon = "GFX_ship_part_reactor_2"
-	icon_frame = 1
-	power = 10000
-	component_set = "power_core"
-	size_restriction = { frameworld_defensive_station }
-
-	upgrades_to = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_3"
-
-	prerequisites = {
-		tech_frameworld_defensive_station_2
-	}
-	
-
-	modifier = {
-		ship_hull_add = 10000
-		ship_armor_add = 1000
-	}
-
-	ai_weight = {
-		weight = 20000
-	}
-}
-
-utility_component_template = {
-	key = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_3" # star fortress
-	size = small
-	icon = "GFX_ship_part_reactor_3"
-	icon_frame = 1
-	power = 15000
-	component_set = "power_core"
-	size_restriction = { frameworld_defensive_station }
-
-	prerequisites = {
-		tech_frameworld_defensive_station_3
-	}
-
-	upgrades_to = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_4"
-
-	modifier = {
-		ship_hull_add = 30000
-		ship_armor_add = 4000
-	}
-
-	ai_weight = {
-		weight = 30000
-	}
-}
-
-utility_component_template = {
-	key = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_4" # citadel
-	size = small
-	icon = "GFX_ship_part_reactor_4"
-	icon_frame = 1
-	power = 20000
-	component_set = "power_core"
-	size_restriction = { frameworld_defensive_station }
-
-	prerequisites = {
-		tech_frameworld_defensive_station_4
-	}
-
-	upgrades_to = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_5"
-
-	modifier = {
-		ship_hull_add = 70000
-		ship_armor_add = 9000
-	}
-
-	ai_weight = {
-		weight = 40000
-	}
-}
-
-utility_component_template = {
-	key = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_5" # maginot
-	size = small
-	icon = "GFX_ship_part_reactor_5"
-	icon_frame = 1
-	power = 40000
-	component_set = "power_core"
-	size_restriction = { frameworld_defensive_station }
-
-	prerequisites = {
-		tech_frameworld_defensive_station_5
-	}
-
-	modifier = {
-		ship_hull_add = 150000
-		ship_armor_add = 19000
-	}
-
-	ai_weight = {
-		weight = 50000
-	}
-}
+# utility_component_template = {
+# 	key = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_1" # starport
+# 	size = small
+# 	icon = "GFX_ship_part_reactor_1"
+# 	icon_frame = 1
+# 	power = 5000
+# 	component_set = "power_core"
+# 	size_restriction = { frameworld_defensive_station }
+#
+# 	upgrades_to = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_2"
+#
+# 	modifier = {
+#
+# 	}
+#
+# 	ai_weight = {
+# 		weight = 10000
+# 	}
+# }
+#
+# utility_component_template = {
+# 	key = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_2" # starhold
+# 	size = small
+# 	icon = "GFX_ship_part_reactor_2"
+# 	icon_frame = 1
+# 	power = 10000
+# 	component_set = "power_core"
+# 	size_restriction = { frameworld_defensive_station }
+#
+# 	upgrades_to = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_3"
+#
+# 	prerequisites = {
+# 		tech_frameworld_defensive_station_2
+# 	}
+#
+#
+# 	modifier = {
+# 		ship_hull_add = 10000
+# 		ship_armor_add = 1000
+# 	}
+#
+# 	ai_weight = {
+# 		weight = 20000
+# 	}
+# }
+#
+# utility_component_template = {
+# 	key = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_3" # star fortress
+# 	size = small
+# 	icon = "GFX_ship_part_reactor_3"
+# 	icon_frame = 1
+# 	power = 15000
+# 	component_set = "power_core"
+# 	size_restriction = { frameworld_defensive_station }
+#
+# 	prerequisites = {
+# 		tech_frameworld_defensive_station_3
+# 	}
+#
+# 	upgrades_to = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_4"
+#
+# 	modifier = {
+# 		ship_hull_add = 30000
+# 		ship_armor_add = 4000
+# 	}
+#
+# 	ai_weight = {
+# 		weight = 30000
+# 	}
+# }
+#
+# utility_component_template = {
+# 	key = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_4" # citadel
+# 	size = small
+# 	icon = "GFX_ship_part_reactor_4"
+# 	icon_frame = 1
+# 	power = 20000
+# 	component_set = "power_core"
+# 	size_restriction = { frameworld_defensive_station }
+#
+# 	prerequisites = {
+# 		tech_frameworld_defensive_station_4
+# 	}
+#
+# 	upgrades_to = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_5"
+#
+# 	modifier = {
+# 		ship_hull_add = 70000
+# 		ship_armor_add = 9000
+# 	}
+#
+# 	ai_weight = {
+# 		weight = 40000
+# 	}
+# }
+#
+# utility_component_template = {
+# 	key = "GIGA_FRAMEWORLD_DEFENSIVE_STATION_REACTOR_5" # maginot
+# 	size = small
+# 	icon = "GFX_ship_part_reactor_5"
+# 	icon_frame = 1
+# 	power = 40000
+# 	component_set = "power_core"
+# 	size_restriction = { frameworld_defensive_station }
+#
+# 	prerequisites = {
+# 		tech_frameworld_defensive_station_5
+# 	}
+#
+# 	modifier = {
+# 		ship_hull_add = 150000
+# 		ship_armor_add = 19000
+# 	}
+#
+# 	ai_weight = {
+# 		weight = 50000
+# 	}
+# }

--- a/common/deposits/giga_job_size_deposits.txt
+++ b/common/deposits/giga_job_size_deposits.txt
@@ -85,7 +85,7 @@ d_giga_job_size = {
 
 		planet_researchers_consumer_goods_upkeep_add = 2
 
-		planet_administrators_unity_produces_add = 4
+		planet_bureaucrats_unity_produces_add = 4
 		planet_administrators_consumer_goods_upkeep_add = 2
 
 		planet_telepaths_unity_produces_add = 5
@@ -206,7 +206,7 @@ d_giga_job_size = {
 
 		planet_researchers_minerals_upkeep_add = 6
 
-		planet_administrators_unity_produces_add = 4
+		planet_bureaucrats_unity_produces_add = 4
 		planet_administrators_energy_upkeep_add = 2
 
 		planet_evaluators_unity_produces_add = 4
@@ -254,7 +254,7 @@ d_giga_job_size = {
 
 		planet_pop_assemblers_alloys_upkeep_add = 0.5 # 50%
 
-		planet_administrators_unity_produces_add = 4
+		planet_bureaucrats_unity_produces_add = 4
 		planet_administrators_energy_upkeep_add = 4
 
 		planet_evaluators_unity_produces_add = 4
@@ -583,7 +583,7 @@ d_giga_job_size = {
 		}
 		multiplier = modifier:giga_planet_job_size
 
-		planet_administrators_unity_produces_add = 1
+		planet_bureaucrats_unity_produces_add = 1
 	}
 
 	# vultaum reality computer
@@ -669,7 +669,7 @@ d_giga_job_size = {
 		}
 		multiplier = modifier:giga_planet_job_size
 
-		planet_administrators_unity_produces_add = 1
+		planet_bureaucrats_unity_produces_add = 1
 	}
 
 	# bio reactor
@@ -757,8 +757,8 @@ d_giga_job_size = {
 	# administrator jobs
 	triggered_planet_modifier = {
 		potential = { always = yes }
-		multiplier = value:giga_job_scaling_country_modifier|MODIFIER|planet_administrators_unity_produces_add|
-		planet_administrators_unity_produces_add = 1
+		multiplier = value:giga_job_scaling_country_modifier|MODIFIER|planet_bureaucrats_unity_produces_add|
+		planet_bureaucrats_unity_produces_add = 1
 	}
 	triggered_planet_modifier = {
 		potential = { always = yes }

--- a/common/districts/giga_alderson.txt
+++ b/common/districts/giga_alderson.txt
@@ -59,7 +59,7 @@ district_alderson_logistics = {
         potential = {
             exists = owner
             owner = {
-                is_gestalt = no
+                is_gestalt = yes
             }
         }
         job_patrol_drone_add = @base_district_jobs

--- a/common/districts/giga_alderson.txt
+++ b/common/districts/giga_alderson.txt
@@ -44,8 +44,26 @@ district_alderson_logistics = {
 
 	planet_modifier = {
 		planet_housing_add = 2500
-		job_enforcer_add = @base_district_jobs
 	}
+
+    triggered_planet_modifier = {
+        potential = {
+            exists = owner
+            owner = {
+                is_gestalt = no
+            }
+        }
+        job_enforcer_add = @base_district_jobs
+    }
+    triggered_planet_modifier = {
+        potential = {
+            exists = owner
+            owner = {
+                is_gestalt = no
+            }
+        }
+        job_patrol_drone_add = @base_district_jobs
+    }
 }
 
 district_alderson_gaia = {

--- a/common/scripted_triggers/giga_planet_class_triggers.txt
+++ b/common/scripted_triggers/giga_planet_class_triggers.txt
@@ -267,13 +267,7 @@
 
 	giga_is_alderson_disk = {
 		optimize_memory
-		or = {
-			is_planet_class = pc_alderson_slice_ecu
-			is_planet_class = pc_alderson_slice_gaia
-			is_planet_class = pc_alderson_slice_hive
-			is_planet_class = pc_alderson_slice_machine
-			is_planet_class = pc_alderson_slice_pc
-		}
+        is_planet_class = pc_alderson_slice_gaia
 	}
 
 	giga_is_habitable_gas_giant = {

--- a/common/starbase_buildings/giga_orbital_ring_buildings.txt
+++ b/common/starbase_buildings/giga_orbital_ring_buildings.txt
@@ -173,7 +173,7 @@ ring_giga_motes_hub = {
 			fail_text = ring_giga_motes_hub_condition
 			planet = {
 				check_modifier_value = {
-					modifier = planet_miners_volatile_motes_produces_add
+					modifier = planet_technician_volatile_motes_produces_add
 					value > 0
 				}
 			}
@@ -183,7 +183,7 @@ ring_giga_motes_hub = {
 	destroy_trigger = {
 		planet = {
 			check_modifier_value = {
-				modifier = planet_miners_volatile_motes_produces_add
+				modifier = planet_technician_volatile_motes_produces_add
 				value <= 0
 			}
 		}
@@ -209,7 +209,7 @@ ring_giga_motes_hub = {
 		}
 		job_mote_harvester_add = 25
 
-		multiplier = planet.value:mining_districts_value
+		multiplier = planet.value:generator_districts_value
 	}
 
 	triggered_planet_modifier = {
@@ -219,7 +219,7 @@ ring_giga_motes_hub = {
 		}
 		job_mote_harvesting_drone_add = 25
 
-		multiplier = planet.value:mining_districts_value
+		multiplier = planet.value:generator_districts_value
 	}
 
 	triggered_planet_modifier = {
@@ -254,7 +254,7 @@ ring_giga_gas_hub = {
 			fail_text = ring_giga_gas_hub_condition
 			planet = {
 				check_modifier_value = {
-					modifier = planet_miners_exotic_gases_produces_add
+					modifier = planet_farmers_exotic_gases_produces_add
 					value > 0
 				}
 			}
@@ -264,7 +264,7 @@ ring_giga_gas_hub = {
 	destroy_trigger = {
 		planet = {
 			check_modifier_value = {
-				modifier = planet_miners_exotic_gases_produces_add
+				modifier = planet_farmers_exotic_gases_produces_add
 				value <= 0
 			}
 		}
@@ -288,7 +288,7 @@ ring_giga_gas_hub = {
 		}
 		job_gas_extractor_add = 25
 
-		multiplier = planet.value:mining_districts_value
+		multiplier = planet.value:farming_districts_value
 	}
 
 	triggered_planet_modifier = {
@@ -298,7 +298,7 @@ ring_giga_gas_hub = {
 		}
 		job_gas_extraction_drone_add = 25
 
-		multiplier = planet.value:mining_districts_value
+		multiplier = planet.value:farming_districts_value
 	}
 
 	triggered_planet_modifier = {

--- a/common/zones/giga_zones.txt
+++ b/common/zones/giga_zones.txt
@@ -692,7 +692,7 @@ zone_maginot_recovery_zones = {
 zone_maginot_ringworld_recovery_zones = {
 	inline_script = {
 		script = zones/maginot/recovery_zones_zone_maginot
-		is_maginot_ring = no
+		is_maginot_ring = yes
 		jobs = @maginot_recovery_zone_soldier_jobs_add_ringworld
 		housing_inline_type = ring_world
 	}

--- a/common/zones/giga_zones.txt
+++ b/common/zones/giga_zones.txt
@@ -308,7 +308,6 @@ zone_alderson_pop_growth = {
 	ai_weight_coefficient = 1.1
 }
 
-
 zone_alderson_housing = {
 	icon = GFX_district_specialization_urban
 	base_buildtime = @zone_buildtime
@@ -338,7 +337,7 @@ zone_alderson_housing = {
 		urban
 	}
 
-	planet_modifier = {
+	district_planet_modifier = {
 		planet_housing_add = 5000
 	}
 
@@ -427,7 +426,10 @@ zone_alderson_unity = {
 
 	ai_priority = 15
 
-
+    convert_to = {
+        zone_alderson_unity_spiritualist
+        zone_alderson_unity_servitor
+    }
 
 	ai_weight_coefficient = 1.1
 }
@@ -444,7 +446,10 @@ zone_alderson_unity_spiritualist = {
 
 	ai_priority = 15
 
-
+    convert_to = {
+        zone_alderson_unity
+        zone_alderson_unity_servitor
+    }
 
 	ai_weight_coefficient = 1.1
 }
@@ -461,7 +466,10 @@ zone_alderson_unity_servitor = {
 
 	ai_priority = 15
 
-
+    convert_to = {
+        zone_alderson_unity
+        zone_alderson_unity_spiritualist
+    }
 
 	ai_weight_coefficient = 1.1
 }

--- a/common/zones/giga_zones.txt
+++ b/common/zones/giga_zones.txt
@@ -199,6 +199,7 @@ zone_alderson_housing_optimization = {
 
 	included_building_sets = {
 		government
+        urban
 	}
 
 	planet_modifier = {
@@ -238,6 +239,7 @@ zone_alderson_infrastructure_optimization = {
 
 	included_building_sets = {
 		government
+        urban
 	}
 
 	planet_modifier = {
@@ -295,6 +297,7 @@ zone_alderson_pop_growth = {
 
 	included_building_sets = {
 		government
+        urban
 	}
 
 	planet_modifier = {

--- a/localisation/braz_por/giga_l_braz_por.yml
+++ b/localisation/braz_por/giga_l_braz_por.yml
@@ -17854,17 +17854,17 @@
   
   sm_orbital_ring_giga_farming_district:99 "Planetary Soil Fertilizer"
   sm_orbital_ring_giga_farming_district_desc:99 "Automated factories produce vast quantities of fertilizer and distribute them to previously inhospitable parts of the planet's surface to permit agriculture.\n\n§YEfficiency is lower on Tomb Worlds and higher on Gaia Worlds. Does not function on Irradiated Desert Worlds.§!\n"
-  
+
   sm_ring_giga_crystals_hub:99 "Laser Crystal Bore"
-  sm_ring_giga_crystals_hub_desc:99 "Immense laser drills cutting into the planet's crust to help planetside rare crystal mining. Other extracted materials supplement the crystal refining process.\n\n§TProvides §G+100§! £job_crystal_miner£ §YCrystal Mining§! Jobs per §G4§! £district£ §Y$district_mining_plural$§!.\n"
+  sm_ring_giga_crystals_hub_desc:99 "Immense laser drills cutting into the planet's crust to help planetside rare crystal mining. Other extracted materials supplement the crystal refining process.\n\n§TProvides §G+25§! £job_crystal_miner£ §YCrystal Mining§! Jobs per £district£ §Y$district_mining$§!.\n"
   ring_giga_crystals_hub_condition:99 "§RPlanet must have deposits of £rare_crystals£ §Y$rare_crystals$.§!"
-  
+
   sm_ring_giga_motes_hub:99 "Hypersonic Mote Sifter"
-  sm_ring_giga_motes_hub_desc:99 "Powerful sonic emitters blast ultrasound waves into the atmosphere and towards mote harvesting sites, stirring up dust deserts with just the right frequency to bring plenty of Volatile Motes to the surface. Electromagnetic nets can also capture materials valuable to the mote refining process.\n\n§TProvides §G+1§! £job_mote_harvester£ §YMote Harvesting§! Job per §G4§! £district£ §Y$district_mining_plural$§!.\n"
+  sm_ring_giga_motes_hub_desc:99 "Powerful sonic emitters blast ultrasound waves into the atmosphere and towards mote harvesting sites, stirring up dust deserts with just the right frequency to bring plenty of Volatile Motes to the surface. Electromagnetic nets can also capture materials valuable to the mote refining process.\n\n§TProvides §G+25§! £job_mote_harvester£ §YMote Harvesting§! Job per £district£ §Y$district_generator$§!.\n"
   ring_giga_motes_hub_condition:99 "§RPlanet must have deposits of £volatile_motes£ §Y$volatile_motes$.§!"
-  
+
   sm_ring_giga_gas_hub:99 "Atmospheric Gas Stabilizer"
-  sm_ring_giga_gas_hub_desc:99 "Chemical plants which inject stabilizing agents into the atmosphere near naturally-occurring gas deposits, making extraction safer and easier. As a side effect, local microbes can be more effectively utilised to refine gases from biomass.\n\n§TProvides §G+100§! £job_gas_extractor£ §YGas Extraction§! Jobs per §G4§! £district£ §Y$district_mining_plural$§!.\n"
+  sm_ring_giga_gas_hub_desc:99 "Chemical plants which inject stabilizing agents into the atmosphere near naturally-occurring gas deposits, making extraction safer and easier. As a side effect, local microbes can be more effectively utilised to refine gases from biomass.\n\n§TProvides §G+25§! £job_gas_extractor£ §YGas Extraction§! Jobs per £district£ §Y$district_farming$§!.\n"
   ring_giga_gas_hub_condition:99 "§RPlanet must have deposits of £exotic_gases£ §Y$exotic_gases$.§!"
   
   sm_ring_giga_iodizium_hub:99 "Field Isolation Grid"

--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -17856,16 +17856,16 @@
   sm_orbital_ring_giga_farming_district_desc:0 "Automated factories produce vast quantities of fertilizer and distribute them to previously inhospitable parts of the planet's surface to permit agriculture.\n\n§YEfficiency is lower on Tomb Worlds and higher on Gaia Worlds. Does not function on Irradiated Desert Worlds.§!\n"
 
   sm_ring_giga_crystals_hub:0 "Laser Crystal Bore"
-  sm_ring_giga_crystals_hub_desc:0 "Immense laser drills cutting into the planet's crust to help planetside rare crystal mining. Other extracted materials supplement the crystal refining process.\n\n§TProvides §G+100§! £job_crystal_miner£ §YCrystal Mining§! Jobs per §G4§! £district£ §Y$district_mining_plural$§!.\n"
-  ring_giga_crystals_hub_condition:99 "§RPlanet must have deposits of £rare_crystals£ §Y$rare_crystals$.§!"
+  sm_ring_giga_crystals_hub_desc:0 "Immense laser drills cutting into the planet's crust to help planetside rare crystal mining. Other extracted materials supplement the crystal refining process.\n\n§TProvides §G+25§! £job_crystal_miner£ §YCrystal Mining§! Jobs per £district£ §Y$district_mining$§!.\n"
+  ring_giga_crystals_hub_condition:0 "§RPlanet must have deposits of £rare_crystals£ §Y$rare_crystals$.§!"
 
   sm_ring_giga_motes_hub:0 "Hypersonic Mote Sifter"
-  sm_ring_giga_motes_hub_desc:0 "Powerful sonic emitters blast ultrasound waves into the atmosphere and towards mote harvesting sites, stirring up dust deserts with just the right frequency to bring plenty of Volatile Motes to the surface. Electromagnetic nets can also capture materials valuable to the mote refining process.\n\n§TProvides §G+1§! £job_mote_harvester£ §YMote Harvesting§! Job per §G4§! £district£ §Y$district_mining_plural$§!.\n"
-  ring_giga_motes_hub_condition:99 "§RPlanet must have deposits of £volatile_motes£ §Y$volatile_motes$.§!"
+  sm_ring_giga_motes_hub_desc:0 "Powerful sonic emitters blast ultrasound waves into the atmosphere and towards mote harvesting sites, stirring up dust deserts with just the right frequency to bring plenty of Volatile Motes to the surface. Electromagnetic nets can also capture materials valuable to the mote refining process.\n\n§TProvides §G+25§! £job_mote_harvester£ §YMote Harvesting§! Job per £district£ §Y$district_generator$§!.\n"
+  ring_giga_motes_hub_condition:0 "§RPlanet must have deposits of £volatile_motes£ §Y$volatile_motes$.§!"
 
   sm_ring_giga_gas_hub:0 "Atmospheric Gas Stabilizer"
-  sm_ring_giga_gas_hub_desc:0 "Chemical plants which inject stabilizing agents into the atmosphere near naturally-occurring gas deposits, making extraction safer and easier. As a side effect, local microbes can be more effectively utilised to refine gases from biomass.\n\n§TProvides §G+100§! £job_gas_extractor£ §YGas Extraction§! Jobs per §G4§! £district£ §Y$district_mining_plural$§!.\n"
-  ring_giga_gas_hub_condition:99 "§RPlanet must have deposits of £exotic_gases£ §Y$exotic_gases$.§!"
+  sm_ring_giga_gas_hub_desc:0 "Chemical plants which inject stabilizing agents into the atmosphere near naturally-occurring gas deposits, making extraction safer and easier. As a side effect, local microbes can be more effectively utilised to refine gases from biomass.\n\n§TProvides §G+25§! £job_gas_extractor£ §YGas Extraction§! Jobs per £district£ §Y$district_farming$§!.\n"
+  ring_giga_gas_hub_condition:0 "§RPlanet must have deposits of £exotic_gases£ §Y$exotic_gases$.§!"
 
   sm_ring_giga_iodizium_hub:0 "Field Isolation Grid"
   sm_ring_giga_iodizium_hub_desc:0 "Shield projectors focused on Iodizium mining facilities ensure that explosive chain reactions are kept to a minimum, greatly improving the efficiency of planetside crystal handling.\n\n§TProvides §G+100§! £job_giga_iodizium_miner£ §YIodizium Mining§! Jobs per active £building£ §Y$building_giga_iodizium_mines$§! Building§!\n"

--- a/localisation/french/giga_l_french.yml
+++ b/localisation/french/giga_l_french.yml
@@ -17854,17 +17854,17 @@
   
   sm_orbital_ring_giga_farming_district:99 "Planetary Soil Fertilizer"
   sm_orbital_ring_giga_farming_district_desc:99 "Automated factories produce vast quantities of fertilizer and distribute them to previously inhospitable parts of the planet's surface to permit agriculture.\n\n§YEfficiency is lower on Tomb Worlds and higher on Gaia Worlds. Does not function on Irradiated Desert Worlds.§!\n"
-  
+
   sm_ring_giga_crystals_hub:99 "Laser Crystal Bore"
-  sm_ring_giga_crystals_hub_desc:99 "Immense laser drills cutting into the planet's crust to help planetside rare crystal mining. Other extracted materials supplement the crystal refining process.\n\n§TProvides §G+100§! £job_crystal_miner£ §YCrystal Mining§! Jobs per §G4§! £district£ §Y$district_mining_plural$§!.\n"
+  sm_ring_giga_crystals_hub_desc:99 "Immense laser drills cutting into the planet's crust to help planetside rare crystal mining. Other extracted materials supplement the crystal refining process.\n\n§TProvides §G+25§! £job_crystal_miner£ §YCrystal Mining§! Jobs per £district£ §Y$district_mining$§!.\n"
   ring_giga_crystals_hub_condition:99 "§RPlanet must have deposits of £rare_crystals£ §Y$rare_crystals$.§!"
-  
+
   sm_ring_giga_motes_hub:99 "Hypersonic Mote Sifter"
-  sm_ring_giga_motes_hub_desc:99 "Powerful sonic emitters blast ultrasound waves into the atmosphere and towards mote harvesting sites, stirring up dust deserts with just the right frequency to bring plenty of Volatile Motes to the surface. Electromagnetic nets can also capture materials valuable to the mote refining process.\n\n§TProvides §G+1§! £job_mote_harvester£ §YMote Harvesting§! Job per §G4§! £district£ §Y$district_mining_plural$§!.\n"
+  sm_ring_giga_motes_hub_desc:99 "Powerful sonic emitters blast ultrasound waves into the atmosphere and towards mote harvesting sites, stirring up dust deserts with just the right frequency to bring plenty of Volatile Motes to the surface. Electromagnetic nets can also capture materials valuable to the mote refining process.\n\n§TProvides §G+25§! £job_mote_harvester£ §YMote Harvesting§! Job per £district£ §Y$district_generator$§!.\n"
   ring_giga_motes_hub_condition:99 "§RPlanet must have deposits of £volatile_motes£ §Y$volatile_motes$.§!"
-  
+
   sm_ring_giga_gas_hub:99 "Atmospheric Gas Stabilizer"
-  sm_ring_giga_gas_hub_desc:99 "Chemical plants which inject stabilizing agents into the atmosphere near naturally-occurring gas deposits, making extraction safer and easier. As a side effect, local microbes can be more effectively utilised to refine gases from biomass.\n\n§TProvides §G+100§! £job_gas_extractor£ §YGas Extraction§! Jobs per §G4§! £district£ §Y$district_mining_plural$§!.\n"
+  sm_ring_giga_gas_hub_desc:99 "Chemical plants which inject stabilizing agents into the atmosphere near naturally-occurring gas deposits, making extraction safer and easier. As a side effect, local microbes can be more effectively utilised to refine gases from biomass.\n\n§TProvides §G+25§! £job_gas_extractor£ §YGas Extraction§! Jobs per £district£ §Y$district_farming$§!.\n"
   ring_giga_gas_hub_condition:99 "§RPlanet must have deposits of £exotic_gases£ §Y$exotic_gases$.§!"
   
   sm_ring_giga_iodizium_hub:99 "Field Isolation Grid"

--- a/localisation/german/giga_l_german.yml
+++ b/localisation/german/giga_l_german.yml
@@ -17854,22 +17854,18 @@
   
   sm_orbital_ring_giga_farming_district:99 "Planetary Soil Fertilizer"
   sm_orbital_ring_giga_farming_district_desc:99 "Automated factories produce vast quantities of fertilizer and distribute them to previously inhospitable parts of the planet's surface to permit agriculture.\n\n§YEfficiency is lower on Tomb Worlds and higher on Gaia Worlds. Does not function on Irradiated Desert Worlds.§!\n"
-  
+
   sm_ring_giga_crystals_hub:99 "Laser Crystal Bore"
-  sm_ring_giga_crystals_hub_desc:99 "Immense laser drills cutting into the planet's crust to help planetside rare crystal mining. Other extracted materials supplement the crystal refining process.\n\n§TProvides §G+100§! £job_crystal_miner£ §YCrystal Mining§! Jobs per §G4§! £district£ §Y$district_mining_plural$§!.\n"
+  sm_ring_giga_crystals_hub_desc:99 "Immense laser drills cutting into the planet's crust to help planetside rare crystal mining. Other extracted materials supplement the crystal refining process.\n\n§TProvides §G+25§! £job_crystal_miner£ §YCrystal Mining§! Jobs per £district£ §Y$district_mining$§!.\n"
   ring_giga_crystals_hub_condition:99 "§RPlanet must have deposits of £rare_crystals£ §Y$rare_crystals$.§!"
-  
+
   sm_ring_giga_motes_hub:99 "Hypersonic Mote Sifter"
-  sm_ring_giga_motes_hub_desc:99 "Powerful sonic emitters blast ultrasound waves into the atmosphere and towards mote harvesting sites, stirring up dust deserts with just the right frequency to bring plenty of Volatile Motes to the surface. Electromagnetic nets can also capture materials valuable to the mote refining process.\n\n§TProvides §G+1§! £job_mote_harvester£ §YMote Harvesting§! Job per §G4§! £district£ §Y$district_mining_plural$§!.\n"
+  sm_ring_giga_motes_hub_desc:99 "Powerful sonic emitters blast ultrasound waves into the atmosphere and towards mote harvesting sites, stirring up dust deserts with just the right frequency to bring plenty of Volatile Motes to the surface. Electromagnetic nets can also capture materials valuable to the mote refining process.\n\n§TProvides §G+25§! £job_mote_harvester£ §YMote Harvesting§! Job per £district£ §Y$district_generator$§!.\n"
   ring_giga_motes_hub_condition:99 "§RPlanet must have deposits of £volatile_motes£ §Y$volatile_motes$.§!"
-  
+
   sm_ring_giga_gas_hub:99 "Atmospheric Gas Stabilizer"
-  sm_ring_giga_gas_hub_desc:99 "Chemical plants which inject stabilizing agents into the atmosphere near naturally-occurring gas deposits, making extraction safer and easier. As a side effect, local microbes can be more effectively utilised to refine gases from biomass.\n\n§TProvides §G+100§! £job_gas_extractor£ §YGas Extraction§! Jobs per §G4§! £district£ §Y$district_mining_plural$§!.\n"
+  sm_ring_giga_gas_hub_desc:99 "Chemical plants which inject stabilizing agents into the atmosphere near naturally-occurring gas deposits, making extraction safer and easier. As a side effect, local microbes can be more effectively utilised to refine gases from biomass.\n\n§TProvides §G+25§! £job_gas_extractor£ §YGas Extraction§! Jobs per £district£ §Y$district_farming$§!.\n"
   ring_giga_gas_hub_condition:99 "§RPlanet must have deposits of £exotic_gases£ §Y$exotic_gases$.§!"
-  
-  sm_ring_giga_iodizium_hub:99 "Field Isolation Grid"
-  sm_ring_giga_iodizium_hub_desc:99 "Shield projectors focused on Iodizium mining facilities ensure that explosive chain reactions are kept to a minimum, greatly improving the efficiency of planetside crystal handling.\n\n§TProvides §G+100§! £job_giga_iodizium_miner£ §YIodizium Mining§! Jobs per active £building£ §Y$building_giga_iodizium_mines$§! Building§!\n"
-  ring_giga_iodizium_hub_condition:99 "§RPlanet must be able to support at least one £building£ §Y$building_giga_iodizium_mines$§! Building.§!"
   
   sm_ring_giga_orbital_arcology:99 "Orbital Arcology"
   sm_ring_giga_orbital_arcology_desc:99 "High density housing developments and ample transport infrastructure will let us make the most of the space on the planet blow.\n\n$sm_ring_giga_orbital_arcology_effect$\n"

--- a/localisation/polish/giga_l_polish.yml
+++ b/localisation/polish/giga_l_polish.yml
@@ -17854,17 +17854,17 @@
   
   sm_orbital_ring_giga_farming_district:99 "Planetary Soil Fertilizer"
   sm_orbital_ring_giga_farming_district_desc:99 "Automated factories produce vast quantities of fertilizer and distribute them to previously inhospitable parts of the planet's surface to permit agriculture.\n\n§YEfficiency is lower on Tomb Worlds and higher on Gaia Worlds. Does not function on Irradiated Desert Worlds.§!\n"
-  
+
   sm_ring_giga_crystals_hub:99 "Laser Crystal Bore"
-  sm_ring_giga_crystals_hub_desc:99 "Immense laser drills cutting into the planet's crust to help planetside rare crystal mining. Other extracted materials supplement the crystal refining process.\n\n§TProvides §G+100§! £job_crystal_miner£ §YCrystal Mining§! Jobs per §G4§! £district£ §Y$district_mining_plural$§!.\n"
+  sm_ring_giga_crystals_hub_desc:99 "Immense laser drills cutting into the planet's crust to help planetside rare crystal mining. Other extracted materials supplement the crystal refining process.\n\n§TProvides §G+25§! £job_crystal_miner£ §YCrystal Mining§! Jobs per £district£ §Y$district_mining$§!.\n"
   ring_giga_crystals_hub_condition:99 "§RPlanet must have deposits of £rare_crystals£ §Y$rare_crystals$.§!"
-  
+
   sm_ring_giga_motes_hub:99 "Hypersonic Mote Sifter"
-  sm_ring_giga_motes_hub_desc:99 "Powerful sonic emitters blast ultrasound waves into the atmosphere and towards mote harvesting sites, stirring up dust deserts with just the right frequency to bring plenty of Volatile Motes to the surface. Electromagnetic nets can also capture materials valuable to the mote refining process.\n\n§TProvides §G+1§! £job_mote_harvester£ §YMote Harvesting§! Job per §G4§! £district£ §Y$district_mining_plural$§!.\n"
+  sm_ring_giga_motes_hub_desc:99 "Powerful sonic emitters blast ultrasound waves into the atmosphere and towards mote harvesting sites, stirring up dust deserts with just the right frequency to bring plenty of Volatile Motes to the surface. Electromagnetic nets can also capture materials valuable to the mote refining process.\n\n§TProvides §G+25§! £job_mote_harvester£ §YMote Harvesting§! Job per £district£ §Y$district_generator$§!.\n"
   ring_giga_motes_hub_condition:99 "§RPlanet must have deposits of £volatile_motes£ §Y$volatile_motes$.§!"
-  
+
   sm_ring_giga_gas_hub:99 "Atmospheric Gas Stabilizer"
-  sm_ring_giga_gas_hub_desc:99 "Chemical plants which inject stabilizing agents into the atmosphere near naturally-occurring gas deposits, making extraction safer and easier. As a side effect, local microbes can be more effectively utilised to refine gases from biomass.\n\n§TProvides §G+100§! £job_gas_extractor£ §YGas Extraction§! Jobs per §G4§! £district£ §Y$district_mining_plural$§!.\n"
+  sm_ring_giga_gas_hub_desc:99 "Chemical plants which inject stabilizing agents into the atmosphere near naturally-occurring gas deposits, making extraction safer and easier. As a side effect, local microbes can be more effectively utilised to refine gases from biomass.\n\n§TProvides §G+25§! £job_gas_extractor£ §YGas Extraction§! Jobs per £district£ §Y$district_farming$§!.\n"
   ring_giga_gas_hub_condition:99 "§RPlanet must have deposits of £exotic_gases£ §Y$exotic_gases$.§!"
   
   sm_ring_giga_iodizium_hub:99 "Field Isolation Grid"

--- a/localisation/russian/giga_l_russian.yml
+++ b/localisation/russian/giga_l_russian.yml
@@ -17856,15 +17856,15 @@
   sm_orbital_ring_giga_farming_district_desc:99 "Automated factories produce vast quantities of fertilizer and distribute them to previously inhospitable parts of the planet's surface to permit agriculture.\n\n§YEfficiency is lower on Tomb Worlds and higher on Gaia Worlds. Does not function on Irradiated Desert Worlds.§!\n"
   
   sm_ring_giga_crystals_hub:99 "Laser Crystal Bore"
-  sm_ring_giga_crystals_hub_desc:99 "Immense laser drills cutting into the planet's crust to help planetside rare crystal mining. Other extracted materials supplement the crystal refining process.\n\n§TProvides §G+100§! £job_crystal_miner£ §YCrystal Mining§! Jobs per §G4§! £district£ §Y$district_mining_plural$§!.\n"
+  sm_ring_giga_crystals_hub_desc:99 "Immense laser drills cutting into the planet's crust to help planetside rare crystal mining. Other extracted materials supplement the crystal refining process.\n\n§TProvides §G+25§! £job_crystal_miner£ §YCrystal Mining§! Jobs per £district£ §Y$district_mining$§!.\n"
   ring_giga_crystals_hub_condition:99 "§RPlanet must have deposits of £rare_crystals£ §Y$rare_crystals$.§!"
-  
+
   sm_ring_giga_motes_hub:99 "Hypersonic Mote Sifter"
-  sm_ring_giga_motes_hub_desc:99 "Powerful sonic emitters blast ultrasound waves into the atmosphere and towards mote harvesting sites, stirring up dust deserts with just the right frequency to bring plenty of Volatile Motes to the surface. Electromagnetic nets can also capture materials valuable to the mote refining process.\n\n§TProvides §G+1§! £job_mote_harvester£ §YMote Harvesting§! Job per §G4§! £district£ §Y$district_mining_plural$§!.\n"
+  sm_ring_giga_motes_hub_desc:99 "Powerful sonic emitters blast ultrasound waves into the atmosphere and towards mote harvesting sites, stirring up dust deserts with just the right frequency to bring plenty of Volatile Motes to the surface. Electromagnetic nets can also capture materials valuable to the mote refining process.\n\n§TProvides §G+25§! £job_mote_harvester£ §YMote Harvesting§! Job per £district£ §Y$district_generator$§!.\n"
   ring_giga_motes_hub_condition:99 "§RPlanet must have deposits of £volatile_motes£ §Y$volatile_motes$.§!"
-  
+
   sm_ring_giga_gas_hub:99 "Atmospheric Gas Stabilizer"
-  sm_ring_giga_gas_hub_desc:99 "Chemical plants which inject stabilizing agents into the atmosphere near naturally-occurring gas deposits, making extraction safer and easier. As a side effect, local microbes can be more effectively utilised to refine gases from biomass.\n\n§TProvides §G+100§! £job_gas_extractor£ §YGas Extraction§! Jobs per §G4§! £district£ §Y$district_mining_plural$§!.\n"
+  sm_ring_giga_gas_hub_desc:99 "Chemical plants which inject stabilizing agents into the atmosphere near naturally-occurring gas deposits, making extraction safer and easier. As a side effect, local microbes can be more effectively utilised to refine gases from biomass.\n\n§TProvides §G+25§! £job_gas_extractor£ §YGas Extraction§! Jobs per £district£ §Y$district_farming$§!.\n"
   ring_giga_gas_hub_condition:99 "§RPlanet must have deposits of £exotic_gases£ §Y$exotic_gases$.§!"
   
   sm_ring_giga_iodizium_hub:99 "Field Isolation Grid"

--- a/localisation/simp_chinese/giga_l_simp_chinese.yml
+++ b/localisation/simp_chinese/giga_l_simp_chinese.yml
@@ -17854,18 +17854,18 @@
   
   sm_orbital_ring_giga_farming_district:0 "行星土壤肥料机"
   sm_orbital_ring_giga_farming_district_desc:0 "自动化工厂产生大量肥料，并将其分配到星球地表上不适居住之处，来促进农业发展。\n\n§Y在死寂星球上效能将降低，在盖亚星球上效能将提高。在辐射沙漠世界上不起作用。§!\n"
-  
-  sm_ring_giga_crystals_hub:0 "激光水晶矿井"
-  sm_ring_giga_crystals_hub_desc:0 "巨型激光钻头深入行星的地壳来辅助稀有水晶开采。其他开采的矿物补充水晶精炼过程\n\n§T每有一个工作中的£building£§Y$building_crystal_mines$§!建筑§G+1§!£job_crystal_miner£§Y水晶开采§!岗位§!\n"
-  ring_giga_crystals_hub_condition:0 "§R行星必须能支持至少一个£building£§Y$building_crystal_mines$§!建筑。§!"
-  
-  sm_ring_giga_motes_hub:0 "超音速微粒筛粉机"
-  sm_ring_giga_motes_hub_desc:0 "强力的声波产生仪向大气层和微粒采集场不断发射超声波，以适当频率激起沙尘，产生大量易爆微粒降至地表。电磁网还可捕获对微粒精炼过程有价值的材料。\n\n§T每有一个工作中的£building£§Y$building_mote_harvesters$§!建筑§G+1§!£job_mote_harvester£§Y微粒捕获§!岗位§!\n"
-  ring_giga_motes_hub_condition:0 "§R行星必须能支持至少一个£building£§Y$building_mote_harvesters$§!建筑。§!"
-  
-  sm_ring_giga_gas_hub:0 "大气气体稳定器"
-  sm_ring_giga_gas_hub_desc:0 "化工厂将自然形成的天然气矿藏附近大气中注入稳定剂，使开采更安全、更轻松。此外，可利用当地微生物可更高效地从生物质中精炼天然气。\n\n§T每有一个工作中的£building£§Y$building_gas_extractors$§!建筑§G+1§!£job_gas_extractor£§Y气体采集§!岗位§!\n"
-  ring_giga_gas_hub_condition:0 "§R行星必须能支持至少一个£building£§Y$building_gas_extractors$§!建筑。§!"
+
+  sm_ring_giga_crystals_hub:99 "Laser Crystal Bore"
+  sm_ring_giga_crystals_hub_desc:99 "Immense laser drills cutting into the planet's crust to help planetside rare crystal mining. Other extracted materials supplement the crystal refining process.\n\n§TProvides §G+25§! £job_crystal_miner£ §YCrystal Mining§! Jobs per £district£ §Y$district_mining$§!.\n"
+  ring_giga_crystals_hub_condition:99 "§RPlanet must have deposits of £rare_crystals£ §Y$rare_crystals$.§!"
+
+  sm_ring_giga_motes_hub:99 "Hypersonic Mote Sifter"
+  sm_ring_giga_motes_hub_desc:99 "Powerful sonic emitters blast ultrasound waves into the atmosphere and towards mote harvesting sites, stirring up dust deserts with just the right frequency to bring plenty of Volatile Motes to the surface. Electromagnetic nets can also capture materials valuable to the mote refining process.\n\n§TProvides §G+25§! £job_mote_harvester£ §YMote Harvesting§! Job per £district£ §Y$district_generator$§!.\n"
+  ring_giga_motes_hub_condition:99 "§RPlanet must have deposits of £volatile_motes£ §Y$volatile_motes$.§!"
+
+  sm_ring_giga_gas_hub:99 "Atmospheric Gas Stabilizer"
+  sm_ring_giga_gas_hub_desc:99 "Chemical plants which inject stabilizing agents into the atmosphere near naturally-occurring gas deposits, making extraction safer and easier. As a side effect, local microbes can be more effectively utilised to refine gases from biomass.\n\n§TProvides §G+25§! £job_gas_extractor£ §YGas Extraction§! Jobs per £district£ §Y$district_farming$§!.\n"
+  ring_giga_gas_hub_condition:99 "§RPlanet must have deposits of £exotic_gases£ §Y$exotic_gases$.§!"
   
   sm_ring_giga_iodizium_hub:0 "场隔离网"
   sm_ring_giga_iodizium_hub_desc:0 "专用于解离素开采设施的场投射器，确保链式爆破反应控制在最低限度，显著提高了行星晶体处理效率。\n\n§T每有一个工作中的£building£§Y$building_giga_iodizium_mines$§!建筑§G+1§!£job_giga_iodizium_miner£§Y解离素开采§!岗位§!\n"

--- a/localisation/spanish/giga_l_spanish.yml
+++ b/localisation/spanish/giga_l_spanish.yml
@@ -17854,18 +17854,18 @@
   
   sm_orbital_ring_giga_farming_district:0 "Fertilizante de Suelo Planetario"
   sm_orbital_ring_giga_farming_district_desc:0 "Fábricas automatizadas producen grandes cantidades de fertilizante y los distribuyen a partes previamente inhóspitas de la superficie del planeta para permitir la agricultura.\n\n§YLa eficiencia es menor en Mundos Tumba y mayor en Mundos Gaia. No funciona en Mundos Desiertos Irradiados.§!\n"
-  
-  sm_ring_giga_crystals_hub:0 "Taladro de Cristal Láser"
-  sm_ring_giga_crystals_hub_desc:0 "Perforadoras láser inmensas cortando la corteza del planeta para ayudar a la minería de cristales raros en el planeta. Otros materiales extraídos complementan el proceso de refinamiento de cristales.\n\n§TProporciona §G+1§! £job_crystal_miner£ §YMinería de Cristales§! por cada £building£ §Y$building_crystal_mines$§! activo§!\n"
-  ring_giga_crystals_hub_condition:0 "§REl planeta debe ser capaz de soportar al menos un £building£ §Y$building_crystal_mines$§!.§!"
-  
-  sm_ring_giga_motes_hub:0 "Cernidor de Motes Hipersónico"
-  sm_ring_giga_motes_hub_desc:0 "Emisores sónicos potentes emiten ondas de ultrasonido hacia la atmósfera y hacia los sitios de recolección de motes, agitando desiertos de polvo con la frecuencia correcta para traer a la superficie una gran cantidad de Motes Volátiles. Las redes electromagnéticas también pueden capturar materiales valiosos para el proceso de refinamiento de motes.\n\n§TProporciona §G+1§! £job_mote_harvester£ §YRecolección de Motes§! por cada £building£ §Y$building_mote_harvesters$§! activo§!\n"
-  ring_giga_motes_hub_condition:0 "§REl planeta debe ser capaz de soportar al menos un £building£ §Y$building_mote_harvesters$§!.§!"
-  
-  sm_ring_giga_gas_hub:0 "Estabilizador de Gas Atmosférico"
-  sm_ring_giga_gas_hub_desc:0 "Plantas químicas que inyectan agentes estabilizadores en la atmósfera cerca de depósitos de gas naturales, haciendo la extracción más segura y fácil. Como efecto secundario, los microbios locales pueden ser utilizados más efectivamente para refinar gases a partir de biomasa.\n\n§TProporciona §G+1§! £job_gas_extractor£ §YExtracción de Gas§! por cada £building£ §Y$building_gas_extractors$§! activo§!\n"
-  ring_giga_gas_hub_condition:0 "§REl planeta debe ser capaz de soportar al menos un £building£ §Y$building_gas_extractors$§!.§!"
+
+  sm_ring_giga_crystals_hub:99 "Laser Crystal Bore"
+  sm_ring_giga_crystals_hub_desc:99 "Immense laser drills cutting into the planet's crust to help planetside rare crystal mining. Other extracted materials supplement the crystal refining process.\n\n§TProvides §G+25§! £job_crystal_miner£ §YCrystal Mining§! Jobs per £district£ §Y$district_mining$§!.\n"
+  ring_giga_crystals_hub_condition:99 "§RPlanet must have deposits of £rare_crystals£ §Y$rare_crystals$.§!"
+
+  sm_ring_giga_motes_hub:99 "Hypersonic Mote Sifter"
+  sm_ring_giga_motes_hub_desc:99 "Powerful sonic emitters blast ultrasound waves into the atmosphere and towards mote harvesting sites, stirring up dust deserts with just the right frequency to bring plenty of Volatile Motes to the surface. Electromagnetic nets can also capture materials valuable to the mote refining process.\n\n§TProvides §G+25§! £job_mote_harvester£ §YMote Harvesting§! Job per £district£ §Y$district_generator$§!.\n"
+  ring_giga_motes_hub_condition:99 "§RPlanet must have deposits of £volatile_motes£ §Y$volatile_motes$.§!"
+
+  sm_ring_giga_gas_hub:99 "Atmospheric Gas Stabilizer"
+  sm_ring_giga_gas_hub_desc:99 "Chemical plants which inject stabilizing agents into the atmosphere near naturally-occurring gas deposits, making extraction safer and easier. As a side effect, local microbes can be more effectively utilised to refine gases from biomass.\n\n§TProvides §G+25§! £job_gas_extractor£ §YGas Extraction§! Jobs per £district£ §Y$district_farming$§!.\n"
+  ring_giga_gas_hub_condition:99 "§RPlanet must have deposits of £exotic_gases£ §Y$exotic_gases$.§!"
   
   sm_ring_giga_iodizium_hub:0 "Red de Aislamiento de Campo"
   sm_ring_giga_iodizium_hub_desc:0 "Proyectores de escudos enfocados en instalaciones de minería de Iodizium aseguran que las reacciones en cadena explosivas se mantengan al mínimo, mejorando enormemente la eficiencia del manejo de cristales en el planeta.\n\n§TProporciona §G+1§! £job_giga_iodizium_miner£ §YMinería de Iodizium§! por cada £building£ §Y$building_giga_iodizium_mines$§! activo§!\n"


### PR DESCRIPTION
I'm targeting the correct branch this time

- Fixed job size deposit not buffing unity jobs
- Fixed alderson logistic districts providing enforcers for gestalts
- Fixed frameworld defense platform reactors appearing on other ship types
- Fixed orbital ring SR buildings not targeting the correct district type / fixed incorrect loc
- Fixed ringworld version of a maginot zone appearing non-ringworld maginots
- Added proper swaps to alderson unity zones
- Allowed urban buildings to be built in alderson logistical zones
- Fixed basic alderson housing zone not scaling based on number of districts