### PR TITLE
EHOF, ruined ships, great ring

### DIFF
--- a/common/buildings/giga_amb_buildings.txt
+++ b/common/buildings/giga_amb_buildings.txt
@@ -602,6 +602,8 @@ holding_giga_megaworkshop = {
 	owner_type = subject_holding
 	empire_limit = 1
 
+	category = resource
+
 	potential = {
 		has_overlord_dlc = yes
 		has_global_flag = @giga_amb_flag

--- a/common/buildings/giga_buildings.txt
+++ b/common/buildings/giga_buildings.txt
@@ -4,6 +4,7 @@ building_giga_paluush_homes = {
 	can_demolish = yes
 	can_be_ruined = no
 	ai_weight = { weight = 0 }
+	category = amenity
 	potential = {
 		exists = owner
 		owner = {
@@ -34,6 +35,7 @@ building_giga_paluush_capital = {
 	can_demolish = yes
 	can_be_ruined = no
 	position_priority = 0
+	category = government
 	ai_weight = { weight = 0 }
 	potential = {
 		exists = owner

--- a/common/buildings/giga_corrona_buildings.txt
+++ b/common/buildings/giga_corrona_buildings.txt
@@ -6,6 +6,7 @@ building_giga_corrona_capital = {
 	can_be_ruined = no
 	position_priority = 0
 	capital_tier = 0
+	category = government
 	ai_weight = { weight = 0 }
 	potential = {
 		owner = { has_country_flag = corrona_primitives }
@@ -50,6 +51,7 @@ building_giga_corrona_homes = {
 	can_demolish = yes
 	can_be_ruined = no
 	ai_weight = { weight = 0 }
+	category = amenity
 	potential = {
 		owner = { has_country_flag = corrona_primitives }
 	}

--- a/common/deposits/giga_planetary_deposits.txt
+++ b/common/deposits/giga_planetary_deposits.txt
@@ -359,18 +359,18 @@ d_floaters = {
 	}
 }
 
-d_giga_gas_giant_hab_core = {
-	icon = d_mining_tunnels
-	is_for_colonizable = yes
-	use_for_min_max_adjustments = yes
-	category = deposit_cat_minerals
-	potential = { always = no }
-	drop_weight = { weight = 0 }
-	triggered_planet_modifier = {
-		district_giga_gas_giant_habitat_mining_max = 0.25
-		multiplier = trigger:planet_size
-	}
-}
+# d_giga_gas_giant_hab_core = {
+# 	icon = d_mining_tunnels
+# 	is_for_colonizable = yes
+# 	use_for_min_max_adjustments = yes
+# 	category = deposit_cat_minerals
+# 	potential = { always = no }
+# 	drop_weight = { weight = 0 }
+# 	triggered_planet_modifier = {
+# 		district_giga_gas_giant_habitat_mining_max = 0.25
+# 		multiplier = trigger:planet_size
+# 	}
+# }
 
 # # Birch World Start
 # d_birch_start = {

--- a/common/districts/giga_maginot_districts.txt
+++ b/common/districts/giga_maginot_districts.txt
@@ -867,16 +867,6 @@ district_maginot_ringworld_barracks = {
 		}
 	}
 
-	triggered_planet_modifier = {
-		potential = {
-			exists = owner
-			owner = { has_active_tradition = tr_mercantile_trickle_up_economics }
-		}
-		modifier = {
-			job_clerk_add = @maginot_entertainer_filler_jobs_buff_ringworld
-		}
-	}
-
 
 	# planet housing and additions
 

--- a/common/districts/giga_planetary_computer.txt
+++ b/common/districts/giga_planetary_computer.txt
@@ -107,7 +107,7 @@ district_giga_pcc_admin = {
 	
 	inline_script = {
 		script = planet/unity/giga_unity_job_swap
-		jobs = 5
+		jobs = 500
 		district = @yes
 	}
 }

--- a/common/districts/giga_planetary_computer.txt
+++ b/common/districts/giga_planetary_computer.txt
@@ -80,10 +80,10 @@ district_giga_pcc_admin = {
 
 	potential = {
 		uses_district_set = giga_planetary_computer
-		exists = owner
-		owner = {
-			giga_country_uses_priests = no
-		}
+		# exists = owner
+		# owner = {
+		# 	giga_country_uses_priests = no
+		# }
 	}
 
 	resources = {

--- a/common/megastructures/zz_e_macroatmospheric_stabilizer.txt
+++ b/common/megastructures/zz_e_macroatmospheric_stabilizer.txt
@@ -269,7 +269,7 @@ macro_stabilizer_3 = {
 			clear_deposits = yes
 			reroll_deposits = yes
 			add_deposit = d_fluffy_plains
-			add_deposit = d_giga_gas_giant_hab_core
+			# add_deposit = d_giga_gas_giant_hab_core
 			random_list = {
 				2 = { while = { count = 1 add_deposit = d_gassy_rivers } }
 				2 = { while = { count = 1 add_deposit = d_mote_cloud } }

--- a/common/megastructures/zz_e_planetary_computer.txt
+++ b/common/megastructures/zz_e_planetary_computer.txt
@@ -319,6 +319,8 @@ planetary_computer_2 = {
 			set_planet_flag = giga_planet_mega
 			set_planet_flag = giga_planetary_computer
 		    change_pc = pc_giga_planetary_computer
+			clear_deposits = yes
+			clear_planet_modifiers = yes
 			add_modifier = { modifier = "giga_planetary_computer" days = -1 }
 
 			if = {

--- a/common/megastructures/zzz_ruined_ships.txt
+++ b/common/megastructures/zzz_ruined_ships.txt
@@ -1,3 +1,117 @@
+
+
+## Tags: @ruined @megaproject
+giga_battleship_ruined = {
+	entity = "giga_ruined_battleship_entity"
+	construction_entity = "giga_ruined_battleship_entity"
+	show_galactic_map_icon = no
+	place_entity_on_planet_plane = no
+	portrait = "GFX_megastructure_construction_background"
+
+	outliner_trigger = {
+		exists = owner
+		NOT = { has_megastructure_flag = giga_outliner_hidden_by_@owner }
+	}
+
+	resources = {
+		category = megastructures
+		produces = {
+			engineering_research = 4
+		}
+	}
+
+	potential = {
+		always = no
+	}
+}
+
+## Tags: @technical
+giga_battleship_scrap = {
+	entity = ""
+	construction_entity = ""
+	show_galactic_map_icon = no
+	place_entity_on_planet_plane = no
+	portrait = "GFX_megastructure_construction_background"
+
+	construction_blocks_and_blocked_by = none
+	potential = {
+		is_ai = no
+	}
+
+	build_time = 360
+
+	upgrade_from = {
+		giga_battleship_ruined
+	}
+
+	resources = {
+		category = megastructures
+		cost = {
+			energy = 2000
+		}
+	}
+
+	on_build_complete = {
+		from = {
+			country_event = { id = giga_wrecked_ships.1032 }	# Notification
+		}
+		remove_megastructure = fromfrom
+	}
+}
+
+## Tags: @restored @megaproject
+giga_battleship_restored = {
+	entity = ""
+	construction_entity = ""
+	show_galactic_map_icon = no
+	portrait = "GFX_megastructure_construction_background"
+
+	construction_blocks_and_blocked_by = none
+	upgrade_from = {
+		giga_battleship_ruined
+	}
+
+	build_time = 360
+
+	resources = {
+		category = megastructures
+		cost = {
+			alloys = 5000
+		}
+	}
+
+	possible = {
+		from = { has_technology = tech_battleships }
+	}
+
+	ai_weight = {
+		weight = 10000
+	}
+
+	on_build_complete = {
+		save_event_target_as = giga_system
+		from = {
+			country_event = { id = giga_wrecked_ships.1031 }	# Notification
+			create_fleet = {
+				name = "Restored Battleships"
+				effect = {
+					set_owner = prev
+					while = {
+						count = 3
+						create_ship = {
+							name = random
+							random_existing_design = battleship
+							graphical_culture = ROOT.fromfrom
+						}
+					}
+				}
+			}
+		}
+		last_created_fleet = { set_location = fromfrom }
+		remove_megastructure = fromfrom
+	}
+}
+
 ## Tags: @ruined @megaproject
 giga_titan_ruined = {
 	entity = "giga_ruined_titan_entity"
@@ -18,7 +132,7 @@ giga_titan_ruined = {
 	resources = {
 		category = megastructures
 		produces = {
-			engineering_research = 7
+			engineering_research = 5
 		}
 	}
 }
@@ -47,7 +161,7 @@ giga_titan_scrap = {
 	resources = {
 		category = megastructures
 		cost = {
-			energy = 1500
+			energy = 2500
 		}
 	}
 
@@ -77,7 +191,7 @@ giga_titan_restored = {
 	resources = {
 		category = megastructures
 		cost = {
-			alloys = 1500
+			alloys = 4500
 		}
 	}
 
@@ -126,7 +240,7 @@ giga_juggernaut_ruined = {
 	resources = {
 		category = megastructures
 		produces = {
-			engineering_research = 12
+			engineering_research = 9
 		}
 	}
 
@@ -157,7 +271,7 @@ giga_juggernaut_scrap = {
 	resources = {
 		category = megastructures
 		cost = {
-			energy = 1500
+			energy = 5000
 		}
 	}
 
@@ -225,118 +339,6 @@ giga_juggernaut_restored = {
 }
 
 ## Tags: @ruined @megaproject
-giga_battleship_ruined = {
-	entity = "giga_ruined_battleship_entity"
-	construction_entity = "giga_ruined_battleship_entity"
-	show_galactic_map_icon = no
-	place_entity_on_planet_plane = no
-	portrait = "GFX_megastructure_construction_background"
-	
-	outliner_trigger = {
-		exists = owner
-		NOT = { has_megastructure_flag = giga_outliner_hidden_by_@owner }
-	}
-	
-	resources = {
-		category = megastructures
-		produces = {
-			engineering_research = 7
-		}
-	}
-
-	potential = {
-		always = no
-	}
-}
-
-## Tags: @technical
-giga_battleship_scrap = {
-	entity = ""
-	construction_entity = ""
-	show_galactic_map_icon = no
-	place_entity_on_planet_plane = no
-	portrait = "GFX_megastructure_construction_background"
-	
-	construction_blocks_and_blocked_by = none
-	potential = {
-		is_ai = no
-	}
-
-	build_time = 360
-
-	upgrade_from = {
-		giga_battleship_ruined
-	}
-
-	resources = {
-		category = megastructures
-		cost = {
-			energy = 1000
-		}
-	}
-
-	on_build_complete = {
-		from = {
-			country_event = { id = giga_wrecked_ships.1032 }	# Notification
-		}
-		remove_megastructure = fromfrom
-	}
-}
-
-## Tags: @restored @megaproject
-giga_battleship_restored = {
-	entity = ""
-	construction_entity = ""
-	show_galactic_map_icon = no
-	portrait = "GFX_megastructure_construction_background"
-	
-	construction_blocks_and_blocked_by = none
-	upgrade_from = {
-		giga_battleship_ruined
-	}
-
-	build_time = 360
-
-	resources = {
-		category = megastructures
-		cost = {
-			alloys = 1750
-		}
-	}
-
-	possible = {
-		from = { has_technology = tech_battleships }	
-	}
-
-	ai_weight = {
-		weight = 10000
-	}
-
-	on_build_complete = {
-		save_event_target_as = giga_system
-		from = {
-			country_event = { id = giga_wrecked_ships.1031 }	# Notification
-			create_fleet = {
-				name = "Restored Battleships"
-				effect = {
-					set_owner = prev
-					while = {
-						count = 3
-						create_ship = {
-							name = random
-							random_existing_design = battleship
-							graphical_culture = ROOT.fromfrom
-						}
-					}
-				}
-			}
-		}
-		last_created_fleet = { set_location = fromfrom }
-		remove_megastructure = fromfrom
-	}
-}
-
-## Tags: @ruined @megaproject
 giga_colossus_ruined = {
 	entity = "giga_ruined_colossus_entity"
 	construction_entity = "giga_ruined_colossus_entity"
@@ -352,7 +354,7 @@ giga_colossus_ruined = {
 	resources = {
 		category = megastructures
 		produces = {
-			engineering_research = 17
+			engineering_research = 13
 		}
 	}
 
@@ -384,7 +386,7 @@ giga_colossus_scrap = {
 	resources = {
 		category = megastructures
 		cost = {
-			energy = 3000
+			energy = 4000
 		}
 	}
 

--- a/common/scripted_effects/compound_effects.txt
+++ b/common/scripted_effects/compound_effects.txt
@@ -717,16 +717,16 @@ annihilator_rewards = {
 	every_country = {
 		limit = { ehof_default_country = yes }
 		random_list = {
-			1 = { set_variable = { which = sa_lootbox value = 1 } }
-			1 = { set_variable = { which = sa_lootbox value = 2 } }
-			1 = { set_variable = { which = sa_lootbox value = 3 } }
-			1 = { set_variable = { which = sa_lootbox value = 4 } }
-			1 = { modifier = { factor = 0 has_ancrel = no } set_variable = { which = sa_lootbox value = 5 } }
-			1 = { set_variable = { which = sa_lootbox value = 6 } }
-			1 = { set_variable = { which = sa_lootbox value = 7 } }
-			1 = { set_variable = { which = sa_lootbox value = 8 } }
-			1 = { set_variable = { which = sa_lootbox value = 9 } }
-			1 = { modifier = { factor = 0 host_has_dlc = Apocalypse } set_variable = { which = sa_lootbox value = 10 } }
+			1 = { set_variable = { which = sa_lootbox value = 1 } } #Minerals
+			1 = { set_variable = { which = sa_lootbox value = 2 } } #Alloys
+			1 = { set_variable = { which = sa_lootbox value = 3 } } #Energy
+			1 = { set_variable = { which = sa_lootbox value = 4 } } #Dark Matter
+			1 = { modifier = { factor = 0 has_ancrel = no } set_variable = { which = sa_lootbox value = 5 } } #Minor Artifacts
+			1 = { set_variable = { which = sa_lootbox value = 6 } } #Salvaged Hornets
+			1 = { set_variable = { which = sa_lootbox value = 7 } } #Salvaged Stalkers
+			1 = { set_variable = { which = sa_lootbox value = 8 } } #Salvaged Humiliators
+			1 = { set_variable = { which = sa_lootbox value = 9 } } #Salvaged Apexes
+			1 = { modifier = { factor = 0 host_has_dlc = Apocalypse } set_variable = { which = sa_lootbox value = 10 } } #Salvaged Sovereigns
 		}
 		country_event = { id = annihilator_dialog.010 }
 	}

--- a/common/scripted_triggers/zzz_overwrites.txt
+++ b/common/scripted_triggers/zzz_overwrites.txt
@@ -2129,6 +2129,9 @@ can_destroy_planet_with_PLANET_KILLER_DELUGE_SYSTEMCRAFT = {
 can_destroy_planet_with_PLANET_KILLER_DEVOLUTION_SYSTEMCRAFT = {
 	can_destroy_planet_with_PLANET_KILLER_DEVOLUTION = yes
 }
+can_destroy_planet_with_PLANET_KILLER_SMELTER_SYSTEMCRAFT = {
+	can_destroy_planet_with_PLANET_KILLER_SMELTER = yes
+}
 
 habitable_planet = {
 	# merger of rules can ignore this, it already covers everything this overwrite does

--- a/common/scripted_variables/ehof_mega_vars.txt
+++ b/common/scripted_variables/ehof_mega_vars.txt
@@ -15,7 +15,7 @@
 @phase_1_energy_upkeep 					= 30
 @phase_1_decomissioned_mineral_upkeep	= 10
 @phase_1_decomissioned_energy_upkeep	= 15
-@phase_1_research_bonus					= 100
+@phase_1_research_bonus					= 40
 
 @phase_2_build_time 					= 1800
 @phase_2_alloy_cost 					= 5000
@@ -24,7 +24,7 @@
 @phase_2_energy_upkeep 					= 60
 @phase_2_decomissioned_mineral_upkeep	= 20
 @phase_2_decomissioned_energy_upkeep	= 30
-@phase_2_research_bonus					= 240
+@phase_2_research_bonus					= 120
 
 @phase_3_build_time 					= 3600
 @phase_3_alloy_cost 					= 20000
@@ -34,7 +34,7 @@
 @phase_3_resource_upkeep 				= 10
 @phase_3_decomissioned_mineral_upkeep	= 35
 @phase_3_decomissioned_energy_upkeep	= 60
-@phase_3_research_bonus					= 480
+@phase_3_research_bonus					= 360
 @phase_3_resource_bonus					= 10
 
 @phase_4_build_time 					= 7200
@@ -45,7 +45,7 @@
 @phase_4_resource_upkeep 				= 20
 @phase_4_decomissioned_mineral_upkeep	= 50
 @phase_4_decomissioned_energy_upkeep	= 100
-@phase_4_research_bonus					= 960
+@phase_4_research_bonus					= 1080
 @phase_4_resource_bonus					= 20
 
 #################### MEGASTRUCTURE USAGE COSTS

--- a/events/ehof_origin_startup.txt
+++ b/events/ehof_origin_startup.txt
@@ -417,17 +417,17 @@ system_event = {
 }
 # Shouldn't matter but I'll leave it here
 
-country_event = {
-	id = ehof_incohesive.8
-	hide_window = yes
-	is_triggered_only = yes
-	trigger = {
-		has_origin = origin_incohesive
-		is_ai = yes
-	}
-
-	immediate = {
-		giga_reset_ai_start = yes
-	}
-}
+# country_event = {
+# 	id = ehof_incohesive.8
+# 	hide_window = yes
+# 	is_triggered_only = yes
+# 	trigger = {
+# 		has_origin = origin_incohesive
+# 		is_ai = yes
+# 	}
+#
+# 	immediate = {
+# 		giga_reset_ai_start = yes
+# 	}
+# }
 # Shouldn't matter but I'll leave it here

--- a/events/giga_010_pouchkinn.txt
+++ b/events/giga_010_pouchkinn.txt
@@ -295,7 +295,18 @@ country_event = {
 planet_event = {
 	id = giga_pouchkinn.107
 	title = "giga_pouchkinn.107.name"
-	desc = "giga_pouchkinn.107.desc"
+	desc = {
+		trigger = {
+			is_gestalt = no
+		}
+		text = "giga_pouchkinn.107.desc"
+	}
+	desc = {
+		trigger = {
+			is_gestalt = yes
+		}
+		text = "giga_pouchkinn.107.gestalt.desc"
+	}
 	picture = GFX_evt_alien_ruins
 	show_sound = event_mystic_reveal
 	location = from
@@ -598,6 +609,9 @@ country_event = {
 	is_triggered_only = yes
 
 	option = {
+		trigger = {
+			is_natural_design_empire = no
+		}
 		name = "giga_pouchkinn.115.a"
 		add_monthly_resource_mult = {
 			resource = society_research
@@ -615,6 +629,34 @@ country_event = {
 		add_tech_progress = { tech = giga_tech_event_exotic_lab_data progress = 0.15 }
 		add_research_option = giga_tech_event_pouchkinn_lifespan
 		add_tech_progress = { tech = giga_tech_event_pouchkinn_lifespan progress = 0.15 }
+		hidden_effect = {
+			random_planet_within_border = {
+				limit = { has_planet_flag = cat_orbital_elysium }
+				remove_modifier = strange_pouchkinn_lab
+			}
+		}
+	}
+
+	option = {
+		trigger = {
+			is_natural_design_empire = yes
+		}
+		name = "giga_pouchkinn.115.natural_design.a"
+		add_monthly_resource_mult = { #bonus society research since Natural Design doesn't get giga_tech_event_pouchkinn_lifespan
+			resource = society_research
+			value = @ehof_tier7researchreward
+			min = @ehof_tier7researchmin
+			max = @ehof_tier7researchmax
+		}
+		add_monthly_resource_mult = {
+			resource = physics_research
+			value = @ehof_tier8researchreward
+			min = @ehof_tier8researchmin
+			max = @ehof_tier8researchmax
+		}
+		add_research_option = giga_tech_event_exotic_lab_data
+		add_tech_progress = { tech = giga_tech_event_exotic_lab_data progress = 0.15 }
+		# Natural Design empires aren't going to study his implants to put in themselves
 		hidden_effect = {
 			random_planet_within_border = {
 				limit = { has_planet_flag = cat_orbital_elysium }

--- a/events/giga_022_flavorsystems.txt
+++ b/events/giga_022_flavorsystems.txt
@@ -968,7 +968,7 @@ country_event = {
 	option = { 
 		name = "giga_wrecked_ships.1022.a"
 		add_monthly_resource_mult = { resource = engineering_research value = 4 }
-		add_resource = { alloys = 2000 }
+		add_resource = { alloys = 3600 }
 	}
 }
 
@@ -1038,7 +1038,7 @@ country_event = {
 	option = { 
 		name = "giga_wrecked_ships.1022.a"
 		add_monthly_resource_mult = { resource = engineering_research value = 6 }
-		add_resource = { alloys = 4000 }
+		add_resource = { alloys = 7500 }
 	}
 }
 
@@ -1108,7 +1108,7 @@ country_event = {
 	option = { 
 		name = "giga_wrecked_ships.1022.a"
 		add_monthly_resource_mult = { resource = engineering_research value = 2 }
-		add_resource = { alloys = 1800 }
+		add_resource = { alloys = 3000 }
 	}
 }
 

--- a/events/giga_203_origins_rings.txt
+++ b/events/giga_203_origins_rings.txt
@@ -9,254 +9,256 @@ country_event = {
 	trigger = { has_origin = origin_great_ring }
 
 	immediate = {
-		if = {
-			limit = { is_ai = yes }
-			capital_scope.solar_system = { set_star_flag = gigas_new_planets }
-			giga_reset_ai_start = yes
-		}
-		else = {
-			capital_scope = {
-				solar_system = {
-					remove_star_flag = sol_sector	# cleanup of stuff used to block New Frontiers subclasser
-					star = {
-						add_deposit = d_dark_matter_deposit_2
-						while = { count = 5 giga_field_debris = yes }
-						giga_set_has_mega_flag = yes
-					}
-					while = { count = 5 giga_field_system_debris = yes }
+		# if = {
+		# 	# limit = { is_ai = yes }
+		# 	capital_scope.solar_system = { set_star_flag = gigas_new_planets }
+		# 	giga_reset_ai_start = yes
+		# }
+		# else = {
+		capital_scope = {
+			solar_system = {
+				remove_star_flag = sol_sector	# cleanup of stuff used to block New Frontiers subclasser
+				star = {
+					set_planet_flag = ignore_startup_effect
+					set_planet_flag = starting_deposit
+					clear_deposits = yes
+					add_deposit = d_dark_matter_deposit_2
+					while = { count = 5 giga_field_debris = yes }
+					giga_set_has_mega_flag = yes
+				}
+				while = { count = 5 giga_field_system_debris = yes }
 
-					spawn_megastructure = { type = "ring_world_behemoth_ruined"		orbit_angle = 90	orbit_distance = 134 }
-					spawn_megastructure = { type = "ring_world_behemoth_ruined"		orbit_angle = 180	orbit_distance = 134 }
-					spawn_megastructure = { type = "ring_world_behemoth_ruined"		orbit_angle = 270	orbit_distance = 134 }
+				spawn_megastructure = { type = "ring_world_behemoth_ruined"		orbit_angle = 90	orbit_distance = 134 }
+				spawn_megastructure = { type = "ring_world_behemoth_ruined"		orbit_angle = 180	orbit_distance = 134 }
+				spawn_megastructure = { type = "ring_world_behemoth_ruined"		orbit_angle = 270	orbit_distance = 134 }
 
-					spawn_planet = {
-						class = pc_ringworld_tech
-						location = solar_system
-						orbit_angle_offset = 300
-						orbit_distance_offset = 134
-						size = 15
+				spawn_planet = {
+					class = pc_ringworld_tech
+					location = solar_system
+					orbit_angle_offset = 300
+					orbit_distance_offset = 134
+					size = 15
 
-						init_effect = {
-							set_name = "Ring Section"
-							root = {
-								giga_set_ringworld_graphical_culture = {
-									TARGET = prev
-									SOURCE = this
-									SIZE = behemoth
-									TYPE = tech
-								}
+					init_effect = {
+						set_name = "Ring Section"
+						root = {
+							giga_set_ringworld_graphical_culture = {
+								TARGET = prev
+								SOURCE = this
+								SIZE = behemoth
+								TYPE = tech
 							}
+						}
 
-							save_event_target_as = ring_section
-							trigger_megastructure_icon = yes
+						save_event_target_as = ring_section
+						trigger_megastructure_icon = yes
 
-							set_planet_flag = forbid_guillis_planet_modifiers
-							set_planet_flag = gpm_has_planet_rings
-							set_planet_flag = hot_zone				# Real Space (Prevents Rings)
-							set_planet_flag = megastructure
-							set_planet_flag = colony_event			# Vanilla uses to prevent unwanted events on planets
-							set_planet_flag = giga_ringworld_tit
-							set_planet_flag = giga_ringworld_beh
-							add_modifier = { modifier = "giga_behemoth_housing" days = -1 }
-						}
-					}
-
-					spawn_planet = {
-						class = pc_ringworld_seam
-						location = solar_system
-						orbit_angle_offset = 270
-						orbit_distance_offset = 134
-						size = 15
-
-						init_effect = {
-							set_name = "Ring Section"
-							root = {
-								giga_set_ringworld_graphical_culture = {
-									TARGET = prev
-									SOURCE = this
-									SIZE = behemoth
-									TYPE = seam
-								}
-							}
-
-							save_event_target_as = ring_section
-							trigger_megastructure_icon = yes
-
-							set_planet_flag = forbid_guillis_planet_modifiers
-							set_planet_flag = gpm_has_planet_rings
-							set_planet_flag = hot_zone				# Real Space (Prevents Rings)
-							set_planet_flag = megastructure
-							set_planet_flag = colony_event			# Vanilla uses to prevent unwanted events on planets
-							set_planet_flag = giga_ringworld_tit
-							set_planet_flag = giga_ringworld_beh
-						}
-					}
-
-					add_asteroid_belt = { type = icy_asteroid_belt		radius = 30 }
-					# 'asteroid' belt : energy 1
-					spawn_planet = {
-						class = pc_ice_asteroid
-						size = 2
-						location = star
-						orbit_distance_offset = 30
-						orbit_angle_offset = 0
-						init_effect = {
-							set_name = "Bountiful Debris"
-							set_planet_flag = ignore_startup_effect
-							set_planet_flag = starting_deposit
-							clear_deposits = yes
-							add_deposit = d_energy_3
-							add_deposit = d_energy_3
-							add_deposit = d_energy_3
-						}
-					}
-					# 'asteroid' belt : energy 2
-					spawn_planet = {
-						class = pc_ice_asteroid
-						size = 2
-						location = star
-						orbit_distance_offset = 30
-						orbit_angle_offset = 60
-						init_effect = {
-							set_name = "Bountiful Debris"
-							set_planet_flag = ignore_startup_effect
-							set_planet_flag = starting_deposit
-							clear_deposits = yes
-							add_deposit = d_energy_3
-							add_deposit = d_energy_3
-							add_deposit = d_energy_3
-						}
-					}
-					# 'asteroid' belt : science
-					spawn_planet = {
-						class = pc_ice_asteroid
-						size = 2
-						location = star
-						orbit_distance_offset = 30
-						orbit_angle_offset = 120
-						init_effect = {
-							set_name = "Bountiful Debris"
-							set_planet_flag = ignore_startup_effect
-							set_planet_flag = starting_deposit
-							clear_deposits = yes
-							add_deposit = d_physics_3
-							add_deposit = d_society_3
-							add_deposit = d_engineering_3
-						}
-					}
-					# 'asteroid' belt : minerals 1
-					spawn_planet = {
-						class = pc_ice_asteroid
-						size = 2
-						location = star
-						orbit_distance_offset = 30
-						orbit_angle_offset = 180
-						init_effect = {
-							set_name = "Bountiful Debris"
-							set_planet_flag = ignore_startup_effect
-							set_planet_flag = starting_deposit
-							clear_deposits = yes
-							add_deposit = d_minerals_3
-							add_deposit = d_minerals_3
-							add_deposit = d_minerals_3
-						}
-					}
-					# 'asteroid' belt : minerals 2
-					spawn_planet = {
-						class = pc_ice_asteroid
-						size = 2
-						location = star
-						orbit_distance_offset = 30
-						orbit_angle_offset = 240
-						init_effect = {
-							set_name = "Bountiful Debris"
-							set_planet_flag = ignore_startup_effect
-							set_planet_flag = starting_deposit
-							clear_deposits = yes
-							add_deposit = d_minerals_3
-							add_deposit = d_minerals_3
-							add_deposit = d_minerals_3
-						}
-					}
-					# 'asteroid' belt : energy 3
-					spawn_planet = {
-						class = pc_ice_asteroid
-						size = 2
-						location = star
-						orbit_distance_offset = 30
-						orbit_angle_offset = 300
-
-						init_effect = {
-							set_name = "Bountiful Debris"
-							set_planet_flag = ignore_startup_effect
-							set_planet_flag = starting_deposit
-							clear_deposits = yes
-							add_deposit = d_energy_3
-							add_deposit = d_energy_3
-							add_deposit = d_energy_3
-						}
-					}
-
-					# Create mining stations
-					every_system_planet = {
-						#limit = { is_star = no }
-						if = {
-							limit = {
-								has_deposit_for = shipclass_mining_station
-								has_mining_station = no
-							}
-							create_mining_station = { owner = root }
-						}
-						else_if = {
-							limit = {
-								has_deposit_for = shipclass_research_station
-								has_research_station = no
-							}
-							create_research_station = { owner = root }
-						}
+						set_planet_flag = forbid_guillis_planet_modifiers
+						set_planet_flag = gpm_has_planet_rings
+						set_planet_flag = hot_zone				# Real Space (Prevents Rings)
+						set_planet_flag = megastructure
+						set_planet_flag = colony_event			# Vanilla uses to prevent unwanted events on planets
+						set_planet_flag = giga_ringworld_tit
+						set_planet_flag = giga_ringworld_beh
+						add_modifier = { modifier = "giga_behemoth_housing" days = -1 }
 					}
 				}
 
-				set_planet_flag = giga_ringworld_tit
-				set_planet_flag = giga_ringworld_beh
-				root = {
-					giga_set_ringworld_graphical_culture = {
-						TARGET = prev
-						SOURCE = this
-						SIZE = behemoth
-						TYPE = gaia_habitable
+				spawn_planet = {
+					class = pc_ringworld_seam
+					location = solar_system
+					orbit_angle_offset = 270
+					orbit_distance_offset = 134
+					size = 15
+
+					init_effect = {
+						set_name = "Ring Section"
+						root = {
+							giga_set_ringworld_graphical_culture = {
+								TARGET = prev
+								SOURCE = this
+								SIZE = behemoth
+								TYPE = seam
+							}
+						}
+
+						save_event_target_as = ring_section
+						trigger_megastructure_icon = yes
+
+						set_planet_flag = forbid_guillis_planet_modifiers
+						set_planet_flag = gpm_has_planet_rings
+						set_planet_flag = hot_zone				# Real Space (Prevents Rings)
+						set_planet_flag = megastructure
+						set_planet_flag = colony_event			# Vanilla uses to prevent unwanted events on planets
+						set_planet_flag = giga_ringworld_tit
+						set_planet_flag = giga_ringworld_beh
 					}
 				}
 
-				prevent_anomaly = yes
-				trigger_megastructure_icon = yes
-				clear_blockers = yes
-				clear_deposits = yes
-				remove_all_districts = yes
+				add_asteroid_belt = { type = icy_asteroid_belt		radius = 30 }
+				# 'asteroid' belt : energy 1
+				spawn_planet = {
+					class = pc_ice_asteroid
+					size = 2
+					location = star
+					orbit_distance_offset = 30
+					orbit_angle_offset = 0
+					init_effect = {
+						set_name = "Bountiful Debris"
+						set_planet_flag = ignore_startup_effect
+						set_planet_flag = starting_deposit
+						clear_deposits = yes
+						add_deposit = d_minerals_3
+						add_deposit = d_minerals_3
+						add_deposit = d_minerals_3
+					}
+				}
+				# 'asteroid' belt : energy 2
+				spawn_planet = {
+					class = pc_ice_asteroid
+					size = 2
+					location = star
+					orbit_distance_offset = 30
+					orbit_angle_offset = 60
+					init_effect = {
+						set_name = "Bountiful Debris"
+						set_planet_flag = ignore_startup_effect
+						set_planet_flag = starting_deposit
+						clear_deposits = yes
+						add_deposit = d_energy_3
+						add_deposit = d_energy_3
+						add_deposit = d_energy_3
+					}
+				}
+				# 'asteroid' belt : science
+				spawn_planet = {
+					class = pc_ice_asteroid
+					size = 2
+					location = star
+					orbit_distance_offset = 30
+					orbit_angle_offset = 120
+					init_effect = {
+						set_name = "Bountiful Debris"
+						set_planet_flag = ignore_startup_effect
+						set_planet_flag = starting_deposit
+						clear_deposits = yes
+						add_deposit = d_physics_3
+						add_deposit = d_society_3
+						add_deposit = d_engineering_3
+					}
+				}
+				# 'asteroid' belt : minerals 1
+				spawn_planet = {
+					class = pc_ice_asteroid
+					size = 2
+					location = star
+					orbit_distance_offset = 30
+					orbit_angle_offset = 180
+					init_effect = {
+						set_name = "Bountiful Debris"
+						set_planet_flag = ignore_startup_effect
+						set_planet_flag = starting_deposit
+						clear_deposits = yes
+						add_deposit = d_minerals_3
+						add_deposit = d_minerals_3
+						add_deposit = d_minerals_3
+					}
+				}
+				# 'asteroid' belt : minerals 2
+				spawn_planet = {
+					class = pc_ice_asteroid
+					size = 2
+					location = star
+					orbit_distance_offset = 30
+					orbit_angle_offset = 240
+					init_effect = {
+						set_name = "Bountiful Debris"
+						set_planet_flag = ignore_startup_effect
+						set_planet_flag = starting_deposit
+						clear_deposits = yes
+						add_deposit = d_minerals_3
+						add_deposit = d_minerals_3
+						add_deposit = d_minerals_3
+					}
+				}
+				# 'asteroid' belt : energy 3
+				spawn_planet = {
+					class = pc_ice_asteroid
+					size = 2
+					location = star
+					orbit_distance_offset = 30
+					orbit_angle_offset = 300
 
-				add_deposit = d_giga_decrepit_tunnels_1
-				add_deposit = d_giga_decrepit_tunnels_2
-				add_deposit = d_giga_decrepit_tunnels_3
-				add_deposit = d_great_ring_excavated_mountain
-				add_deposit = d_ringworld_capital_city
-				add_deposit = d_segment_rubble_3
-				add_deposit = d_segment_rubble_4
+					init_effect = {
+						set_name = "Bountiful Debris"
+						set_planet_flag = ignore_startup_effect
+						set_planet_flag = starting_deposit
+						clear_deposits = yes
+						add_deposit = d_energy_3
+						add_deposit = d_energy_3
+						add_deposit = d_energy_3
+					}
+				}
 
-
-				#gas deposit for exotic metabolism empires
-				generate_home_planet_final_pass = yes
-
-				if = { #Galvanic civic game start compat due to deposits being wiped
-					limit = { is_galvanic_empire = yes }
+				# Create mining stations
+				every_system_planet = {
+					#limit = { is_star = no }
 					if = {
-						limit = { NOT = { has_deposit = d_galvanic_living_metal } }
-						add_deposit = d_galvanic_living_metal
+						limit = {
+							has_deposit_for = shipclass_mining_station
+							has_mining_station = no
+						}
+						create_mining_station = { owner = root }
+					}
+					else_if = {
+						limit = {
+							has_deposit_for = shipclass_research_station
+							has_research_station = no
+						}
+						create_research_station = { owner = root }
 					}
 				}
-
-                giga_generate_starting_ringworld_districts = yes
 			}
+
+			set_planet_flag = giga_ringworld_tit
+			set_planet_flag = giga_ringworld_beh
+			root = {
+				giga_set_ringworld_graphical_culture = {
+					TARGET = prev
+					SOURCE = this
+					SIZE = behemoth
+					TYPE = gaia_habitable
+				}
+			}
+
+			prevent_anomaly = yes
+			trigger_megastructure_icon = yes
+			clear_blockers = yes
+			clear_deposits = yes
+			remove_all_districts = yes
+
+			add_deposit = d_giga_decrepit_tunnels_1
+			add_deposit = d_giga_decrepit_tunnels_2
+			add_deposit = d_giga_decrepit_tunnels_3
+			add_deposit = d_great_ring_excavated_mountain
+			add_deposit = d_ringworld_capital_city
+			add_deposit = d_segment_rubble_3
+			add_deposit = d_segment_rubble_4
+
+			#gas deposit for exotic metabolism empires
+			generate_home_planet_final_pass = yes
+
+			if = { #Galvanic civic game start compat due to deposits being wiped
+				limit = { is_galvanic_empire = yes }
+				if = {
+					limit = { NOT = { has_deposit = d_galvanic_living_metal } }
+					add_deposit = d_galvanic_living_metal
+				}
+			}
+
+			giga_generate_starting_ringworld_districts = yes
 		}
+		# }
 	}
 }
 

--- a/localisation/english/giga_birch_l_english.yml
+++ b/localisation/english/giga_birch_l_english.yml
@@ -2183,3 +2183,11 @@
     giga_birch.11070:0 "Observational Insight"
     giga_birch.11070.desc:0 "Our [GetResearchers] at the restored observatory on the arctic layer are reporting an influx of new data. It seems a junction redirection in the Structure's information network has connected us to a previously unknown set of processing nodes."
     giga_birch.11070.a:0 "Excellent"
+
+
+
+    #####################
+    ##### Modifiers #####
+    #####################
+    giga_birch_restoration_fix:0 "giga_birch_restoration_fix"
+    giga_birch_origin_critter_balance: "giga_birch_origin_critter_balance"

--- a/localisation/english/giga_deposits_l_english.yml
+++ b/localisation/english/giga_deposits_l_english.yml
@@ -52,6 +52,10 @@
   d_giga_hab_consumer_goods_1_desc: ""
   d_giga_hab_astral_threads_1_desc: ""
   d_subsurface_ocean_deposit_1_desc: ""
+  d_giga_food_1:0 "£food£ +1"
+  d_giga_food_1_desc: "$d_giga_food_1$"
+  d_giga_food_2: "£food£ +2"
+  d_giga_food_2_desc: "$d_giga_food_2$"
 
   #########################################
   ### Lifeless World Deposits #############
@@ -103,7 +107,7 @@
   d_giga_rogue_ai_corrupt_code_desc:0 "Large chunks of the Planetary Computing Complex's databanks are filled with dangerous bloatware code, actively impeding our scientific efforts on this planet."
 
   d_ringworld_capital_city: "The Great Capital"
-  d_ringworld_capital_city_desc: "A great capital city build on the ringworld. This places serves as a central hub for the ringworld segment and provides local population with various services."
+  d_ringworld_capital_city_desc: "A great capital city build on the ringworld. This places serves as a central hub for the ringworld segment and provides the local population with various services."
 
   d_interstellar_ringworld_commerce_blocker: "Abandoned Infrastructure"
   d_interstellar_ringworld_commerce_blocker_desc: "As the ringworld offers nearly endless amount of space, little consideration was given to land re-development, leading to large swaths of land being filled with long-abandoned buildings. If these territories are cleared and re-developed, local business will be able to grow considerably, increasing the empire's wealth."

--- a/localisation/english/giga_ehof_l_english.yml
+++ b/localisation/english/giga_ehof_l_english.yml
@@ -987,8 +987,8 @@
  tech_condensed_ews_desc:0 "Extremely high energy states lead to the unification of the electromagnetic and weak forces into their initial force, the electroweak force. The secrets of the $ehof_the_sphere_named$ revealed how to manifest physical \"Electroweak Quasi-Fields\", which open up possibilities for tremendously precise field and spacetime manipulation, even down to the level of quantum foam itself."
 
  # Arcane Rift Generator Restoration
- tech_arcane_g_r:0 "Arcane Rift Generator Restoration"
- tech_arcane_g_r_desc:0 "The secrets of the $ehof_ep$ allow us to control sentient metal. With the help of it and negative mass, we are now able to entirely restore the Arcane Rift Generator to its former glory, allowing us to utilize it to its fullest potential."
+ # tech_arcane_g_r:0 "Arcane Rift Generator Restoration"
+ # tech_arcane_g_r_desc:0 "The secrets of the $ehof_ep$ allow us to control sentient metal. With the help of it and negative mass, we are now able to entirely restore the Arcane Rift Generator to its former glory, allowing us to utilize it to its fullest potential."
 
  # Event Horizon Offset Facility Alpha
  allow_ehof_p1:0 "§HUnlocks Megastructure:§! $ehof_ehofp1$"
@@ -1305,7 +1305,7 @@
  ehof_reply_endcomms:0 "End communication"
  ehof_btn_letsdoit:0 "Let's do it"
  ehof_reply_not_good:0 "That's not good..."
- ehof_timetoresearch:0 "Tell the scientists to look into $tech_negative_pressure$!"
+ # ehof_timetoresearch:0 "Tell the scientists to look into $tech_negative_pressure$!"
 
  ehof_megastructure.008.desc:0 "We have captured an $ehof_ehof$ that is more advanced than the one we're currently using. Would you like to relocate our operations to the better $ehof_ehof$?\n\nIf you choose not to, we will assume you have strategically positioned our $ehof_ehof$ and will not ask again about relocating."
  ehof_megastructure.008.a:0 "No"

--- a/localisation/english/giga_gas_giant_hab_l_english.yml
+++ b/localisation/english/giga_gas_giant_hab_l_english.yml
@@ -34,17 +34,17 @@
     decision_giga_flood_atmosphere:0 "Flood Planetary Atmosphere"
     decision_giga_flood_atmosphere_desc:0 ""
 
-    d_giga_gas_giant_hab_core:0 "Rich Planetary Core"
-    d_giga_gas_giant_hab_core_desc:0 ""
+    # d_giga_gas_giant_hab_core:0 "Rich Planetary Core"
+    # d_giga_gas_giant_hab_core_desc:0 ""
 
-    district_giga_gas_giant_habitat_mining:0 "Core Mining Site"
-    district_giga_gas_giant_habitat_mining_plural:0 "Core Mining Sites"
-    district_giga_gas_giant_habitat_mining_desc:0 ""
+    # district_giga_gas_giant_habitat_mining:0 "Core Mining Site"
+    # district_giga_gas_giant_habitat_mining_plural:0 "Core Mining Sites"
+    # district_giga_gas_giant_habitat_mining_desc:0 ""
 
     giga_gas_giant_hab:0 "Habitable Gas Giant"
-
     giga_gas_giant_hab_desc:0 "Plentiful exotic gases means easy collection, but harsher working conditions for planetary core mining operations."
-    mod_district_giga_gas_giant_habitat_mining_max:0 "Max $district_giga_gas_giant_habitat_mining_plural$"
+
+    # mod_district_giga_gas_giant_habitat_mining_max:0 "Max $district_giga_gas_giant_habitat_mining_plural$"
 
     ### Jobs
 

--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -6350,6 +6350,7 @@
 
   giga_pouchkinn.107.name:0 "Lab Exploration"
   giga_pouchkinn.107.desc:0 "Now that the lab drones have been defeated, what course of action should we take? It seems there is much more to this Laboratory than previously thought...\nOur citizens are becoming wary of this incredibly strange building, and some say it should be destroyed. Our scientists advise against this, however, as we don't know what kind of events destroying the lab would cause."
+  giga_pouchkinn.107.gestalt.desc:0 "Now that the lab drones have been defeated, what course of action should we take? It seems there is much more to this Laboratory than previously thought...\nOur drones' self-preservation protocols are routing them away from this incredibly strange building, and pathfinding efficiency reviews suggest it should be destroyed. However, collective self-preservation might be best pursued by leaving it, as we don't know what kind of events destroying the lab would cause."
   giga_pouchkinn.107.a:0 "Send a smaller team of scientists."
 
   giga_pouchkinn.108.name:0 "The Depths of the Laboratory"
@@ -6395,6 +6396,7 @@
   giga_pouchkinn.115.name:0 "Lab Raided"
   giga_pouchkinn.115.desc:0 "Shortly after talking with Pouchkinn, the expedition's lead scientist pulled out a gun and shot him in the chest, killing him on the spot. Our team then scavenged through the lab, gathering anything they could.\nAn autopsy was performed on Pouchkinn's body, revealing incredibly advanced cybernetic and biological implants which will surely benefit our research.\nThe lab was then sealed off."
   giga_pouchkinn.115.a:0 "His sacrifice will contribute to science."
+  giga_pouchkinn.115.natural_design.a:0 "Another body mutilated by implants."
 
   giga_pouchkinn.116.name:0 "Escapee"
   giga_pouchkinn.116.desc:0 "Our scientists were not able to kill Pouchkinn, as he activated some sort of teleportation device, sending him into an escape pod which then fled into hyperspace, never to be seen again.\n\nWe were however able to raid the laboratory itself, gathering incredible amounts of data from Pouchkinn's research. The lab was then sealed off."

--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -1394,7 +1394,7 @@
   giga_behemoth_ring_system_DESC:0 "Start on a gargantuan ringworld around a dead star."
   origin_great_ring:0 "The Great Ring"
   origin_great_ring_desc:0 "When this star collapsed into a black hole, it destroyed the inner ringworld and the precursor civilization that built it. The outer ring, however, survived without much damage and, eventually, new life emerged on it, warmed up by the pale light of the black hole's accretion disk."
-  origin_tooltip_great_ring_effects:0 "Start on a behemoth ringworld around a dead star.\n- Species habitability is set to §LRingworld§!.\n- §RThere will be no systems with guaranteed habitable worlds nearby§!.\n\n§RAI cannot use this origin. Any generated predefined custom AI empires with this origin will be generate with $origin_default$ instead.§!"
+  origin_tooltip_great_ring_effects:0 "Start on a behemoth ringworld around a dead star.\n- Species habitability is set to §LRingworld§!.\n- §RThere will be no systems with guaranteed habitable worlds nearby§!."
 
   #########################################
   ### Interstellar Ring ###################
@@ -12291,7 +12291,7 @@
   giga_titan_restored:0 "Restored Titan"
   giga_titan_restored_DESC:0 "An ancient Titan-class warship, repaired and brought back to its former glory."
 
-  giga_titan_scrap:0 "Scrap for §Y2000§! £alloys£"
+  giga_titan_scrap:0 "Scrap for §Y3600§! £alloys£"
   giga_titan_scrap_DESC:0 "Break down this vessel for parts and its constituent alloys."
 
   giga_wrecked_ships.1010.name:0 "Wrecked Titan"
@@ -12315,7 +12315,7 @@
   giga_juggernaut_restored:0 "Restored Juggernaut"
   giga_juggernaut_restored_DESC:0 "An ancient Juggernaut-class warship, repaired and brought back to its former glory."
 
-  giga_juggernaut_scrap:0 "Scrap for §Y4000§! £alloys£"
+  giga_juggernaut_scrap:0 "Scrap for §Y7500§! £alloys£"
   giga_juggernaut_scrap_DESC:0 "Break down this vessel for parts and its constituent alloys."
 
   giga_wrecked_ships.1020.name:0 "Wrecked Juggernaut"
@@ -12340,7 +12340,7 @@
   giga_battleship_restored:0 "Restored Battleships"
   giga_battleship_restored_DESC:0 "Several ancient battleships, repaired and brought back to their former glory."
 
-  giga_battleship_scrap:0 "Scrap for §Y1800§! £alloys£"
+  giga_battleship_scrap:0 "Scrap for §Y3000§! £alloys£"
   giga_battleship_scrap_DESC:0 "Break down this vessel for parts and its constituent alloys."
 
   giga_wrecked_ships.1030.name:0 "Wrecked Battleships"


### PR DESCRIPTION
Added missing categories for more Paluushian and Corronian buildings.
Spiritualists now have access to the admin district on the planetary computer.
Planetary computers now clear planetary deposits and modifiers upon construction (no more fertile valleys getting dirt on your motherboards).
Removed the defunct Rich Planetary Core modifier from habitable gas giants.
Rebalanced ruined ships: generally, research outputs have been reduced by roughly 40%, repairing costs more alloys, and scrapping provides more alloys.
Rebalanced the physics given by the EHOF stages to start lower and scale faster, with the general result of decreasing the physics output of the earlier stages.
Added a gestalt description swap for an event while exploring Pouchkinn's stellar ring.
Added a Natural Design response swap for an event while exploring Pouchkinn's stellar ring.
Swapped an energy asteroid for a mineral asteroid in the Great Ring origin.
AI can now use the Great Ring origin if spawned from a manually-designed empire.