### PR TITLE
Wildermaginot

### DIFF
--- a/common/buildings/giga_maginot_buildings.txt
+++ b/common/buildings/giga_maginot_buildings.txt
@@ -46,23 +46,9 @@ building_giga_maginot_stronghold = {
 		army_collateral_damage_mult = -0.05
 	}
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		modifier = {
-			job_maginot_bunker_officer_add = 100
-		}
-	}
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		modifier = {
-			job_maginot_bunker_officer_gestalt_add = 100
-		}
+	inline_script = {
+		script = jobs/maginot_bunker_officer_add
+		AMOUNT = 100
 	}
 
 	resources = {
@@ -144,23 +130,9 @@ building_giga_maginot_global_bunker = {
 		army_collateral_damage_mult = -0.15
 	}
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		modifier = {
-			job_maginot_bunker_officer_add = 100
-		}
-	}
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		modifier = {
-			job_maginot_bunker_officer_gestalt_add = 100
-		}
+	inline_script = {
+		script = jobs/maginot_bunker_officer_add
+		AMOUNT = 100
 	}
 
 	resources = {

--- a/common/deposits/maginot_planetary_deposits.txt
+++ b/common/deposits/maginot_planetary_deposits.txt
@@ -18,19 +18,9 @@ d_maginot_command = { # the central, deepest command bunkers including antimatte
 	}
 
 	# central command job
-	triggered_planet_modifier = {
-		potential = { 
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		job_maginot_central_command_add = 100
-	}
-	triggered_planet_modifier = {
-		potential = { 
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		job_maginot_central_command_gestalt_add = 100
+	inline_script = {
+		script = jobs/maginot_central_command_add
+		AMOUNT = 100
 	}
 	
 	# upkeep

--- a/common/districts/giga_maginot_districts.txt
+++ b/common/districts/giga_maginot_districts.txt
@@ -19,12 +19,21 @@ district_maginot_world_barracks = {
 		slot_maginot_barracks_02
 	}
 
+	conversion_ratio = 1
+	convert_to = {
+		district_maginot_world_barracks_wilderness
+	}
+
 	show_on_uncolonized = {
 		uses_district_set = maginot_world_districts
+		exists = from
+		from = { is_wilderness_empire = no }
 	}
 
 	potential = {
 		uses_district_set = maginot_world_districts
+		exists = owner
+		owner = { is_wilderness_empire = no }
 	}
 
 	allow = {
@@ -102,8 +111,159 @@ district_maginot_world_barracks = {
 			owner = { is_bugged_rooftop_farmers = yes }
 		}
 		modifier = {
-			job_clerk_add = -1
-			job_farmer_add = 1
+			job_clerk_add = -100
+			job_farmer_add = 100
+		}
+	}
+
+
+	# planet housing and additions
+
+	planet_modifier = {
+		planet_housing_add = @maginot_district_housing_barracks
+		planet_amenities_add = @maginot_district_amenities_barracks
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			exists = owner
+			owner = { has_active_tradition = tr_prosperity_public_works }
+		}
+		modifier = {
+			planet_housing_add = @maginot_district_housing_buffs
+		}
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			exists = owner
+			owner = {
+				has_technology = tech_housing_1
+			}
+		}
+		modifier = {
+			planet_housing_add = @maginot_district_housing_buffs
+		}
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			exists = owner
+			owner = {
+				has_technology = tech_housing_2
+				NOT = { has_valid_civic = civic_agrarian_idyll }
+			}
+		}
+		modifier = {
+			planet_housing_add = @maginot_district_housing_buffs
+		}
+	}
+
+	# AI weight
+
+	ai_weight = {
+		weight = 0
+		modifier = {
+			weight = 500
+			free_housing < 5
+		}
+		modifier = {
+			weight = 500
+			free_amenities < 5
+		}
+	}
+}
+district_maginot_world_barracks_wilderness = {
+	icon = district_maginot_world_barracks
+	base_buildtime = @maginot_district_buildtime
+	is_capped_by_modifier = no
+	exempt_from_ai_planet_specialization = yes
+	district_background = district_city
+	gridbox = district_city
+	zone_slots = {
+		slot_city_government
+		slot_maginot_barracks_01
+		slot_maginot_barracks_02
+	}
+
+	conversion_ratio = 1
+	convert_to = {
+		district_maginot_world_barracks
+	}
+
+	show_on_uncolonized = {
+		uses_district_set = maginot_world_districts
+		exists = from
+		from = { is_wilderness_empire = yes }
+	}
+
+	potential = {
+		uses_district_set = maginot_world_districts
+		exists = owner
+		owner = { is_wilderness_empire = yes }
+	}
+
+	allow = {
+	}
+
+	resources = {
+		category = planet_districts
+		cost = {
+			minerals = @maginot_district_cost_minerals
+			alloys = @maginot_district_cost_alloys_cheap
+			rare_crystals = @maginot_district_cost_sr
+		}
+		upkeep = {
+			energy = @maginot_district_upkeep_energy_barracks
+			rare_crystals = @maginot_district_upkeep_sr
+		}
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			always = yes
+		}
+		modifier = {
+			job_coordinator_add = @maginot_entertainer_filler_jobs_add
+			job_patrol_drone_add = @maginot_barracks_police_jobs_add
+		}
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			exists = owner
+			owner = {
+				has_active_tradition = tr_virtuality_4
+			}
+		}
+		modifier = {
+			job_coordinator_add = 200
+		}
+	}
+
+	# extra jobs from tradition/tech
+	triggered_planet_modifier = {
+		potential = {
+			exists = owner
+			owner = {
+				has_technology = tech_housing_2
+				is_gestalt = yes
+			}
+		}
+		modifier = {
+			job_maintenance_drone_add = @maginot_entertainer_filler_jobs_buff #mostly obsolete but helps virtuality
+		}
+	}
+
+	# Bug Branch
+	triggered_planet_modifier = {
+		potential = {
+			exists = owner
+			owner = { is_bugged_rooftop_farmers = yes }
+		}
+		modifier = {
+			job_clerk_add = -100
+			job_farmer_add = 100
 		}
 	}
 
@@ -173,9 +333,16 @@ district_maginot_world_shield_generators = {
 	district_background = district_arcology_research_physics
 	show_on_uncolonized = {
 		uses_district_set = maginot_world_districts
+		exists = from
+		from = { is_wilderness_empire = no }
 	}
 	zone_slots = {
 		slot_maginot_shield_generators
+	}
+
+	conversion_ratio = 1
+	convert_to = {
+		district_maginot_world_shield_generators_wilderness
 	}
 
 	allow = {
@@ -183,6 +350,77 @@ district_maginot_world_shield_generators = {
 
 	potential = {
 		uses_district_set = maginot_world_districts
+		exists = owner
+		owner = { is_wilderness_empire = no }
+	}
+
+	resources = {
+		category = planet_districts
+		cost = {
+			minerals = @maginot_district_cost_minerals
+			alloys = @maginot_district_cost_alloys_medium
+			exotic_gases = @maginot_district_cost_sr
+		}
+		upkeep = {
+			energy = @maginot_district_upkeep_energy_shields
+			exotic_gases = @maginot_district_upkeep_sr
+		}
+	}
+
+	on_built = {
+		maginot_check_upgrade_points = yes
+	}
+
+	inline_script = {
+		script = jobs/maginot_shield_generator_operator_add
+		AMOUNT = @maginot_special_jobs_add
+	}
+
+	triggered_desc = {
+		trigger = { exists = owner }
+		text = job_maginot_planetary_shield_effect_desc
+	}
+
+	inline_script = {
+		script = districts/maginot/maginot_triggered_names_shield_generators
+	}
+
+	planet_modifier = {
+		planet_orbital_bombardment_damage = -0.05 # yes these are spammable to 100% and beyond, intentional
+		army_collateral_damage_mult = -0.1 # stuff on the planet is protected by shields from damage
+	}
+
+	ai_weight = {
+		weight = 33
+	}
+}
+district_maginot_world_shield_generators_wilderness = {
+	icon = district_maginot_world_shield_generators
+	base_buildtime = @maginot_district_buildtime
+	is_capped_by_modifier = no
+	gridbox = district_arcology_administrative
+	district_background = district_arcology_research_physics
+	show_on_uncolonized = {
+		uses_district_set = maginot_world_districts
+		exists = from
+		from = { is_wilderness_empire = yes }
+	}
+	zone_slots = {
+		slot_maginot_shield_generators
+	}
+
+	conversion_ratio = 1
+	convert_to = {
+		district_maginot_world_shield_generators
+	}
+
+	allow = {
+	}
+
+	potential = {
+		uses_district_set = maginot_world_districts
+		exists = owner
+		owner = { is_wilderness_empire = yes }
 	}
 
 	resources = {
@@ -233,10 +471,17 @@ district_maginot_world_planetary_cannons = {
 	district_background = district_arcology_administrative
 	show_on_uncolonized = {
 		uses_district_set = maginot_world_districts
+		exists = from
+		from = { is_wilderness_empire = no }
 	}
 
 	zone_slots = {
 		slot_maginot_orbital_defense_grid
+	}
+
+	conversion_ratio = 1
+	convert_to = {
+		district_maginot_world_planetary_cannons_wilderness
 	}
 
 	allow = {
@@ -244,6 +489,71 @@ district_maginot_world_planetary_cannons = {
 
 	potential = {
 		uses_district_set = maginot_world_districts
+		exists = owner
+		owner = { is_wilderness_empire = no }
+	}
+
+	resources = {
+		category = planet_districts
+		cost = {
+			minerals = @maginot_district_cost_minerals
+			alloys = @maginot_district_cost_alloys_expensive
+		}
+		upkeep = {
+			energy = @maginot_district_upkeep_energy_medium
+			alloys = @maginot_district_upkeep_alloys
+		}
+	}
+
+	on_built = {
+		maginot_check_upgrade_points = yes
+	}
+
+	inline_script = {
+		script = jobs/maginot_planetary_cannon_operator_add
+		AMOUNT = @maginot_special_jobs_add
+	}
+
+	triggered_desc = {
+		trigger = { exists = owner }
+		text = job_maginot_planetary_artillery_effect_desc
+	}
+
+	inline_script = {
+		script = districts/maginot/maginot_triggered_names_defense_grids
+	}
+
+	ai_weight = {
+		weight = 33
+	}
+}
+district_maginot_world_planetary_cannons_wilderness = {
+	icon = district_maginot_world_planetary_cannons
+	base_buildtime = @maginot_district_buildtime
+	is_capped_by_modifier = no
+	district_background = district_arcology_administrative
+	show_on_uncolonized = {
+		uses_district_set = maginot_world_districts
+		exists = from
+		from = { is_wilderness_empire = yes }
+	}
+
+	zone_slots = {
+		slot_maginot_orbital_defense_grid
+	}
+
+	conversion_ratio = 1
+	convert_to = {
+		district_maginot_world_planetary_cannons
+	}
+
+	allow = {
+	}
+
+	potential = {
+		uses_district_set = maginot_world_districts
+		exists = owner
+		owner = { is_wilderness_empire = yes }
 	}
 
 	resources = {
@@ -290,9 +600,16 @@ district_maginot_world_bunkers = {
 	show_on_uncolonized = {
 		uses_district_set = maginot_world_districts
 		NOT = { is_planet_class = pc_giga_maginot_gas_giant }
+		exists = from
+		from = { is_wilderness_empire = no }
 	}
 	zone_slots = {
 		slot_maginot_bunker_complexes
+	}
+
+	conversion_ratio = 1
+	convert_to = {
+		district_maginot_world_bunkers_wilderness
 	}
 
 	allow = {
@@ -301,6 +618,8 @@ district_maginot_world_bunkers = {
 	potential = {
 		uses_district_set = maginot_world_districts
 		NOT = { is_planet_class = pc_giga_maginot_gas_giant }
+		exists = owner
+		owner = { is_wilderness_empire = no }
 	}
 
 	resources = {
@@ -335,6 +654,82 @@ district_maginot_world_bunkers = {
 		potential = {
 			exists = owner
 			owner = { is_gestalt = yes }
+		}
+		modifier = {
+			job_maginot_bunker_officer_gestalt_add = @maginot_special_jobs_add
+			job_warrior_drone_add = @maginot_bunker_police_jobs_add
+			job_patrol_drone_add = @maginot_bunker_police_jobs_add
+		}
+	}
+
+	planet_modifier = {
+		planet_housing_add = @maginot_district_housing_bunkers
+	}
+
+	triggered_desc = {
+		trigger = { exists = owner }
+		text = job_maginot_planetary_bunker_effect_desc
+	}
+
+	inline_script = {
+		script = districts/maginot/maginot_triggered_names_bunkers
+	}
+
+	ai_weight = {
+		weight = 33
+	}
+}
+district_maginot_world_bunkers_wilderness = {
+	icon = district_maginot_world_bunkers
+	base_buildtime = @maginot_district_buildtime
+	is_capped_by_modifier = no
+	gridbox = district_arcology_fortress
+	district_background = district_arcology_fortress
+	show_on_uncolonized = {
+		uses_district_set = maginot_world_districts
+		NOT = { is_planet_class = pc_giga_maginot_gas_giant }
+		exists = from
+		from = { is_wilderness_empire = yes }
+	}
+	zone_slots = {
+		slot_maginot_bunker_complexes
+	}
+
+	conversion_ratio = 1
+	convert_to = {
+		district_maginot_world_bunkers
+	}
+
+	allow = {
+	}
+
+	potential = {
+		uses_district_set = maginot_world_districts
+		NOT = { is_planet_class = pc_giga_maginot_gas_giant }
+		exists = owner
+		owner = { is_wilderness_empire = yes }
+	}
+
+	resources = {
+		category = planet_districts
+		cost = {
+			minerals = @maginot_district_cost_minerals
+			alloys = @maginot_district_cost_alloys_medium
+			volatile_motes = @maginot_district_cost_sr
+		}
+		upkeep = {
+			energy = @maginot_district_upkeep_energy_medium
+			volatile_motes = @maginot_district_upkeep_sr
+		}
+	}
+
+	on_built = {
+		maginot_check_upgrade_points = yes
+	}
+
+	triggered_planet_modifier = {
+		potential = {
+			always = yes
 		}
 		modifier = {
 			job_maginot_bunker_officer_gestalt_add = @maginot_special_jobs_add

--- a/common/districts/giga_maginot_districts.txt
+++ b/common/districts/giga_maginot_districts.txt
@@ -43,14 +43,11 @@ district_maginot_world_barracks = {
 		}
 	}
 
-	# base jobs 
-
 	triggered_planet_modifier = {
 		potential = {
 			exists = owner
 			owner = {
 				is_gestalt = no
-				NOT = { has_valid_civic = civic_warrior_culture }
 			}
 		}
 		modifier = {
@@ -63,34 +60,7 @@ district_maginot_world_barracks = {
 		potential = {
 			exists = owner
 			owner = {
-				is_gestalt = no
-				has_valid_civic = civic_warrior_culture
-			}
-		}
-		modifier = {
-			job_duelist_add = @maginot_entertainer_filler_jobs_add
-			job_maginot_military_police_add = @maginot_barracks_police_jobs_add
-		}
-	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_hive_empire = yes
-			}
-		}
-		modifier = {
-			job_synapse_drone_add = @maginot_entertainer_filler_jobs_add
-			job_patrol_drone_add = @maginot_barracks_police_jobs_add
-		}
-	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_machine_empire = yes
+				is_gestalt = yes
 			}
 		}
 		modifier = {
@@ -103,12 +73,11 @@ district_maginot_world_barracks = {
 		potential = {
 			exists = owner
 			owner = {
-				is_machine_empire = yes
 				has_active_tradition = tr_virtuality_4
 			}
 		}
 		modifier = {
-			job_coordinator_add = 2
+			job_coordinator_add = 200
 		}
 	}
 
@@ -122,7 +91,7 @@ district_maginot_world_barracks = {
 			}
 		}
 		modifier = {
-			job_maintenance_drone_add = @maginot_entertainer_filler_jobs_buff
+			job_maintenance_drone_add = @maginot_entertainer_filler_jobs_buff #mostly obsolete but helps virtuality
 		}
 	}
 
@@ -233,24 +202,9 @@ district_maginot_world_shield_generators = {
 		maginot_check_upgrade_points = yes
 	}
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		modifier = {
-			job_maginot_shield_generator_operator_add = @maginot_special_jobs_add
-		}
-	}	
-	
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		modifier = {
-			job_maginot_shield_generator_operator_gestalt_add = @maginot_special_jobs_add
-		}
+	inline_script = {
+		script = jobs/maginot_shield_generator_operator_add
+		AMOUNT = @maginot_special_jobs_add
 	}
 
 	triggered_desc = {
@@ -264,15 +218,7 @@ district_maginot_world_shield_generators = {
 
 	planet_modifier = {
 		planet_orbital_bombardment_damage = -0.05 # yes these are spammable to 100% and beyond, intentional
-		# stuff on the planet is protected by shields from damage
-		army_collateral_damage_mult = -1.00
-		# army health/morale buffs from protection
-		# army_defense_health_mult = 0.25
-		# army_defense_morale_mult = 0.25
-		# army_health = 0.20
-		# army_morale = 0.20
-		# army_attack_health_mult = 0.10
-		# army_attack_morale_mult = 0.10
+		army_collateral_damage_mult = -0.1 # stuff on the planet is protected by shields from damage
 	}
 
 	ai_weight = {
@@ -316,26 +262,10 @@ district_maginot_world_planetary_cannons = {
 		maginot_check_upgrade_points = yes
 	}
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_gestalt = no }					
-		}
-		modifier = {
-			job_maginot_planetary_cannon_operator_add = @maginot_special_jobs_add
-		}
+	inline_script = {
+		script = jobs/maginot_planetary_cannon_operator_add
+		AMOUNT = @maginot_special_jobs_add
 	}
-	
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_gestalt = yes }					
-		}
-		modifier = {
-			job_maginot_planetary_cannon_operator_gestalt_add = @maginot_special_jobs_add
-		}
-	}
-
 
 	triggered_desc = {
 		trigger = { exists = owner }
@@ -415,20 +345,6 @@ district_maginot_world_bunkers = {
 
 	planet_modifier = {
 		planet_housing_add = @maginot_district_housing_bunkers
-		# universal army buffs, but less than specialized ones
-		# army_starting_experience_add = 100
-		# army_experience_gain_mult = 0.20
-		# army_defense_damage_mult = 0.20
-		# army_damage_mult = 0.10
-		# army_morale_damage_mult = 0.10
-		# army_attack_damage_mult = 0.10
-		# army_attack_health_mult = 0.10
-		# army_attack_morale_mult = 0.10
-		# army_defense_health_mult = 0.20
-		# army_defense_morale_mult = 0.20
-		# army_health = 0.10
-		# army_morale = 0.10
-		# army_collateral_damage_mult = -0.10
 	}
 
 	triggered_desc = {
@@ -495,26 +411,10 @@ district_maginot_ringworld_barracks = {
 			exists = owner
 			owner = {
 				is_gestalt = no
-				NOT = { has_valid_civic = civic_warrior_culture }
 			}
 		}
 		modifier = {
 			job_entertainer_add = @maginot_entertainer_filler_jobs_add_ringworld
-			job_clerk_add = @maginot_entertainer_filler_jobs_add_ringworld
-			job_maginot_military_police_add = @maginot_barracks_police_jobs_add_ringworld
-		}
-	}
-
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = {
-				is_gestalt = no
-				has_valid_civic = civic_warrior_culture
-			}
-		}
-		modifier = {
-			job_duelist_add = @maginot_entertainer_filler_jobs_add_ringworld
 			job_clerk_add = @maginot_entertainer_filler_jobs_add_ringworld
 			job_maginot_military_police_add = @maginot_barracks_police_jobs_add_ringworld
 		}
@@ -669,24 +569,9 @@ district_maginot_ringworld_shield_generators = {
 		slot_maginot_shield_generators
 	}
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_gestalt = no }
-		}
-		modifier = {
-			job_maginot_shield_generator_operator_add = @maginot_special_jobs_add_ringworld
-		}
-	}	
-	
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_gestalt = yes }
-		}
-		modifier = {
-			job_maginot_shield_generator_operator_gestalt_add = @maginot_special_jobs_add_ringworld
-		}
+	inline_script = {
+		script = jobs/maginot_shield_generator_operator_add
+		AMOUNT = @maginot_special_jobs_add_ringworld
 	}
 
 	triggered_desc = {
@@ -700,15 +585,7 @@ district_maginot_ringworld_shield_generators = {
 
 	planet_modifier = {
 		planet_orbital_bombardment_damage = -0.05 # yes these are spammable to 100% and beyond, intentional
-		# stuff on the planet is protected by shields from damage
-		army_collateral_damage_mult = -1.00
-		# army health/morale buffs from protection
-		# army_defense_health_mult = 0.25
-		# army_defense_morale_mult = 0.25
-		# army_health = 0.20
-		# army_morale = 0.20
-		# army_attack_health_mult = 0.10
-		# army_attack_morale_mult = 0.10
+		army_collateral_damage_mult = -0.1 # stuff on the planet is protected by shields from damage
 	}
 
 	ai_weight = {
@@ -752,26 +629,10 @@ district_maginot_ringworld_planetary_cannons = {
 		slot_maginot_orbital_defense_grid
 	}
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_gestalt = no }					
-		}
-		modifier = {
-			job_maginot_planetary_cannon_operator_add = @maginot_special_jobs_add_ringworld
-		}
+	inline_script = {
+		script = jobs/maginot_planetary_cannon_operator_add
+		AMOUNT = @maginot_special_jobs_add_ringworld
 	}
-	
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { is_gestalt = yes }					
-		}
-		modifier = {
-			job_maginot_planetary_cannon_operator_gestalt_add = @maginot_special_jobs_add_ringworld
-		}
-	}
-
 
 	triggered_desc = {
 		trigger = { exists = owner }
@@ -780,16 +641,6 @@ district_maginot_ringworld_planetary_cannons = {
 
 	inline_script = {
 		script = districts/maginot/maginot_triggered_names_defense_grids
-	}
-
-	planet_modifier = {
-		# armies do more damage
-		# army_defense_damage_mult = 0.25
-		# army_damage_mult = 0.25
-		# army_morale_damage_mult = 0.25
-		# army_attack_damage_mult = 0.25
-		# army_attack_health_mult = 0.20
-		# army_attack_morale_mult = 0.20
 	}
 
 	ai_weight = {
@@ -860,23 +711,8 @@ district_maginot_ringworld_bunkers = {
 		}
 	}
 
-
 	planet_modifier = {
 		planet_housing_add = @maginot_district_housing_bunkers_ringworld
-		# universal army buffs, but less than specialized ones
-		# army_starting_experience_add = 100
-		# army_experience_gain_mult = 0.20
-		# army_defense_damage_mult = 0.20
-		# army_damage_mult = 0.10
-		# army_morale_damage_mult = 0.10
-		# army_attack_damage_mult = 0.10
-		# army_attack_health_mult = 0.10
-		# army_attack_morale_mult = 0.10
-		# army_defense_health_mult = 0.20
-		# army_defense_morale_mult = 0.20
-		# army_health = 0.10
-		# army_morale = 0.10
-		# army_collateral_damage_mult = -0.10
 	}
 
 	triggered_desc = {

--- a/common/inline_scripts/jobs/maginot_bunker_officer_add.txt
+++ b/common/inline_scripts/jobs/maginot_bunker_officer_add.txt
@@ -1,0 +1,25 @@
+### Regular Empires
+triggered_planet_modifier = {
+    potential = {
+        exists = owner
+        owner = {
+            is_regular_empire = yes
+        }
+    }
+    modifier = {
+        job_maginot_bunker_officer_add = $AMOUNT$
+    }
+}
+
+# Gestalt Empires
+triggered_planet_modifier = {
+    potential = {
+        exists = owner
+        owner = {
+            is_gestalt = yes
+        }
+    }
+    modifier = {
+        job_maginot_bunker_officer_gestalt_add = $AMOUNT$
+    }
+}

--- a/common/inline_scripts/jobs/maginot_central_command_add.txt
+++ b/common/inline_scripts/jobs/maginot_central_command_add.txt
@@ -1,0 +1,25 @@
+### Regular Empires
+triggered_planet_modifier = {
+    potential = {
+        exists = owner
+        owner = {
+            is_regular_empire = yes
+        }
+    }
+    modifier = {
+        job_maginot_central_command_add = $AMOUNT$
+    }
+}
+
+# Gestalt Empires
+triggered_planet_modifier = {
+    potential = {
+        exists = owner
+        owner = {
+            is_gestalt = yes
+        }
+    }
+    modifier = {
+        job_maginot_central_command_gestalt_add = $AMOUNT$
+    }
+}

--- a/common/inline_scripts/jobs/maginot_planetary_cannon_operator_add.txt
+++ b/common/inline_scripts/jobs/maginot_planetary_cannon_operator_add.txt
@@ -1,0 +1,25 @@
+### Regular Empires
+triggered_planet_modifier = {
+    potential = {
+        exists = owner
+        owner = {
+            is_regular_empire = yes
+        }
+    }
+    modifier = {
+        job_maginot_planetary_cannon_operator_add = $AMOUNT$
+    }
+}
+
+# Gestalt Empires
+triggered_planet_modifier = {
+    potential = {
+        exists = owner
+        owner = {
+            is_gestalt = yes
+        }
+    }
+    modifier = {
+        job_maginot_planetary_cannon_operator_gestalt_add = $AMOUNT$
+    }
+}

--- a/common/inline_scripts/jobs/maginot_shield_generator_operator_add.txt
+++ b/common/inline_scripts/jobs/maginot_shield_generator_operator_add.txt
@@ -1,0 +1,25 @@
+### Regular Empires
+triggered_planet_modifier = {
+    potential = {
+        exists = owner
+        owner = {
+            is_regular_empire = yes
+        }
+    }
+    modifier = {
+        job_maginot_shield_generator_operator_add = $AMOUNT$
+    }
+}
+
+# Gestalt Empires
+triggered_planet_modifier = {
+    potential = {
+        exists = owner
+        owner = {
+            is_gestalt = yes
+        }
+    }
+    modifier = {
+        job_maginot_shield_generator_operator_gestalt_add = $AMOUNT$
+    }
+}

--- a/common/inline_scripts/zones/maginot/fortified_trenches_zone_maginot.txt
+++ b/common/inline_scripts/zones/maginot/fortified_trenches_zone_maginot.txt
@@ -2,17 +2,17 @@ icon = GFX_district_specialization_fortress
 base_buildtime = @zone_buildtime
 potential = { # planet scope
     hidden_trigger = { exists = owner }
-    owner = {
-        is_wilderness_empire = no
-    }
+    # owner = {
+    #     is_wilderness_empire = no
+    # }
     planet_is_ring_world_equivalent = $is_maginot_ring$
 }
 
 unlock = { # planet scope
     hidden_trigger = { exists = owner }
-    owner = {
-        is_wilderness_empire = no
-    }
+    # owner = {
+    #     is_wilderness_empire = no
+    # }
     planet_is_ring_world_equivalent = $is_maginot_ring$
 }
 

--- a/common/inline_scripts/zones/maginot/housing_zone_maginot.txt
+++ b/common/inline_scripts/zones/maginot/housing_zone_maginot.txt
@@ -3,16 +3,16 @@ base_buildtime = @zone_buildtime
 
 potential = { # planet scope
     hidden_trigger = { exists = owner }
-    owner = {
-        is_wilderness_empire = no
-    }
+    # owner = {
+    #     is_wilderness_empire = no
+    # }
 }
 
 unlock = { # planet scope
     hidden_trigger = { exists = owner }
-    owner = {
-        is_wilderness_empire = no
-    }
+    # owner = {
+    #     is_wilderness_empire = no
+    # }
 }
 
 resources = {

--- a/common/inline_scripts/zones/maginot/killing_fields_zone_maginot.txt
+++ b/common/inline_scripts/zones/maginot/killing_fields_zone_maginot.txt
@@ -2,17 +2,17 @@ icon = GFX_district_specialization_duelist
 base_buildtime = @zone_buildtime
 potential = { # planet scope
     hidden_trigger = { exists = owner }
-    owner = {
-        is_wilderness_empire = no
-    }
+    # owner = {
+    #     is_wilderness_empire = no
+    # }
     planet_is_ring_world_equivalent = $is_maginot_ring$
 }
 
 unlock = { # planet scope
     hidden_trigger = { exists = owner }
-    owner = {
-        is_wilderness_empire = no
-    }
+    # owner = {
+    #     is_wilderness_empire = no
+    # }
     planet_is_ring_world_equivalent = $is_maginot_ring$
 }
 

--- a/common/inline_scripts/zones/maginot/logistics_zone_maginot.txt
+++ b/common/inline_scripts/zones/maginot/logistics_zone_maginot.txt
@@ -2,17 +2,17 @@ icon = GFX_district_specialization_trade
 base_buildtime = @zone_buildtime
 potential = { # planet scope
     hidden_trigger = { exists = owner }
-    owner = {
-        is_wilderness_empire = no
-    }
+    # owner = {
+    #     is_wilderness_empire = no
+    # }
     planet_is_ring_world_equivalent = $is_maginot_ring$
 }
 
 unlock = { # planet scope
     hidden_trigger = { exists = owner }
-    owner = {
-        is_wilderness_empire = no
-    }
+    # owner = {
+    #     is_wilderness_empire = no
+    # }
     planet_is_ring_world_equivalent = $is_maginot_ring$
 }
 

--- a/common/inline_scripts/zones/maginot/orbital_defense_grids_zone_maginot.txt
+++ b/common/inline_scripts/zones/maginot/orbital_defense_grids_zone_maginot.txt
@@ -2,17 +2,17 @@ icon = GFX_district_specialization_fortress
 base_buildtime = @zone_buildtime
 potential = { # planet scope
     hidden_trigger = { exists = owner }
-    owner = {
-        is_wilderness_empire = no
-    }
+    # owner = {
+    #     is_wilderness_empire = no
+    # }
     planet_is_ring_world_equivalent = $is_maginot_ring$
 }
 
 unlock = { # planet scope
     hidden_trigger = { exists = owner }
-    owner = {
-        is_wilderness_empire = no
-    }
+    # owner = {
+    #     is_wilderness_empire = no
+    # }
     planet_is_ring_world_equivalent = $is_maginot_ring$
 }
 

--- a/common/inline_scripts/zones/maginot/recovery_zones_zone_maginot.txt
+++ b/common/inline_scripts/zones/maginot/recovery_zones_zone_maginot.txt
@@ -2,19 +2,17 @@ icon = GFX_district_specialization_healthcare
 base_buildtime = @zone_buildtime
 potential = { # planet scope
     hidden_trigger = { exists = owner }
-    owner = {
-        is_wilderness_empire = no
-    }
+    # owner = {
+    #     is_wilderness_empire = no
+    # }
     planet_is_ring_world_equivalent = $is_maginot_ring$
 }
 
 unlock = { # planet scope
     hidden_trigger = { exists = owner }
-    owner = {
-        NOR = {
-            is_wilderness_empire = yes
-        }
-    }
+    # owner = {
+    #     is_wilderness_empire = no
+    # }
     planet_is_ring_world_equivalent = $is_maginot_ring$
 }
 

--- a/common/inline_scripts/zones/maginot/shield_generators_zone_maginot.txt
+++ b/common/inline_scripts/zones/maginot/shield_generators_zone_maginot.txt
@@ -2,17 +2,17 @@ icon = GFX_district_specialization_fortress
 base_buildtime = @zone_buildtime
 potential = { # planet scope
     hidden_trigger = { exists = owner }
-    owner = {
-        is_wilderness_empire = no
-    }
+    # owner = {
+    #     is_wilderness_empire = no
+    # }
     planet_is_ring_world_equivalent = $is_maginot_ring$
 }
 
 unlock = { # planet scope
     hidden_trigger = { exists = owner }
-    owner = {
-        is_wilderness_empire = no
-    }
+    # owner = {
+    #     is_wilderness_empire = no
+    # }
     planet_is_ring_world_equivalent = $is_maginot_ring$
 }
 

--- a/common/inline_scripts/zones/maginot/training_facilities_zone_maginot.txt
+++ b/common/inline_scripts/zones/maginot/training_facilities_zone_maginot.txt
@@ -2,17 +2,17 @@ icon = GFX_district_specialization_fortress
 base_buildtime = @zone_buildtime
 potential = { # planet scope
     hidden_trigger = { exists = owner }
-    owner = {
-        is_wilderness_empire = no
-    }
+    # owner = {
+    #     is_wilderness_empire = no
+    # }
     planet_is_ring_world_equivalent = $is_maginot_ring$
 }
 
 unlock = { # planet scope
     hidden_trigger = { exists = owner }
-    owner = {
-        is_wilderness_empire = no
-    }
+    # owner = {
+    #     is_wilderness_empire = no
+    # }
     planet_is_ring_world_equivalent = $is_maginot_ring$
 }
 

--- a/common/megastructures/zz_e_maginot_world.txt
+++ b/common/megastructures/zz_e_maginot_world.txt
@@ -109,7 +109,10 @@ maginot_world_0 = {
 		# always = no #Disabled for 4.0
 		has_technology = giga_tech_maginot_world # this needs galactic wonders, full-blown megastructure
 		NOT = { has_global_flag = maginot_disabled }
-		giga_can_use_habitables = yes
+		OR = {
+			giga_can_use_habitables = yes
+			is_wilderness_empire = yes
+		}
 		OR = {
 			has_global_flag = maginot_capped_u
 			check_variable = {

--- a/common/megastructures/zz_e_planetary_computer.txt
+++ b/common/megastructures/zz_e_planetary_computer.txt
@@ -46,6 +46,7 @@ planetary_computer_0 = {
 				value < value:giga_planetary_computer_limit
 			}
 		}
+		is_wilderness_empire = no #Wilderness can get a swap of the tech but can't build the mega
 	}
 
 	possible = {

--- a/common/pop_jobs/giga_maginot_jobs.txt
+++ b/common/pop_jobs/giga_maginot_jobs.txt
@@ -124,6 +124,18 @@ maginot_central_command_gestalt = {
 			condition_string = DRONE_JOB_TRIGGER
 			building_icon = building_imperial_capital
 		}
+		swap_type = {
+			trigger = {
+				exists = owner
+				owner = { is_wilderness_empire = yes }
+			}
+			name = maginot_central_command_gestalt_wilderness
+			desc = maginot_central_command_gestalt_wilderness_desc
+			building_icon = building_imperial_capital
+			icon = maginot_central_command_gestalt
+			condition_string = DRONE_JOB_TRIGGER
+			weight = 100
+		}
 	}
 	possible_pre_triggers = {
 		has_owner = yes
@@ -264,6 +276,18 @@ maginot_shield_generator_operator_gestalt = {
 			condition_string = DRONE_JOB_TRIGGER
 			building_icon = building_planetary_shield_generator
 		}
+		swap_type = {
+			trigger = {
+				exists = owner
+				owner = { is_wilderness_empire = yes }
+			}
+			name = maginot_shield_generator_operator_gestalt_wilderness
+			desc = maginot_shield_generator_operator_gestalt_wilderness_desc
+			building_icon = building_planetary_shield_generator
+			icon = maginot_shield_generator_operator_gestalt
+			condition_string = DRONE_JOB_TRIGGER
+			weight = 100
+		}
 	}
 
 	possible_pre_triggers = {
@@ -375,6 +399,18 @@ maginot_planetary_cannon_operator_gestalt = {
 		default = {
 			condition_string = DRONE_JOB_TRIGGER
 			building_icon = building_maintenance_depot
+		}
+		swap_type = {
+			trigger = {
+				exists = owner
+				owner = { is_wilderness_empire = yes }
+			}
+			name = maginot_planetary_cannon_operator_gestalt_wilderness
+			desc = maginot_planetary_cannon_operator_gestalt_wilderness_desc
+			building_icon = building_maintenance_depot
+			icon = maginot_planetary_cannon_operator_gestalt
+			condition_string = DRONE_JOB_TRIGGER
+			weight = 100
 		}
 	}
 
@@ -504,6 +540,18 @@ maginot_bunker_officer_gestalt = {
 		default = {
 			condition_string = DRONE_JOB_TRIGGER
 			building_icon = building_dread_encampment
+		}
+		swap_type = {
+			trigger = {
+				exists = owner
+				owner = { is_wilderness_empire = yes }
+			}
+			name = maginot_bunker_officer_gestalt_wilderness
+			desc = maginot_bunker_officer_gestalt_wilderness_desc
+			building_icon = building_dread_encampment
+			icon = maginot_bunker_officer_gestalt
+			condition_string = DRONE_JOB_TRIGGER
+			weight = 100
 		}
 	}
 

--- a/common/scripted_triggers/zzz_overwrites.txt
+++ b/common/scripted_triggers/zzz_overwrites.txt
@@ -2350,8 +2350,9 @@ is_habitable_for_wilderness = {
 	NOR = {
 		AND = {
 			is_artificial = yes
-			NOT = {
+			NOR = {
 				is_planet_class = pc_habitable_gas_giant
+				is_planet_class = pc_giga_maginot_world
 			}
 		}
 		is_planet_class = pc_city

--- a/common/technology/giga_02_society.txt
+++ b/common/technology/giga_02_society.txt
@@ -603,6 +603,7 @@ giga_tech_planetary_computer = {
 		has_any_galactic_wonders_dlc = yes
 		has_galactic_wonders = yes
 		NOT = { has_global_flag = planetary_computer_disabled }
+		is_wilderness_empire = no #sorry Wilderness, maybe you'll get a brainworld alt one day
 	}
 
 	weight_modifier = {

--- a/common/technology/giga_02_society.txt
+++ b/common/technology/giga_02_society.txt
@@ -594,16 +594,38 @@ giga_tech_planetary_computer = {
 	is_rare = yes
 	prerequisites = { "tech_ecological_adaptation" "tech_self_aware_logic" "tech_power_plant_3" "giga_tech_macro_scale_weather_manipulation" }
 	weight = @tier5weight3
-	prereqfor_desc = {
-		custom = { title = "allow_planetary_computer"	desc = "desc_planetary_computer" }
+
+	#everyone who isn't Wilderness technically gets a swap so Wilderness doesn't get the "Unlocks Megastructure" desc
+	technology_swap = {
+		name = giga_tech_planetary_computer
+		inherit_icon = yes
+		inherit_effects = yes
+
+		prereqfor_desc = {
+			custom = { title = "allow_planetary_computer"	desc = "desc_planetary_computer" }
+		}
+
+		trigger = {
+			is_wilderness_empire = no
+		}
 	}
-	modifier = { all_technology_research_speed = 0.05 }			# Incase this tech's megastructure is disabled
+
+	technology_swap = {
+		name = giga_tech_planetary_computer_wilderness_swap
+		inherit_icon = yes
+		inherit_effects = yes
+
+		trigger = {
+			is_wilderness_empire = yes
+		}
+	}
+
+	modifier = { all_technology_research_speed = 0.05 }			# Incase this tech's megastructure is disabled or inaccessible to your empire type
 
 	potential = {
 		has_any_galactic_wonders_dlc = yes
 		has_galactic_wonders = yes
 		NOT = { has_global_flag = planetary_computer_disabled }
-		is_wilderness_empire = no #sorry Wilderness, maybe you'll get a brainworld alt one day
 	}
 
 	weight_modifier = {

--- a/common/technology/giga_15_maginot.txt
+++ b/common/technology/giga_15_maginot.txt
@@ -20,6 +20,17 @@ giga_tech_maginot_world = {
 		custom = { title = "allow_maginot"	desc = "maginot_desc" }
 		#custom = { title = "allow_maginot_strategic_defence_command_platform"	desc = "maginot_strategic_defence_command_platform_desc" }
 	}
+
+	technology_swap = {
+		name = giga_tech_maginot_world_wilderness_swap
+		inherit_icon = yes
+		inherit_effects = yes
+
+		trigger = {
+			is_wilderness_empire = yes
+		}
+	}
+
 	modifier = {
 		country_naval_cap_add = 150
 		army_defense_health_mult = 0.25 # improved bunker techniques or something idk

--- a/common/terraform/giga_terraform_links.txt
+++ b/common/terraform/giga_terraform_links.txt
@@ -1525,7 +1525,34 @@ terraform_link = {
 
 	potential = {
 		has_origin = origin_wilderness
-		has_technology = giga_tech_terraform_gas
+		from = { is_colony = no }
+	}
+
+	ai_weight = {
+		weight = 100
+	}
+
+	inline_script = {
+		script = terraform/wilderness_biomass_special
+	}
+}
+terraform_link = {
+	from = "pc_giga_maginot_world"
+	to = "pc_giga_maginot_world"
+
+	resources = {
+		category = terraforming
+
+		cost = {
+			biomass = @wildernessCost
+		}
+	}
+
+	duration = @wildernessTime
+
+	potential = {
+		has_origin = origin_wilderness
+		has_technology = giga_tech_maginot_world
 		from = { is_colony = no }
 	}
 

--- a/events/giga_012_katzen.txt
+++ b/events/giga_012_katzen.txt
@@ -5559,41 +5559,40 @@ country_event = { #Manage war forges and the Kaiser's eco
 		update_katzen_tech_level_buffs = yes
 		update_katzen_tech_level_display = yes
 
-			if = {
-				limit = {
-					NOT = { 
-						any_owned_fleet = { 
-							any_owned_ship = {
-								OR = {
-									is_ship_size = giga_war_moon
-									is_ship_size = giga_kaiser_moon_flusion
-								}
-								has_ship_flag = kaiser_moon_ship
-							} 
-						} 
+		if = {
+			limit = {
+				NOT = {
+					any_owned_fleet = {
+						any_owned_ship = {
+							OR = {
+								is_ship_size = giga_war_moon
+								is_ship_size = giga_kaiser_moon_flusion
+							}
+							has_ship_flag = kaiser_moon_ship
+						}
 					}
 				}
-				NOT = { has_country_flag = kaiser_moon_destroyed }
 			}
-			every_country = {
-				limit = { has_country_flag = allied_to_kaiser }
-				country_event = { id = giga_katzen.3003 days = 15 } #FTO collapses
-			}
-			every_country = {
-				limit = { has_country_flag = katzen_vassal }
-				country_event = { id = giga_katzen.0033 days = 15 } #Vassals rebel
-			}
-			every_playable_country = {
-				limit = { is_ai = no }
-				country_event = { id = giga_katzen.089 }
-			}
-			set_country_flag = kaiser_moon_destroyed
-			add_modifier = {
-				modifier = katzenartig_disarray
-				days = -1
-			}
-			country_event = { id = giga_katmoons.001 days = 3600 } #make a new one CHANGE TO 10 YEARS
+			NOT = { has_country_flag = kaiser_moon_destroyed }
 		}
+		every_country = {
+			limit = { has_country_flag = allied_to_kaiser }
+			country_event = { id = giga_katzen.3003 days = 15 } #FTO collapses
+		}
+		every_country = {
+			limit = { has_country_flag = katzen_vassal }
+			country_event = { id = giga_katzen.0033 days = 15 } #Vassals rebel
+		}
+		every_playable_country = {
+			limit = { is_ai = no }
+			country_event = { id = giga_katzen.089 }
+		}
+		set_country_flag = kaiser_moon_destroyed
+		add_modifier = {
+			modifier = katzenartig_disarray
+			days = -1
+		}
+		country_event = { id = giga_katmoons.001 days = 3600 } #make a new one CHANGE TO 10 YEARS
 		country_event = { id = giga_katzen.030 days = 30 }
 		set_variable = {
 			which = "kaiser_ehof_count"

--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -6003,6 +6003,8 @@
   #########################################
   giga_tech_planetary_computer:0 "Planetary Scale Computing Complexes"
   giga_tech_planetary_computer_desc:0 "The solution to ever-expanding needs for computing power: an entire planet transformed into a computer! Using specialized terraforming techniques, this seemingly silly project can become a reality."
+  giga_tech_planetary_computer_wilderness_swap:0 "Planetary Ecosystem Collective Computing"
+  giga_tech_planetary_computer_wilderness_swap_desc:0 "One brain alone is weak, but many brains together are strong. The Wilderness has always been an emergent property of its many members, but it is time to take the next step: interconnecting floral electrochemical systems across the planetary crust could effectively transform an entire celestial body into one wetware computer."
 
   giga_dialog.1301.name:0 "$name_planetary_computer$ Construction Site Complete"
   giga_dialog.1301.desc:0 "The construction site for a future $name_planetary_computer$ has now been completed in the [giga_system.GetName] system. Upon this scaffold, we will eventually convert this entire planet into a massive computer, possessing immense processing power."

--- a/localisation/english/giga_maginot_l_english.yml
+++ b/localisation/english/giga_maginot_l_english.yml
@@ -133,17 +133,17 @@
     district_maginot_world_barracks:0 "Barracks District"
     district_maginot_world_barracks_desc:0 "Sprawling support facilities for housing troops on and below the surface, including various leisure and recreation areas."
     district_maginot_world_barracks_plural:0 "Barracks Districts"
-    district_maginot_world_barracks_wilderness:0 ""
-    district_maginot_world_barracks_wilderness_desc:0 ""
-    district_maginot_world_barracks_wilderness_plural:0 ""
+    district_maginot_world_barracks_wilderness:0 "Bone City"
+    district_maginot_world_barracks_wilderness_desc:0 "A bustling hub of common symbionts undertaking common tasks - but signs of the martial focus here are never out of sight."
+    district_maginot_world_barracks_wilderness_plural:0 "Bone Cities"
 
     # shield district
     district_maginot_world_shield_generators:0 "Shield Generator Array"
     district_maginot_world_shield_generators_desc:0 "Emitters of scales unheard of for any single ship generate force fields to rival entire navies. Additional point-defense weaponry and anti-missile missile silos prevent most ordnance from even getting that far. Specialized support facilities can be used to supplement orbital platform shields."
     district_maginot_world_shield_generators_plural:0 "Shield Generator Arrays"
-    district_maginot_world_shield_generators_wilderness:0 ""
-    district_maginot_world_shield_generators_wilderness_desc:0 ""
-    district_maginot_world_shield_generators_wilderness_plural:0 ""
+    district_maginot_world_shield_generators_wilderness:0 "Shield Canopy Copse"
+    district_maginot_world_shield_generators_wilderness_desc:0 "Harmonising the shield-producing organs of a whole ecosystem allows for force fields beyond what any one organism could ever create. Additional point-defense adaptations prevent most ordnance from even getting that far. A mutualistic relationship with orbital protectors keeps the entire planet safer."
+    district_maginot_world_shield_generators_wilderness_plural:0 "Shield Canopy Copses"
 
     job_maginot_planetary_shield_effect_desc:0 "Provides 1 §YShield Battery§! army capable of soaking up vast amounts of enemy fire and 1 §Y$defensive_upgrade_point$§! per 100 jobs."
 
@@ -151,9 +151,9 @@
     district_maginot_world_planetary_cannons:0 "Orbital Defense Grid"
     district_maginot_world_planetary_cannons_desc:0 "The towering planetary cannons are quite capable of shredding any vessel in low orbit - ensuring starship captains stay well out of their firing envelopes. As such the cannons are mainly prepared for interception duties against enemy ordnance and dropships. Vast command and control complexes interface with orbital strategic defense systems, allowing deployment of greater numbers of platforms, as well as strengthening existing ones."
     district_maginot_world_planetary_cannons_plural:0 "Orbital Defense Grids"
-    district_maginot_world_planetary_cannons_wilderness:0 ""
-    district_maginot_world_planetary_cannons_wilderness_desc:0 ""
-    district_maginot_world_planetary_cannons_wilderness_plural:0 ""
+    district_maginot_world_planetary_cannons_wilderness:0 "Aeroterritorial Defense Grid"
+    district_maginot_world_planetary_cannons_wilderness_desc:0 "Vast plains pockmarked with pressurised cysts can propel a forest of corrosive bone-harpoons at anything in low orbit - deterring enemy ships from getting within range to begin with. As such, the launchers are mostly adapted for intercepting long-range ordnance or dropships. Encrypted bioelectric emitters boost the carrying capacity of the orbital strategic defense ecosystem, and strengthen existing platforms."
+    district_maginot_world_planetary_cannons_wilderness_plural:0 "Aeroterritorial Defense Grids"
 
     job_maginot_planetary_artillery_effect_desc:0 "Provides 1 §YPlanetary Artillery§! army which deals extreme damage but is relatively fragile and 1 §Y$offensive_upgrade_point$§! per 100 jobs."
 
@@ -161,9 +161,9 @@
     district_maginot_world_bunkers:0 "Bunker Complex"
     district_maginot_world_bunkers_desc:0 "Bunkers and heavy anti-ground weaponry as far as the eye can see. The ground is criss-crossed by endless trenches, tank traps, and heavy barriers that ensure nothing ever moves in straight lines on this world. Camouflaged gun emplacements are ready to rain hell on enemy forces, their overlapping fields of fire covering every square meter on the planet. Extensive training facilities ensure our troops are prepared for any contingency, and drills are constantly held on all sorts of terrain."
     district_maginot_world_bunkers_plural:0 "Bunker Complexes"
-    district_maginot_world_bunkers_wilderness:0 ""
-    district_maginot_world_bunkers_wilderness_desc:0 ""
-    district_maginot_world_bunkers_wilderness_plural:0 ""
+    district_maginot_world_bunkers_wilderness:0 "Fortified Warren"
+    district_maginot_world_bunkers_wilderness_desc:0 "Carapaced crevices and heavy anti-ground adaptations as far as the eye can see. The ground is criss-crossed with muscle-lined chasms, bone spikes, and lithic spurs that ensure nothing ever moves in straight lines on this world. Camouflaged chemical-spitters are ready to rain hell on enemy forces, their overlapping fields of fire covering every square metre on the planet. Territorial skirmishes ensure all symbionts train relentlessly, until the right pheromones unite them all outside threats."
+    district_maginot_world_bunkers_wilderness_plural:0 "Fortified Warrens"
 
     job_maginot_planetary_bunker_effect_desc:0 "Provides 1 §YFortification Network§! army which cripples the morale of enemy troops while inflicting steady damage."
 
@@ -302,6 +302,10 @@
     job_maginot_central_command_gestalt_desc:0 "Specially selected drones especially fit for command duty, set to overseeing the $name_maginot_world$. They command the vast array of planetary defenses from the deepest command complexes."
     job_maginot_central_command_gestalt_effect_desc:0 "£job_maginot_central_command_gestalt£ $job_maginot_central_command_gestalt_plural$ decrease £crime£ §Y$PLANET_CRIME_TITLE$§!, increase £mod_planet_stability_add£ §Y$PLANET_STABILITY_TITLE$§!, spawn £defense_army£ §YDefense Armies§!, increase £mod_country_naval_cap_add£ §Y$MOD_COUNTRY_NAVAL_CAP_ADD$§!, and produce £unity£ §Y$unity$§! and £influence£ §YInfluence§!"
     mod_job_maginot_central_command_gestalt_add:0 "$job_maginot_central_command_gestalt$"
+    maginot_central_command_gestalt_wilderness: "Stratosymbiont"
+    job_maginot_central_command_gestalt_wilderness: "$maginot_central_command_gestalt_wilderness$"
+    maginot_central_command_gestalt_wilderness_plural: "Stratosymbionts"
+    maginot_central_command_gestalt_wilderness_desc: "Specially selected symbionts especially fit for command duty, set to overseeing the $name_maginot_world$. They cultivate the vast array of planetary defenses from the deepest command complexes."
 
     ## shield district
     job_maginot_shield_generator_operator:0 "Shield Generator Operator"
@@ -315,6 +319,10 @@
     job_maginot_shield_generator_operator_gestalt_desc:0 "Trained to operate city block-sized generator arrays, and otherwise ensure the $name_maginot_world$ remains quite safe from any threat of enemy ordnance striking."
     job_maginot_shield_generator_operator_gestalt_effect_desc:0 "£job_maginot_shield_generator_operator_gestalt£ $job_maginot_shield_generator_operator_gestalt_plural$ turn £energy£ §Y$energy$§! and £alloys£ §Y$alloys$§! into £unity£ §YUnity§! and enable §Ydefensive upgrades§! for the $name_maginot_world$. 1 §Y$defensive_upgrade_point$§! per 100 jobs."
     mod_job_maginot_shield_generator_operator_gestalt_add:0 "$job_maginot_shield_generator_operator_gestalt$"
+    maginot_shield_generator_operator_gestalt_wilderness:0 "Aegisymbiont"
+    job_maginot_shield_generator_operator_gestalt_wilderness:0 "$maginot_shield_generator_operator_gestalt_wilderness$"
+    maginot_shield_generator_operator_gestalt_wilderness_plural:0 "Aegisymbionts"
+    maginot_shield_generator_operator_gestalt_wilderness_desc:0 "Trained to tend to field-sized shield canopy growths, and otherwise ensure the $name_maginot_world$ remains quite safe from any threat of ballistic predation."
 
     ## cannon/orbital uplink district
     job_maginot_planetary_cannon_operator:0 "Defense Grid Operator"
@@ -328,6 +336,10 @@
     job_maginot_planetary_cannon_operator_gestalt_desc:0 "A horde of trained engineer drones maintain both planetary cannons and orbital uplinks. Combat drones are stationed both on the ground weapons as well as in orbital SD platforms to engage any hostile foolish enough to share a system with a $name_maginot_world$."
     job_maginot_planetary_cannon_operator_gestalt_effect_desc:0 "£job_maginot_planetary_cannon_operator_gestalt£ $job_maginot_planetary_cannon_operator_gestalt_plural$ turn £energy£ §Y$energy$§! and £alloys£ §Y$alloys$§! into £unity£ §YUnity§! and enable §Yoffensive upgrades§! for the $name_maginot_world$. 1 §Y$offensive_upgrade_point$§! per 100 jobs."
     mod_job_maginot_planetary_cannon_operator_gestalt_add:0 "$job_maginot_planetary_cannon_operator_gestalt$"
+    maginot_planetary_cannon_operator_gestalt_wilderness:0 "Sentinelsymbiont"
+    job_maginot_planetary_cannon_operator_gestalt_wilderness:0 "$Sentinelsymbiont$"
+    maginot_planetary_cannon_operator_gestalt_wilderness_plural:0 "Sentinelsymbionts"
+    maginot_planetary_cannon_operator_gestalt_wilderness_desc:0 "Engineering and combat symbionts with a primal urge to protect the herd from danger. They oversee both an orbital canopy of SD platforms, and a planetside understory of ballistic projectors."
 
     ## bunker district
     job_maginot_bunker_officer:0 "Maginot Defense Commander"
@@ -341,6 +353,10 @@
     job_maginot_bunker_officer_gestalt_desc:0 "Drones specially created to organize the defense of a whole bunker sector."
     job_maginot_bunker_officer_gestalt_effect_desc:0 "£job_maginot_bunker_officer_gestalt£ $job_maginot_bunker_officer_gestalt_plural$ turn £energy£ §Y$energy$§! and £alloys£ §Y$alloys$§! into £unity£ §Y$unity$§!, increase £mod_country_naval_cap_add£ §Y$MOD_COUNTRY_NAVAL_CAP_ADD$§! and spawn £defense_army£ §YDefense Armies§!"
     mod_job_maginot_bunker_officer_gestalt_add:0 "$job_maginot_bunker_officer_gestalt$"
+    maginot_bunker_officer_gestalt_wilderness:0 "Warrensymbiont"
+    job_maginot_bunker_officer_gestalt_wilderness:0 "$maginot_bunker_officer_gestalt_wilderness$"
+    maginot_bunker_officer_gestalt_wilderness_plural:0 "Warrensymbionts"
+    maginot_bunker_officer_gestalt_wilderness_desc:0 "Symbionts specially adapted to maintain deep refuges for the planet's population."
 
     ## housing district military police (non-gestalts only)
     job_maginot_military_police:0 "Maginot Military Police"
@@ -384,7 +400,7 @@
     giga_dialog.5001.a:0 "Excellent."
 
     giga_dialog.5002.name:0 "$name_maginot_world$ Internals Complete"
-    giga_dialog.5002.desc:0 "We are another step closer to completing a $name_maginot_world$ in the [giga_system.GetName] system. Geoforming and space-based construction is well under way, and we have dug the spaces for the deepest bunkers and command centers. We are now ready to install the antimatter-based failsafe system, and finalize the initial planetary defenses."
+    giga_dialog.5002.desc:0 "We are another step closer to completing a $name_maginot_world$ in the [giga_system.GetName] system. Geoforming and space-based construction are well under way, and we have dug the spaces for the deepest bunkers and command centers. We are now ready to install the antimatter-based failsafe system, and finalize the initial planetary defenses."
     giga_dialog.5002.a:0 "Excellent."
 
     giga_dialog.5003.name:0 "$name_maginot_world$ Complete!"
@@ -537,6 +553,8 @@
     giga_tech_maginot_world_desc:0 "To defend our empire we must construct the ultimate defensive strongpoint, and transform an entire planet into a massive fortress complex - the $name_maginot_world$. \n\nThis world shall be equipped with orbital defenses, planetary cannons, countless bunkers, deep underground command complexes, and continent-sized shield generators. In addition, a Dead Hand system will be developed to deter enemy Colossus-class warships.\n\n§YThe planetary building is necessary to begin $name_maginot_world$ construction§!, but the building can also be built in other locations not suitable for full development."
     maginot_desc:0 "A vast planet-spanning stronghold that seeks to be utterly unassailable for any enemy force."
     allow_maginot:0 "§HUnlocks Megastructure:§! $name_maginot_world$"
+    giga_tech_maginot_world_wilderness_swap:0 "Ultimate Strongpoint Defense Adaptations"
+    giga_tech_maginot_world_wilderness_swap_desc:0 "To defend our habitats we must evolve the ultimate defensive strongpoint, and transform an entire planet into a massive fortress biome - the $name_maginot_world$. \n\nThis world shall be equipped with orbital defenses, planetary cannons, countless bunkers, deep underground command-hormone organs, and continent-sized shield generators. In addition, a Dead Hand organ will be developed to deter enemy Colossus-class warships.\n\n§YThe planetary building is necessary to begin $name_maginot_world$ construction§!, but the building can also be built in other locations not suitable for full development."
 
     giga_tech_maginot_firepower_1:0 "Improved Maginot Firepower"
     giga_tech_maginot_firepower_1_desc:0 "With practical developments complete, we can now focus on further pushing the envelope with regards to various optimizations for the $name_maginot_world$ systems. In particular, ever greater firepower."

--- a/localisation/english/giga_maginot_l_english.yml
+++ b/localisation/english/giga_maginot_l_english.yml
@@ -201,7 +201,7 @@
     # bunker district
 
     #############
-    ### Zones ###
+    ### Zones ### #TODO actual Wilderness alts
     #############
     zone_maginot_housing:0 "Barracks Expansion"
     zone_maginot_housing_desc:0 "A sprawling complex of barracks housing military personnel of all ranks and specializations, stretching beyond the horizon."
@@ -305,7 +305,9 @@
     maginot_central_command_gestalt_wilderness: "Stratosymbiont"
     job_maginot_central_command_gestalt_wilderness: "$maginot_central_command_gestalt_wilderness$"
     maginot_central_command_gestalt_wilderness_plural: "Stratosymbionts"
+    job_maginot_central_command_gestalt_wilderness_plural: "$maginot_central_command_gestalt_wilderness_plural$"
     maginot_central_command_gestalt_wilderness_desc: "Specially selected symbionts especially fit for command duty, set to overseeing the $name_maginot_world$. They cultivate the vast array of planetary defenses from the deepest command complexes."
+    job_maginot_central_command_gestalt_wilderness_desc: "$maginot_central_command_gestalt_wilderness_desc$"
 
     ## shield district
     job_maginot_shield_generator_operator:0 "Shield Generator Operator"
@@ -322,7 +324,9 @@
     maginot_shield_generator_operator_gestalt_wilderness:0 "Aegisymbiont"
     job_maginot_shield_generator_operator_gestalt_wilderness:0 "$maginot_shield_generator_operator_gestalt_wilderness$"
     maginot_shield_generator_operator_gestalt_wilderness_plural:0 "Aegisymbionts"
+    job_maginot_shield_generator_operator_gestalt_wilderness_plural:0 "$maginot_shield_generator_operator_gestalt_wilderness_plural$"
     maginot_shield_generator_operator_gestalt_wilderness_desc:0 "Trained to tend to field-sized shield canopy growths, and otherwise ensure the $name_maginot_world$ remains quite safe from any threat of ballistic predation."
+    job_maginot_shield_generator_operator_gestalt_wilderness_desc:0 "$maginot_shield_generator_operator_gestalt_wilderness_desc$"
 
     ## cannon/orbital uplink district
     job_maginot_planetary_cannon_operator:0 "Defense Grid Operator"
@@ -339,7 +343,9 @@
     maginot_planetary_cannon_operator_gestalt_wilderness:0 "Sentinelsymbiont"
     job_maginot_planetary_cannon_operator_gestalt_wilderness:0 "$Sentinelsymbiont$"
     maginot_planetary_cannon_operator_gestalt_wilderness_plural:0 "Sentinelsymbionts"
+    job_maginot_planetary_cannon_operator_gestalt_wilderness_plural:0 "$maginot_planetary_cannon_operator_gestalt_wilderness_plural$"
     maginot_planetary_cannon_operator_gestalt_wilderness_desc:0 "Engineering and combat symbionts with a primal urge to protect the herd from danger. They oversee both an orbital canopy of SD platforms, and a planetside understory of ballistic projectors."
+    job_maginot_planetary_cannon_operator_gestalt_wilderness_desc:0 "$maginot_planetary_cannon_operator_gestalt_wilderness_desc$"
 
     ## bunker district
     job_maginot_bunker_officer:0 "Maginot Defense Commander"
@@ -356,7 +362,9 @@
     maginot_bunker_officer_gestalt_wilderness:0 "Warrensymbiont"
     job_maginot_bunker_officer_gestalt_wilderness:0 "$maginot_bunker_officer_gestalt_wilderness$"
     maginot_bunker_officer_gestalt_wilderness_plural:0 "Warrensymbionts"
+    job_maginot_bunker_officer_gestalt_wilderness_plural:0 "$maginot_bunker_officer_gestalt_wilderness_plural$"
     maginot_bunker_officer_gestalt_wilderness_desc:0 "Symbionts specially adapted to maintain deep refuges for the planet's population."
+    job_maginot_bunker_officer_gestalt_wilderness_desc:0 "$maginot_bunker_officer_gestalt_wilderness_desc$"
 
     ## housing district military police (non-gestalts only)
     job_maginot_military_police:0 "Maginot Military Police"

--- a/localisation/english/giga_maginot_l_english.yml
+++ b/localisation/english/giga_maginot_l_english.yml
@@ -133,17 +133,27 @@
     district_maginot_world_barracks:0 "Barracks District"
     district_maginot_world_barracks_desc:0 "Sprawling support facilities for housing troops on and below the surface, including various leisure and recreation areas."
     district_maginot_world_barracks_plural:0 "Barracks Districts"
+    district_maginot_world_barracks_wilderness:0 ""
+    district_maginot_world_barracks_wilderness_desc:0 ""
+    district_maginot_world_barracks_wilderness_plural:0 ""
 
     # shield district
     district_maginot_world_shield_generators:0 "Shield Generator Array"
     district_maginot_world_shield_generators_desc:0 "Emitters of scales unheard of for any single ship generate force fields to rival entire navies. Additional point-defense weaponry and anti-missile missile silos prevent most ordnance from even getting that far. Specialized support facilities can be used to supplement orbital platform shields."
     district_maginot_world_shield_generators_plural:0 "Shield Generator Arrays"
+    district_maginot_world_shield_generators_wilderness:0 ""
+    district_maginot_world_shield_generators_wilderness_desc:0 ""
+    district_maginot_world_shield_generators_wilderness_plural:0 ""
+
     job_maginot_planetary_shield_effect_desc:0 "Provides 1 §YShield Battery§! army capable of soaking up vast amounts of enemy fire and 1 §Y$defensive_upgrade_point$§! per 100 jobs."
 
     # cannon/orbital uplink district
     district_maginot_world_planetary_cannons:0 "Orbital Defense Grid"
     district_maginot_world_planetary_cannons_desc:0 "The towering planetary cannons are quite capable of shredding any vessel in low orbit - ensuring starship captains stay well out of their firing envelopes. As such the cannons are mainly prepared for interception duties against enemy ordnance and dropships. Vast command and control complexes interface with orbital strategic defense systems, allowing deployment of greater numbers of platforms, as well as strengthening existing ones."
     district_maginot_world_planetary_cannons_plural:0 "Orbital Defense Grids"
+    district_maginot_world_planetary_cannons_wilderness:0 ""
+    district_maginot_world_planetary_cannons_wilderness_desc:0 ""
+    district_maginot_world_planetary_cannons_wilderness_plural:0 ""
 
     job_maginot_planetary_artillery_effect_desc:0 "Provides 1 §YPlanetary Artillery§! army which deals extreme damage but is relatively fragile and 1 §Y$offensive_upgrade_point$§! per 100 jobs."
 
@@ -151,6 +161,10 @@
     district_maginot_world_bunkers:0 "Bunker Complex"
     district_maginot_world_bunkers_desc:0 "Bunkers and heavy anti-ground weaponry as far as the eye can see. The ground is criss-crossed by endless trenches, tank traps, and heavy barriers that ensure nothing ever moves in straight lines on this world. Camouflaged gun emplacements are ready to rain hell on enemy forces, their overlapping fields of fire covering every square meter on the planet. Extensive training facilities ensure our troops are prepared for any contingency, and drills are constantly held on all sorts of terrain."
     district_maginot_world_bunkers_plural:0 "Bunker Complexes"
+    district_maginot_world_bunkers_wilderness:0 ""
+    district_maginot_world_bunkers_wilderness_desc:0 ""
+    district_maginot_world_bunkers_wilderness_plural:0 ""
+
     job_maginot_planetary_bunker_effect_desc:0 "Provides 1 §YFortification Network§! army which cripples the morale of enemy troops while inflicting steady damage."
 
     ### Ringworld versions ###
@@ -168,7 +182,6 @@
     district_maginot_ringworld_planetary_cannons:0 "Orbital Defense Segment"
     district_maginot_ringworld_planetary_cannons_desc:0 "Outfitting our ringworld with massive weapons batteries makes it quite capable of shredding any vessel in low orbit - ensuring starship captains stay well out of any firing envelopes. As such the cannons are mainly prepared for interception duties against enemy ordnance and dropships. Vast command and control complexes interface with near-space strategic defense systems, allowing deployment of greater numbers of platforms, as well as strengthening existing ones."
     district_maginot_ringworld_planetary_cannons_plural:0 "Orbital Defense Segments"
-
 
     # bunker district
     district_maginot_ringworld_bunkers:0 "Bunker Segment"


### PR DESCRIPTION
Wilderness empires can now use the Maginot world. They have text-only flavour swaps for the technology, jobs, and districts, but not zones.
Wilderness now have a tech swap for Planetary Scale Computing Complexes, which no longer claims to unlock the Planetary Computer (Wilderness empires cannot use it), but still gives the research speed boost.
Reduced collateral damage reduction from Maginot Shield Districts (including ringworld version) from 100% reduction per district to 10% reduction per district.
Warrior Culture empires will now correctly receive entertainer jobs from Maginot Barracks Districts (including ringworld version).
Gestalt virtual empires will now receive 200, instead of 2, coordinators from Maginot Barracks Districts (including ringworld version).