### PR TITLE
Fix hive using deprecated alloy jobs

### DIFF
--- a/common/buildings/giga_buildings.txt
+++ b/common/buildings/giga_buildings.txt
@@ -1316,16 +1316,7 @@ building_giga_pcc_scrap_pile = {
 	triggered_planet_modifier = {
 		potential = {
 			exists = owner
-			owner = { is_hive_empire = yes }
-		}
-		job_mining_drone_add = 600
-		job_alloy_drone_add = 200
-	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_machine_empire = yes }
+			owner = { is_gestalt = yes }
 		}
 		job_mining_drone_add = 600
 		job_fabricator_add = 200

--- a/common/buildings/giga_flusion_buildings.txt
+++ b/common/buildings/giga_flusion_buildings.txt
@@ -251,19 +251,7 @@ building_katzen_foundry = {
 		potential = {
 			exists = owner
 			owner = {
-				is_hive_empire = yes
-			}
-		}
-		modifier = {
-			job_alloy_drone_add = 800
-		}
-	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_machine_empire = yes
+				is_gestalt = yes
 			}
 		}
 		modifier = {

--- a/common/deposits/giga_birch_deposits.txt
+++ b/common/deposits/giga_birch_deposits.txt
@@ -1322,19 +1322,7 @@ d_giga_birch_expedition_4 = {
 			has_planet_flag = birch_expedition_4_complete
 			exists = owner
 			owner = { 
-				is_hive_empire = yes 
-				is_catalytic_empire = no
-			}
-		}
-		job_alloy_drone_add = 8
-	}
-	triggered_planet_modifier = {
-		potential = {
-			has_planet_flag = birch_expedition_4_alloys
-			has_planet_flag = birch_expedition_4_complete
-			exists = owner
-			owner = { 
-				is_machine_empire = yes 
+				is_gestalt = yes 
 				is_catalytic_empire = no
 			}
 		}


### PR DESCRIPTION
Currently hives are allotted alloy jobs via job_alloy_drone_add. That is deprecated and no longer in use, it seems. Now both gestalts need to get alloy jobs via job_fabricator_add. The job name is swapped depending on the empire.

job_alloy_drone_add produces duplicate jobs that cannot be worked as shown below:
<img width="869" height="369" alt="image" src="https://github.com/user-attachments/assets/29f9fdeb-9725-40f8-9cad-bbe6ef11896d" />
