### PR TITLE
(bugfixes) - do not cat the pie

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ tags={
     "Gameplay"
     "Megastructures"
 }
-supported_version="3.10.*"
+supported_version="v4.3.*"
 ```
 
 Change `supported_version` to whatever the newest stellaris version is if necessary. Place the .mod file in `Documents/Paradox Interactive/Stellaris/mod/`. That is *alongside* the Gigastructures folder with the mod content, not inside it. You will need "file extensions shown" enabled in windows to verify the proper file type.

--- a/common/button_effects/giga_button_effects.txt
+++ b/common/button_effects/giga_button_effects.txt
@@ -771,6 +771,11 @@ giga_presets_patreon_46 = { #abbreviatedcheese
     allow = { custom_tooltip = { fail_text = "must_not_have_started_game" NOT = { has_global_flag = giga_game_started } } }
     effect = { hidden_effect = { from = { giga_preset_patreon_46 = yes } } }
 }
+giga_presets_patreon_47 = { #bundil
+    potential = { exists = from from = { has_country_flag = giga_menu_page_presets_02 } }
+    allow = { custom_tooltip = { fail_text = "must_not_have_started_game" NOT = { has_global_flag = giga_game_started } } }
+    effect = { hidden_effect = { from = { giga_preset_patreon_47 = yes } } }
+}
 
 # FE Stuff
 giga_fe_megas_disabled = {

--- a/common/button_effects/giga_button_effects.txt
+++ b/common/button_effects/giga_button_effects.txt
@@ -736,10 +736,15 @@ giga_presets_patreon_41 = {
 }
 
 # page 2
-giga_presets_19 = { # im on page 2
+giga_presets_19 = { # im on page 2 # xahkarias
 	potential = { exists = from from = { has_country_flag = giga_menu_page_presets_02 } }
 	allow = { custom_tooltip = { fail_text = "must_not_have_started_game" NOT = { has_global_flag = giga_game_started } } }
 	effect = { hidden_effect = { from = { giga_preset_19 = yes } } }
+}
+giga_presets_20 = { # im on page 2 #caramel
+    potential = { exists = from from = { has_country_flag = giga_menu_page_presets_02 } }
+    allow = { custom_tooltip = { fail_text = "must_not_have_started_game" NOT = { has_global_flag = giga_game_started } } }
+    effect = { hidden_effect = { from = { giga_preset_20 = yes } } }
 }
 giga_presets_patreon_42 = {
 	potential = { exists = from from = { has_country_flag = giga_menu_page_presets_02 } }

--- a/common/scripted_effects/giga_menu_effects.txt
+++ b/common/scripted_effects/giga_menu_effects.txt
@@ -3194,6 +3194,7 @@ giga_preset_arcade = {
 		set_global_flag = ehof_ai_capped_1
 		set_global_flag = giga_core_shuffle
 		set_global_flag = giga_galactic_fed_shuffle
+        set_global_flag = compound_disabled # THE KING STAYS DEAD
 		event_target:global_event_country = {
 			set_variable = { #For mega output
 				which = giga_mega_output

--- a/common/scripted_effects/giga_menu_effects.txt
+++ b/common/scripted_effects/giga_menu_effects.txt
@@ -4822,7 +4822,7 @@ giga_preset_14 = {
 }
 
  # piecat
- giga_preset_17 = {
+giga_preset_17 = {
 	remove_all_menu_flags = yes
 	set_global_flag = giga_rings_gar
 	set_global_flag = vanilla_dyson_capped_3
@@ -8948,7 +8948,7 @@ giga_preset_patreon_34 = {
 	}
 }
 
- # Fishum
+# Fishum
 giga_preset_patreon_35 = {
 	remove_all_menu_flags = yes
 	set_global_flag = giga_blokkats_easy
@@ -9041,6 +9041,7 @@ giga_preset_patreon_35 = {
 		}
 	}
  }
+#Aeryn
 giga_preset_patreon_36 = {
 	remove_all_menu_flags = yes
 	remove_flags_buildcap = yes
@@ -9651,6 +9652,7 @@ giga_preset_patreon_41 = {
 	}
 }
 
+#Jin2188
 giga_preset_patreon_42 = {
 	remove_all_menu_flags = yes
 	remove_flags_buildcap = yes
@@ -10213,6 +10215,116 @@ giga_preset_patreon_46 = {
         set_variable = { which = giga_mega_output_ai value = 100  }
         set_variable = { which = giga_mega_cost value = 100  }
         set_variable = { which = giga_mega_cost_ai value = 100  }
+        set_variable = { which = giga_mega_upkeep value = 100  }
+        set_variable = { which = giga_mega_upkeep_ai value = 100  }
+    }
+}
+
+#bundil
+giga_preset_patreon_47 = {
+    remove_all_menu_flags = yes
+    remove_all_menu_flags = yes
+    set_global_flag = giga_achievements_disabled
+    #No flag for O class stars found! O class stars enabled!
+    set_global_flag = giga_dyson_scaling
+    set_global_flag = giga_lifter_scaling
+    set_global_flag = giga_matroishka_scaling
+    set_global_flag = giga_buildcap_j
+    set_global_flag = giga_disable_influence_upkeep
+    #No flag for planet bulking found! Planet bulking enabled!
+    #No flag for bulk matter cost found! Bulk matter cost enabled!
+    #No flag for Attack moon printer found! Attack moon printer enabled!
+    #No flag for Attack planet printer found! Attack planet printer enabled!
+    #No flag for Wrecked warhips found! Wrecked warships enabled!
+    set_global_flag = giga_core_shuffle
+    #No flag for Jublio found! Jublio enabled!
+    #No flag for Jupitwo found! Jupitwo enabled!
+    #No flag for Faust found! Faust enabled!
+    #No flag for Tyaur found! Tyaur enabled!
+    #No flag for Squareworld found! Squareworld enabled!
+    #No flag for Kerbol found! Kerbol enabled!
+    #No flag found for Gatzo! Gatzo enabled!
+    #No flag for Ehof found! Ehof enabled!
+    set_global_flag = ehof_ai_disabled
+    set_global_flag = compound_disabled
+    set_global_flag = giga_fe_planetcrafts_1
+    #No flag for Katzenartig portraits set! Setting default!
+    set_global_flag = katzenartig_disabled
+    set_global_flag = giga_eawaf_sirens_disabled
+    set_global_flag = giga_core_aeternum_2
+    #No flag for Blokkat Portraits found! Setting default!
+    set_global_flag = giga_blokkats_disabled
+    #No flag for Blokkat spawn guarantee found! Blokkat spawn guarantee disab
+    set_global_flag = vanilla_dyson_capped_3
+    set_global_flag = vanilla_dyson_swarm_capped_u
+    #No flag to disable swarm replacement found! Dyson Swarm Replacement Enab
+    set_global_flag = vanilla_interstellar_capped_3
+    set_global_flag = vanilla_matter_capped_u
+    set_global_flag = vanilla_art_capped_3
+    set_global_flag = vanilla_shipyard_capped_3
+    set_global_flag = vanilla_ringworld_capped_3
+    set_global_flag = vanilla_nexus_capped_3
+    set_global_flag = vanilla_strategic_capped_3
+    set_global_flag = vanilla_furnace_capped_u
+    set_global_flag = vanilla_array_capped_1
+    set_global_flag = giga_rings_gar
+    set_global_flag = upgrade_capped_u
+    set_global_flag = alderson_capped_1
+    set_global_flag = birch_capped_1
+    set_global_flag = shipyard_capped_u
+    set_global_flag = stellarhabitat_capped_3
+    set_global_flag = maginot_capped_u
+    set_global_flag = planetary_computer_capped_3
+    set_global_flag = asteroid_artillery_capped_u
+    set_global_flag = asteroid_manufactory_capped_u
+    set_global_flag = megabase_capped_u
+    set_global_flag = orbital_artificial_eco_capped_u
+    set_global_flag = storm_observatory_capped_u
+    set_global_flag = succ_capped_u
+    set_global_flag = drill_capped_u
+    set_global_flag = crystal_capped_u
+    set_global_flag = kugel_capped_u
+    set_global_flag = planetary_seeder_nexus_capped_u
+    set_global_flag = psychic_beacon_capped_1
+    set_global_flag = the_vat_capped_3
+    set_global_flag = suppressor_capped_u
+    set_global_flag = disco_moon_capped_3
+    set_global_flag = gigaforge_capped_3
+    set_global_flag = orbital_arcologies_capped_u
+    set_global_flag = orbital_naval_logistics_capped_u
+    set_global_flag = siphon_capped_u
+    set_global_flag = lifters_capped_u
+    set_global_flag = orchid_capped_u
+    set_global_flag = planetshipyard_capped_u
+    set_global_flag = hraemc_capped_u
+    set_global_flag = hyperstructural_ass_capped_1
+    set_global_flag = matrioshka_brain_capped_1
+    set_global_flag = ndb_capped_1
+    set_global_flag = nidavellir_capped_1
+    set_global_flag = giga_galactic_fed_shuffle
+    set_global_flag = quasistellar_capped_1
+    set_global_flag = penrose_sphere_capped_u
+    set_global_flag = supermassive_ehof_capped_1
+    set_global_flag = warmoon_capped_u
+    set_global_flag = warplanet_capped_1
+    set_global_flag = systemcraft_disabled
+    set_global_flag = terraform_toxic_capped_u
+    set_global_flag = terraform_barren_capped_u
+    set_global_flag = geothermal_capped_u
+    set_global_flag = glue_capped_u
+    set_global_flag = terraform_gasgiant_capped_u
+    set_global_flag = compressor_capped_u
+    event_target:global_event_country = {
+        set_variable = { which = giga_ruined_warships_perc value = 500 }
+        set_variable = { which = giga_ruined_warships_perc_colossi value = 100 }
+        set_variable = { which = giga_ruined_warships_perc_juggs value = 100 }
+        set_variable = { which = giga_ruined_warships_perc_titan value = 100 }
+        set_variable = { which = giga_ruined_warships_perc_battle value = 100 }
+        set_variable = { which = blokkat_spawn_date value = 2500  }
+        set_variable = { which = giga_mega_output value = 100  }
+        set_variable = { which = giga_mega_output_ai value = 100  }
+        set_variable = { which = giga_mega_cost value = 100  }
+        set_variable = { which = giga_mega_cost_ai value = 50  }
         set_variable = { which = giga_mega_upkeep value = 100  }
         set_variable = { which = giga_mega_upkeep_ai value = 100  }
     }

--- a/common/scripted_effects/giga_menu_effects.txt
+++ b/common/scripted_effects/giga_menu_effects.txt
@@ -5205,6 +5205,114 @@ giga_preset_19 = {
 	}
 }
 
+# Caramel146
+giga_preset_20 = {
+    remove_all_menu_flags = yes
+    set_global_flag = giga_achievements_disabled
+    #No flag for O class stars found! O class stars enabled!
+    set_global_flag = giga_dyson_scaling
+    set_global_flag = giga_lifter_scaling
+    set_global_flag = giga_matroishka_scaling
+    set_global_flag = giga_buildcap_j
+    #No flag for Influence upkeep found! Influence upkeep enabled!
+    set_global_flag = giga_planet_bulking_disabled
+    #No flag for bulk matter cost found! Bulk matter cost enabled!
+    #No flag for Attack moon printer found! Attack moon printer enabled!
+    set_global_flag = giga_celestial_printing_planet_disabled
+    #No flag for Wrecked warhips found! Wrecked warships enabled!
+    set_global_flag = giga_core_always_empty
+    #No flag for Jublio found! Jublio enabled!
+    #No flag for Jupitwo found! Jupitwo enabled!
+    #No flag for Faust found! Faust enabled!
+    #No flag for Tyaur found! Tyaur enabled!
+    #No flag for Squareworld found! Squareworld enabled!
+    #No flag for Kerbol found! Kerbol enabled!
+    #No flag found for Gatzo! Gatzo enabled!
+    set_global_flag = ehof_disabled
+    set_global_flag = ehof_ai_disabled
+    set_global_flag = compound_disabled
+    set_global_flag = giga_fe_planetcrafts_0
+    #No flag for Katzenartig portraits set! Setting default!
+    set_global_flag = katzenartig_disabled
+    set_global_flag = giga_eawaf_sirens_disabled
+    set_global_flag = giga_core_aeternum_2
+    #No flag for Blokkat Portraits found! Setting default!
+    set_global_flag = giga_blokkats_disabled
+    #No flag for Blokkat spawn guarantee found! Blokkat spawn guarantee disab
+    set_global_flag = vanilla_dyson_capped_1
+    set_global_flag = vanilla_dyson_swarm_capped_3
+    #No flag to disable swarm replacement found! Dyson Swarm Replacement Enab
+    set_global_flag = vanilla_interstellar_capped_1
+    set_global_flag = vanilla_matter_capped_1
+    set_global_flag = vanilla_art_capped_1
+    set_global_flag = vanilla_shipyard_capped_1
+    set_global_flag = vanilla_ringworld_capped_u
+    set_global_flag = vanilla_nexus_capped_1
+    set_global_flag = vanilla_strategic_capped_1
+    set_global_flag = vanilla_furnace_capped_3
+    set_global_flag = vanilla_array_capped_1
+    set_global_flag = giga_rings_gar
+    set_global_flag = upgrade_disabled
+    set_global_flag = alderson_capped_1
+    set_global_flag = birch_capped_1
+    set_global_flag = shipyard_capped_u
+    set_global_flag = stellarhabitat_capped_1
+    set_global_flag = maginot_capped_1
+    set_global_flag = planetary_computer_capped_u
+    set_global_flag = asteroid_artillery_capped_u
+    set_global_flag = asteroid_manufactory_capped_u
+    set_global_flag = megabase_capped_1
+    set_global_flag = orbital_artificial_eco_capped_1
+    set_global_flag = storm_observatory_capped_1
+    set_global_flag = succ_capped_1
+    set_global_flag = drill_capped_1
+    set_global_flag = crystal_capped_1
+    set_global_flag = kugel_capped_1
+    set_global_flag = planetary_seeder_nexus_capped_1
+    set_global_flag = psychic_beacon_capped_1
+    set_global_flag = the_vat_capped_1
+    set_global_flag = suppressor_capped_u
+    set_global_flag = disco_moon_capped_1
+    set_global_flag = gigaforge_capped_1
+    set_global_flag = orbital_arcologies_disabled
+    set_global_flag = orbital_naval_logistics_capped_1
+    set_global_flag = siphon_capped_1
+    set_global_flag = lifters_disabled
+    set_global_flag = orchid_capped_1
+    set_global_flag = planetshipyard_capped_u
+    set_global_flag = hraemc_capped_1
+    set_global_flag = hyperstructural_ass_disabled
+    set_global_flag = matrioshka_brain_capped_1
+    set_global_flag = ndb_disabled
+    set_global_flag = nidavellir_capped_1
+    set_global_flag = giga_galactic_fed_shuffle
+    set_global_flag = quasistellar_capped_1
+    set_global_flag = penrose_sphere_capped_1
+    set_global_flag = supermassive_ehof_capped_1
+    set_global_flag = warmoon_capped_3
+    set_global_flag = warplanet_disabled
+    set_global_flag = systemcraft_disabled
+    set_global_flag = terraform_toxic_capped_u
+    set_global_flag = terraform_barren_capped_u
+    set_global_flag = geothermal_capped_u
+    set_global_flag = glue_capped_u
+    set_global_flag = terraform_gasgiant_capped_u
+    set_global_flag = compressor_capped_u
+    event_target:global_event_country = {
+        set_variable = { which = giga_ruined_warships_perc value = 50 }
+        set_variable = { which = giga_ruined_warships_perc_colossi value = 100 }
+        set_variable = { which = giga_ruined_warships_perc_juggs value = 100 }
+        set_variable = { which = giga_ruined_warships_perc_titan value = 100 }
+        set_variable = { which = giga_ruined_warships_perc_battle value = 100 }
+        set_variable = { which = blokkat_spawn_date value = 2500  }
+        set_variable = { which = giga_mega_output value = 100  }
+        set_variable = { which = giga_mega_output_ai value = 100  }
+        set_variable = { which = giga_mega_cost value = 100  }
+        set_variable = { which = giga_mega_cost_ai value = 50  }
+        set_variable = { which = giga_mega_upkeep value = 100  }
+        set_variable = { which = giga_mega_upkeep_ai value = 100  }
+    }
+}
 
 # ASpec
 giga_preset_patreon_01 = {

--- a/common/special_projects/giga_eawaf_projects.txt
+++ b/common/special_projects/giga_eawaf_projects.txt
@@ -49,10 +49,18 @@ special_project = {
 						add = 40
 						has_tradition = tr_psionics_breach_shroud
 					}
+                    modifier = {
+                        add = 40
+                        has_tradition = tr_psionics_shroud_great_awakening
+                    }
 					modifier = {
 						add = 15
 						has_tradition = tr_psionics_finish
 					}
+                    modifier = {
+                        add = 15
+                        has_tradition = tr_psionics_shroud_finish
+                    }
 				}
 				95 = {
 					country_event = { id = giga_eawaf.10172 }
@@ -64,10 +72,18 @@ special_project = {
 						add = -40
 						has_tradition = tr_psionics_breach_shroud
 					}
+                    modifier = {
+                        add = -40
+                        has_tradition = tr_psionics_shroud_great_awakening
+                    }
 					modifier = {
 						add = -15
 						has_tradition = tr_psionics_finish
 					}
+                    modifier = {
+                        add = -15
+                        has_tradition = tr_psionics_shroud_finish
+                    }
 				}
 				
 			}

--- a/common/starbase_buildings/giga_starbase_buildings.txt
+++ b/common/starbase_buildings/giga_starbase_buildings.txt
@@ -70,13 +70,14 @@ hyperstructural_shipyard_uplink = {
 		custom_tooltip = { fail_text = "already_have_ass_uplink"	NOT = { has_starbase_building = hyperstructural_shipyard_uplink } }
 		custom_tooltip = {
 			fail_text = "requires_shipyard"
-			OR = {
-				has_starbase_module = shipyard
-				has_starbase_module = acot_starbase_shipyard
-				has_starbase_module = acot_sigma_starbase_shipyard
-				has_starbase_module = acot_phanon_starbase_shipyard
-				has_starbase_module = acot_theta_starbase_shipyard
-			}
+            OR = {
+                has_starbase_module = shipyard
+                has_starbase_module = acot_spaceport_module_shipyard
+                has_starbase_module = acot_precursor_starbase_shipyard
+                has_starbase_module = acot_sigma_starbase_shipyard
+                has_starbase_module = acot_phanon_starbase_shipyard
+                has_starbase_module = acot_theta_starbase_shipyard
+            }
 		}
 	}
 
@@ -112,13 +113,14 @@ equatorial_shipyard_uplink = {
 		}
 		custom_tooltip = {
 			fail_text = "requires_shipyard"
-			OR = {
-				has_starbase_module = shipyard
-				has_starbase_module = acot_starbase_shipyard
-				has_starbase_module = acot_sigma_starbase_shipyard
-				has_starbase_module = acot_phanon_starbase_shipyard
-				has_starbase_module = acot_theta_starbase_shipyard
-			}
+            OR = {
+                has_starbase_module = shipyard
+                has_starbase_module = acot_spaceport_module_shipyard
+                has_starbase_module = acot_precursor_starbase_shipyard
+                has_starbase_module = acot_sigma_starbase_shipyard
+                has_starbase_module = acot_phanon_starbase_shipyard
+                has_starbase_module = acot_theta_starbase_shipyard
+            }
 		}
 		custom_tooltip = { fail_text = "already_have_eq_uplink"		NOT = { has_starbase_building = equatorial_shipyard_uplink } }
 	}
@@ -167,13 +169,14 @@ planetary_drive_yard_uplink = {
 		}
 		custom_tooltip = {
 			fail_text = "requires_shipyard"
-			OR = {
-				has_starbase_module = shipyard
-				has_starbase_module = acot_starbase_shipyard
-				has_starbase_module = acot_sigma_starbase_shipyard
-				has_starbase_module = acot_phanon_starbase_shipyard
-				has_starbase_module = acot_theta_starbase_shipyard
-			}
+            OR = {
+                has_starbase_module = shipyard
+                has_starbase_module = acot_spaceport_module_shipyard
+                has_starbase_module = acot_precursor_starbase_shipyard
+                has_starbase_module = acot_sigma_starbase_shipyard
+                has_starbase_module = acot_phanon_starbase_shipyard
+                has_starbase_module = acot_theta_starbase_shipyard
+            }
 		}
 		custom_tooltip = { fail_text = "already_have_pd_uplink"		NOT = { has_starbase_building = planetary_drive_yard_uplink } }
 	}

--- a/common/static_modifiers/giga_birch_static_modifiers.txt
+++ b/common/static_modifiers/giga_birch_static_modifiers.txt
@@ -60,8 +60,9 @@ giga_birch_physma_jobs_bonus_workforce_mult = {
 	researcher_jobs_bonus_workforce_mult = 1
 	bureaucrat_jobs_bonus_workforce_mult = 1
 	giga_soldier_jobs_bonus_workforce_mult = 1
-	#pop_bio_trophy_bonus_workforce_mult = 1
-        # stop the efficiency loop for now
+    planet_bio_trophies_unity_produces_mult = 0.5
+    planet_bio_trophies_upkeep_mult = 0.5
+        # keeps efficiency from looping
 
 	pop_giga_birch_physma_worker_bonus_workforce_mult = 1
 	pop_giga_birch_physma_worker_drone_bonus_workforce_mult = 1

--- a/interface/giga_gui_main_menu.gui
+++ b/interface/giga_gui_main_menu.gui
@@ -4319,7 +4319,7 @@ guiTypes = {
                 ####################################
                 containerWindowType = {
                     name = "presets_patreon_46_options"
-                    position = { x = -412 y = -95 }
+                    position = { x = -412 y = -55 }
                     size = { width = 410 height = 34 }
                     orientation = upper_left
 
@@ -4343,6 +4343,38 @@ guiTypes = {
                         text = "Enable Preset"
                         clicksound = interface
                         effect = "giga_presets_patreon_46"
+                    }
+                }
+
+                ####################################
+                ### presets_47 #####################
+                ####################################
+                containerWindowType = {
+                    name = "presets_patreon_47_options"
+                    position = { x = -412 y = -15 }
+                    size = { width = 410 height = 34 }
+                    orientation = upper_left
+
+                    effectButtonType = {
+                        name = "background_presets_patreon_47"
+                        spriteType = "GFX_giga_menu_button_bg"
+                        position = { x = 0 y = 0 }
+                        format = left
+                        no_clicksound = yes
+                        borderSize = { x = 10 y = 0 }
+                        font = "cg_16b"
+                        text = "giga_menu_presets_patreon_47"
+                        effect = "giga_page_presets_02"
+                    }
+
+                    effectButtonType = {
+                        name = "presets_patreon_47_button"
+                        spriteType = "GFX_button_116_24"
+                        position = { x = 277 y = -7 }
+                        font = "cg_16b"
+                        text = "Enable Preset"
+                        clicksound = interface
+                        effect = "giga_presets_patreon_47"
                     }
                 }
 

--- a/interface/giga_gui_main_menu.gui
+++ b/interface/giga_gui_main_menu.gui
@@ -4123,7 +4123,7 @@ guiTypes = {
 
 				
 				####################################
-				### presets_19 #####################
+				### dev presets_19 #####################
 				####################################
 				containerWindowType = {
 					name = "presets_19_options"
@@ -4154,12 +4154,44 @@ guiTypes = {
 					}
 				}
 
+                ####################################
+                ### dev presets_20 #####################
+                ####################################
+                containerWindowType = {
+                    name = "presets_20_options"
+                    position = { x = -412 y = -255 }
+                    size = { width = 410 height = 34 }
+                    orientation = upper_left
+
+                    effectButtonType = {
+                        name = "background_presets_20"
+                        spriteType = "GFX_giga_menu_button_bg"
+                        position = { x = 0 y = 0 }
+                        format = left
+                        no_clicksound = yes
+                        borderSize = { x = 10 y = 0 }
+                        font = "cg_16b"
+                        text = "giga_menu_presets_20"
+                        effect = "giga_page_presets_02"
+                    }
+
+                    effectButtonType = {
+                        name = "presets_19_button"
+                        spriteType = "GFX_button_116_24"
+                        position = { x = 277 y = -7 }
+                        font = "cg_16b"
+                        text = "Enable Preset"
+                        clicksound = interface
+                        effect = "giga_presets_20"
+                    }
+                }
+
 				####################################
 				### presets_42 #####################
 				####################################
 				containerWindowType = {
 					name = "presets_patreon_42_options"
-					position = { x = -412 y = -255 }
+					position = { x = -412 y = -215 }
 					size = { width = 410 height = 34 }
 					orientation = upper_left
 
@@ -4191,7 +4223,7 @@ guiTypes = {
 				####################################
 				containerWindowType = {
 					name = "presets_patreon_43_options"
-					position = { x = -412 y = -215 }
+					position = { x = -412 y = -175 }
 					size = { width = 410 height = 34 }
 					orientation = upper_left
 
@@ -4223,7 +4255,7 @@ guiTypes = {
 				####################################
 				containerWindowType = {
 					name = "presets_patreon_44_options"
-					position = { x = -412 y = -175 }
+					position = { x = -412 y = -135 }
 					size = { width = 410 height = 34 }
 					orientation = upper_left
 
@@ -4255,7 +4287,7 @@ guiTypes = {
                 ####################################
                 containerWindowType = {
                     name = "presets_patreon_45_options"
-                    position = { x = -412 y = -135 }
+                    position = { x = -412 y = -95 }
                     size = { width = 410 height = 34 }
                     orientation = upper_left
 

--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -1253,6 +1253,7 @@
   giga_menu_presets_patreon_33:0 "Contributor: §LLucy§!"
   giga_menu_presets_18:0 "Contributor: §LTempest§!"
   giga_menu_presets_19:0 "Contributor: §LXahkarias§!"
+  giga_menu_presets_20:0 "Contributor: §LCaramel146§!"
 
     giga_menu_presets_patreon_01:0 "Patreon: §MASpec§!"
     giga_menu_presets_patreon_02:0 "Patreon: §MArnieKuma§!"

--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -1300,6 +1300,7 @@
     giga_menu_presets_patreon_44:0 "Patreon: §MLucy§!"
     giga_menu_presets_patreon_45:0 "Patreon: §MBlue Lobster§!"
     giga_menu_presets_patreon_46:0 "Patreon: §Mabbreviatedcheese§!"
+    giga_menu_presets_patreon_47:0 "Patreon: §Mbundil§!"
 
     giga_menu_presets_other_01:0 "Competition Winner: §HThe_Strateg1st§!"
 

--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -1253,7 +1253,7 @@
   giga_menu_presets_patreon_33:0 "Contributor: §LLucy§!"
   giga_menu_presets_18:0 "Contributor: §LTempest§!"
   giga_menu_presets_19:0 "Contributor: §LXahkarias§!"
-  giga_menu_presets_20:0 "Contributor: §LCaramel146§!"
+  giga_menu_presets_20:0 "Contributor: §LCaramel§!"
 
     giga_menu_presets_patreon_01:0 "Patreon: §MASpec§!"
     giga_menu_presets_patreon_02:0 "Patreon: §MArnieKuma§!"


### PR DESCRIPTION
Accumulating bugfixes, dont merge until steam push:

- Updated acot starbase references to match new ids
- Disabled (again) the compound in the arcade preset
- Physma managers give biotrophies unity produces and upkeep multiplies at half strength (compared to normal efficiency buff)
- Fixed a Sirens project not checking for Secrets of the Shroud psionic tradition tree
- Added Caramel146 dev preset / bundil patreon preset