### PR TITLE
More Updates AND DISABLED SUPERTENSILES

### DIFF
--- a/common/megastructures/zz_e_behemoth_egg.txt
+++ b/common/megastructures/zz_e_behemoth_egg.txt
@@ -33,13 +33,7 @@ behemoth_egg = {
 	}
 
 	possible = {
-		hidden_trigger = {
-			exists = starbase
-		}
-		custom_tooltip = {
-			fail_text = "requires_inside_border"
-			is_inside_border = from
-		}
+        inline_script = megastructures/system_ownership_or_waystation_check
 		custom_tooltip = {
 			fail_text = "requires_no_existing_megastructure"
 			has_no_non_gate_megastructure = yes
@@ -539,13 +533,7 @@ behemoth_chrysalis = {
 	}
 
 	possible = {
-		hidden_trigger = {
-			exists = starbase
-		}
-		custom_tooltip = {
-			fail_text = "requires_inside_border"
-			is_inside_border = from
-		}
+        inline_script = megastructures/system_ownership_or_waystation_check
 	}
 
 	on_build_start = {}
@@ -648,13 +636,7 @@ behemoth_chrysalis_big = {
 	}
 
 	possible = {
-		hidden_trigger = {
-			exists = starbase
-		}
-		custom_tooltip = {
-			fail_text = "requires_inside_border"
-			is_inside_border = from
-		}
+        inline_script = megastructures/system_ownership_or_waystation_check
 	}
 
 	on_build_start = {}

--- a/common/megastructures/zz_e_penrose_sphere.txt
+++ b/common/megastructures/zz_e_penrose_sphere.txt
@@ -35,6 +35,7 @@ penrose_sphere_0 = {
 				value < value:giga_penrose_sphere_limit
 			}
 		}
+        is_nomadic = no
 	}
 
 	possible = {

--- a/common/megastructures/zz_e_planetary_drive_yard.txt
+++ b/common/megastructures/zz_e_planetary_drive_yard.txt
@@ -37,6 +37,7 @@ planetary_drive_yard_0 = {
 				value < value:giga_planetshipyard_limit
 			}
 		}
+        is_nomadic = no
 	}
 
 	possible = {

--- a/common/megastructures/zz_e_quantum_catapult.txt
+++ b/common/megastructures/zz_e_quantum_catapult.txt
@@ -29,6 +29,10 @@ quantum_catapult_0 = {
 	
 	prerequisites = { "tech_quantum_catapult" }
 
+    potential = {
+        is_nomadic = no
+    }
+
 	possible = {
 		hidden_trigger = {
 			exists = starbase

--- a/common/megastructures/zz_e_substellar_compressor.txt
+++ b/common/megastructures/zz_e_substellar_compressor.txt
@@ -34,6 +34,7 @@ substellar_compressor_0 = {
 				value < value:giga_compressor_limit
 			}
 		}
+        is_nomadic = no
 	}
 
 	possible = {

--- a/common/scripted_triggers/zzz_overwrites.txt
+++ b/common/scripted_triggers/zzz_overwrites.txt
@@ -2380,3 +2380,550 @@ is_regular_empire = {
     }
     NOT = { has_ethic = ethic_gestalt_consciousness	}
 }
+
+# BIG EVIL
+is_megastructure_incompatible_with_nomads = {
+    OR = {
+        is_megastructure_type = deep_space_citadel_0
+        is_megastructure_type = dyson_swarm_1
+        is_megastructure_type = dyson_swarm_2
+        is_megastructure_type = dyson_swarm_3
+        is_megastructure_type = dyson_sphere_0
+        is_megastructure_type = dyson_sphere_1
+        is_megastructure_type = dyson_sphere_2
+        is_megastructure_type = dyson_sphere_3
+        is_megastructure_type = dyson_sphere_4
+        is_megastructure_type = dyson_sphere_5
+        is_megastructure_type = dyson_sphere_disco
+        is_megastructure_type = dyson_sphere_restored
+        is_megastructure_type = dyson_sphere_disco_restored
+        is_megastructure_type = interstellar_assembly_0
+        is_megastructure_type = interstellar_assembly_1
+        is_megastructure_type = interstellar_assembly_2
+        is_megastructure_type = interstellar_assembly_3
+        is_megastructure_type = interstellar_assembly_4
+        is_megastructure_type = interstellar_assembly_restored
+        is_megastructure_type = habitat_central_complex
+        is_megastructure_type = mega_art_installation_0
+        is_megastructure_type = mega_art_installation_1
+        is_megastructure_type = mega_art_installation_2
+        is_megastructure_type = mega_art_installation_3
+        is_megastructure_type = mega_art_installation_4
+        is_megastructure_type = mega_art_installation_restored
+        is_megastructure_type = mega_art_installation_restored_2
+        is_megastructure_type = mega_shipyard_0
+        is_megastructure_type = mega_shipyard_1
+        is_megastructure_type = mega_shipyard_2
+        is_megastructure_type = mega_shipyard_3
+        is_megastructure_type = mega_shipyard_restored
+        is_megastructure_type = ring_world_1
+        is_megastructure_type = ring_world_2_intermediate
+        is_megastructure_type = ring_world_3_intermediate
+        is_megastructure_type = quantum_catapult_0
+        is_megastructure_type = quantum_catapult_1
+        is_megastructure_type = quantum_catapult_2
+        is_megastructure_type = quantum_catapult_3
+        is_megastructure_type = quantum_catapult_restored
+        is_megastructure_type = quantum_catapult_restored_slingshot
+        is_megastructure_type = quantum_catapult_improved_slingshot
+        is_megastructure_type = think_tank_0
+        is_megastructure_type = think_tank_1
+        is_megastructure_type = think_tank_2
+        is_megastructure_type = think_tank_3
+        is_megastructure_type = think_tank_4
+        is_megastructure_type = think_tank_restored
+        is_megastructure_type = spy_orb_0
+        is_megastructure_type = spy_orb_1
+        is_megastructure_type = spy_orb_2
+        is_megastructure_type = spy_orb_3
+        is_megastructure_type = spy_orb_4
+        is_megastructure_type = spy_orb_restored
+        is_megastructure_type = strategic_coordination_center_0
+        is_megastructure_type = strategic_coordination_center_1
+        is_megastructure_type = strategic_coordination_center_2
+        is_megastructure_type = strategic_coordination_center_3
+        is_megastructure_type = strategic_coordination_center_restored
+
+        # BEGIN THE PAIN
+        is_megastructure_type = dyson_sphere_1_b_star
+        is_megastructure_type = dyson_sphere_1_m_giant_star
+        is_megastructure_type = dyson_sphere_1_a_star
+        is_megastructure_type = dyson_sphere_1_f_star
+        is_megastructure_type = dyson_sphere_1_g_star
+        is_megastructure_type = dyson_sphere_1_k_star
+        is_megastructure_type = dyson_sphere_1_m_star
+        is_megastructure_type = dyson_sphere_1_o_star
+
+        is_megastructure_type = dyson_sphere_2_b_star
+        is_megastructure_type = dyson_sphere_2_m_giant_star
+        is_megastructure_type = dyson_sphere_2_a_star
+        is_megastructure_type = dyson_sphere_2_f_star
+        is_megastructure_type = dyson_sphere_2_g_star
+        is_megastructure_type = dyson_sphere_2_k_star
+        is_megastructure_type = dyson_sphere_2_m_star
+        is_megastructure_type = dyson_sphere_2_o_star
+
+        is_megastructure_type = dyson_sphere_3_b_star
+        is_megastructure_type = dyson_sphere_3_m_giant_star
+        is_megastructure_type = dyson_sphere_3_a_star
+        is_megastructure_type = dyson_sphere_3_f_star
+        is_megastructure_type = dyson_sphere_3_g_star
+        is_megastructure_type = dyson_sphere_3_k_star
+        is_megastructure_type = dyson_sphere_3_m_star
+        is_megastructure_type = dyson_sphere_3_o_star
+
+        is_megastructure_type = dyson_sphere_4_b_star
+        is_megastructure_type = dyson_sphere_4_m_giant_star
+        is_megastructure_type = dyson_sphere_4_a_star
+        is_megastructure_type = dyson_sphere_4_f_star
+        is_megastructure_type = dyson_sphere_4_g_star
+        is_megastructure_type = dyson_sphere_4_k_star
+        is_megastructure_type = dyson_sphere_4_m_star
+        is_megastructure_type = dyson_sphere_4_o_star
+
+        is_megastructure_type = dyson_sphere_5_b_star
+        is_megastructure_type = dyson_sphere_5_m_giant_star
+        is_megastructure_type = dyson_sphere_5_a_star
+        is_megastructure_type = dyson_sphere_5_f_star
+        is_megastructure_type = dyson_sphere_5_g_star
+        is_megastructure_type = dyson_sphere_5_k_star
+        is_megastructure_type = dyson_sphere_5_m_star
+        is_megastructure_type = dyson_sphere_5_o_star
+
+        is_megastructure_type = dyson_sphere_ruined_b_star
+        is_megastructure_type = dyson_sphere_ruined_m_giant_star
+        is_megastructure_type = dyson_sphere_ruined_a_star
+        is_megastructure_type = dyson_sphere_ruined_f_star
+        is_megastructure_type = dyson_sphere_ruined_g_star
+        is_megastructure_type = dyson_sphere_ruined_k_star
+        is_megastructure_type = dyson_sphere_ruined_m_star
+
+        is_megastructure_type = dyson_sphere_restored_b_star
+        is_megastructure_type = dyson_sphere_restored_m_giant_star
+        is_megastructure_type = dyson_sphere_restored_a_star
+        is_megastructure_type = dyson_sphere_restored_f_star
+        is_megastructure_type = dyson_sphere_restored_g_star
+        is_megastructure_type = dyson_sphere_restored_k_star
+        is_megastructure_type = dyson_sphere_restored_m_star
+
+        # matrioshka scaling
+        #is_megastructure_type = matrioshka_brain_0
+        is_megastructure_type = matrioshka_brain_0_b_star
+        is_megastructure_type = matrioshka_brain_0_m_giant_star
+        is_megastructure_type = matrioshka_brain_0_a_star
+        is_megastructure_type = matrioshka_brain_0_f_star
+        is_megastructure_type = matrioshka_brain_0_g_star
+        is_megastructure_type = matrioshka_brain_0_k_star
+        is_megastructure_type = matrioshka_brain_0_m_star
+        is_megastructure_type = matrioshka_brain_0_o_star
+
+        #is_megastructure_type = matrioshka_brain_1
+        is_megastructure_type = matrioshka_brain_1_b_star
+        is_megastructure_type = matrioshka_brain_1_m_giant_star
+        is_megastructure_type = matrioshka_brain_1_a_star
+        is_megastructure_type = matrioshka_brain_1_f_star
+        is_megastructure_type = matrioshka_brain_1_g_star
+        is_megastructure_type = matrioshka_brain_1_k_star
+        is_megastructure_type = matrioshka_brain_1_m_star
+        is_megastructure_type = matrioshka_brain_1_o_star
+
+        #is_megastructure_type = matrioshka_brain_2
+        is_megastructure_type = matrioshka_brain_2_b_star
+        is_megastructure_type = matrioshka_brain_2_m_giant_star
+        is_megastructure_type = matrioshka_brain_2_a_star
+        is_megastructure_type = matrioshka_brain_2_f_star
+        is_megastructure_type = matrioshka_brain_2_g_star
+        is_megastructure_type = matrioshka_brain_2_k_star
+        is_megastructure_type = matrioshka_brain_2_m_star
+        is_megastructure_type = matrioshka_brain_2_o_star
+
+        #is_megastructure_type = matrioshka_brain_3
+        is_megastructure_type = matrioshka_brain_3_b_star
+        is_megastructure_type = matrioshka_brain_3_m_giant_star
+        is_megastructure_type = matrioshka_brain_3_a_star
+        is_megastructure_type = matrioshka_brain_3_f_star
+        is_megastructure_type = matrioshka_brain_3_g_star
+        is_megastructure_type = matrioshka_brain_3_k_star
+        is_megastructure_type = matrioshka_brain_3_m_star
+        is_megastructure_type = matrioshka_brain_3_o_star
+
+        #is_megastructure_type = matrioshka_brain_4
+        is_megastructure_type = matrioshka_brain_4_b_star
+        is_megastructure_type = matrioshka_brain_4_m_giant_star
+        is_megastructure_type = matrioshka_brain_4_a_star
+        is_megastructure_type = matrioshka_brain_4_f_star
+        is_megastructure_type = matrioshka_brain_4_g_star
+        is_megastructure_type = matrioshka_brain_4_k_star
+        is_megastructure_type = matrioshka_brain_4_m_star
+        is_megastructure_type = matrioshka_brain_4_o_star
+
+        #is_megastructure_type = matrioshka_brain_5
+        is_megastructure_type = matrioshka_brain_5_b_star
+        is_megastructure_type = matrioshka_brain_5_m_giant_star
+        is_megastructure_type = matrioshka_brain_5_a_star
+        is_megastructure_type = matrioshka_brain_5_f_star
+        is_megastructure_type = matrioshka_brain_5_g_star
+        is_megastructure_type = matrioshka_brain_5_k_star
+        is_megastructure_type = matrioshka_brain_5_m_star
+        is_megastructure_type = matrioshka_brain_5_o_star
+
+        is_megastructure_type = star_lifter_0
+        is_megastructure_type = star_lifter_0_b_star
+        is_megastructure_type = star_lifter_0_m_giant_star
+        is_megastructure_type = star_lifter_0_a_star
+        is_megastructure_type = star_lifter_0_f_star
+        is_megastructure_type = star_lifter_0_g_star
+        is_megastructure_type = star_lifter_0_k_star
+        is_megastructure_type = star_lifter_0_m_star
+        is_megastructure_type = star_lifter_0_o_star
+
+        is_megastructure_type = star_lifter_1
+        is_megastructure_type = star_lifter_1_b_star
+        is_megastructure_type = star_lifter_1_m_giant_star
+        is_megastructure_type = star_lifter_1_a_star
+        is_megastructure_type = star_lifter_1_f_star
+        is_megastructure_type = star_lifter_1_g_star
+        is_megastructure_type = star_lifter_1_k_star
+        is_megastructure_type = star_lifter_1_m_star
+        is_megastructure_type = star_lifter_1_o_star
+
+        is_megastructure_type = star_lifter_2
+        is_megastructure_type = star_lifter_2_b_star
+        is_megastructure_type = star_lifter_2_m_giant_star
+        is_megastructure_type = star_lifter_2_a_star
+        is_megastructure_type = star_lifter_2_f_star
+        is_megastructure_type = star_lifter_2_g_star
+        is_megastructure_type = star_lifter_2_k_star
+        is_megastructure_type = star_lifter_2_m_star
+        is_megastructure_type = star_lifter_2_o_star
+
+        is_megastructure_type = star_lifter_3
+        is_megastructure_type = star_lifter_3_b_star
+        is_megastructure_type = star_lifter_3_m_giant_star
+        is_megastructure_type = star_lifter_3_a_star
+        is_megastructure_type = star_lifter_3_f_star
+        is_megastructure_type = star_lifter_3_g_star
+        is_megastructure_type = star_lifter_3_k_star
+        is_megastructure_type = star_lifter_3_m_star
+        is_megastructure_type = star_lifter_3_o_star
+
+        is_megastructure_type = star_lifter_4
+        is_megastructure_type = star_lifter_4_b_star
+        is_megastructure_type = star_lifter_4_m_giant_star
+        is_megastructure_type = star_lifter_4_a_star
+        is_megastructure_type = star_lifter_4_f_star
+        is_megastructure_type = star_lifter_4_g_star
+        is_megastructure_type = star_lifter_4_k_star
+        is_megastructure_type = star_lifter_4_m_star
+        is_megastructure_type = star_lifter_4_o_star
+
+        is_megastructure_type = star_lifter_5
+        is_megastructure_type = star_lifter_5_b_star
+        is_megastructure_type = star_lifter_5_m_giant_star
+        is_megastructure_type = star_lifter_5_a_star
+        is_megastructure_type = star_lifter_5_f_star
+        is_megastructure_type = star_lifter_5_g_star
+        is_megastructure_type = star_lifter_5_k_star
+        is_megastructure_type = star_lifter_5_m_star
+        is_megastructure_type = star_lifter_5_o_star
+
+        # gigas
+        is_megastructure_type = alderson_disk_0
+        is_megastructure_type = alderson_disk_1
+        is_megastructure_type = alderson_disk_2
+        # is_megastructure_type = alderson_disk_2_ecu
+        is_megastructure_type = alderson_disk_2_gaia
+        # is_megastructure_type = alderson_disk_2_pc
+        # is_megastructure_type = alderson_disk_2_hive
+        # is_megastructure_type = alderson_disk_2_machine
+
+        is_megastructure_type = asteroid_manufactory_0
+        is_megastructure_type = asteroid_manufactory_platform_alloys
+        is_megastructure_type = asteroid_manufactory_ai_alloys
+        is_megastructure_type = asteroid_manufactory_alloys
+        is_megastructure_type = asteroid_manufactory_platform_consumer_goods
+        is_megastructure_type = asteroid_manufactory_ai_consumer_goods
+        is_megastructure_type = asteroid_manufactory_consumer_goods
+        is_megastructure_type = asteroid_manufactory_platform_energy
+        is_megastructure_type = asteroid_manufactory_ai_energy
+        is_megastructure_type = asteroid_manufactory_energy
+        is_megastructure_type = asteroid_manufactory_platform_food
+        is_megastructure_type = asteroid_manufactory_ai_food
+        is_megastructure_type = asteroid_manufactory_food
+        is_megastructure_type = asteroid_manufactory_platform_supertensiles
+        is_megastructure_type = asteroid_manufactory_ai_supertensiles
+        is_megastructure_type = asteroid_manufactory_supertensiles
+        #is_megastructure_type = asteroid_manufactory_1
+        is_megastructure_type = asteroid_manufactory_2
+
+        is_megastructure_type = terraform_toxic_0
+        is_megastructure_type = terraform_toxic_1
+
+        is_megastructure_type = war_moon_0
+        is_megastructure_type = war_moon_1
+        is_megastructure_type = war_moon_2
+
+        is_megastructure_type = war_planet_0
+        is_megastructure_type = war_planet_1
+        is_megastructure_type = war_planet_2
+        is_megastructure_type = war_planet_3
+
+        is_megastructure_type = birch_world_0
+        is_megastructure_type = birch_world_1
+        is_megastructure_type = birch_world_2
+        is_megastructure_type = birch_world_3
+
+        is_megastructure_type = terraform_barren_0
+        is_megastructure_type = terraform_barren_1
+
+        is_megastructure_type = eq_shipyard_0
+        is_megastructure_type = eq_shipyard_1
+        is_megastructure_type = eq_shipyard_2
+
+        is_megastructure_type = ehof_megastructure_phase0
+        is_megastructure_type = ehof_megastructure_phase1
+        is_megastructure_type = ehof_megastructure_phase2
+        is_megastructure_type = ehof_megastructure_phase3
+        is_megastructure_type = ehof_megastructure_phase4
+        is_megastructure_type = ehof_megastructure_restored
+        is_megastructure_type = ehof_megastructure_ruined
+        is_megastructure_type = ehof_megastructure_restored_origin
+        is_megastructure_type = ehof_megastructure_ruined_origin
+
+        is_megastructure_type = ehof_presphere_dyson
+        is_megastructure_type = ehof_presphere_ruined
+
+        is_megastructure_type = ehof_sm_forge_phase0
+        is_megastructure_type = ehof_sm_forge_phase00
+        is_megastructure_type = ehof_sm_forge_phase1
+        is_megastructure_type = ehof_sm_forge_phase2
+        is_megastructure_type = ehof_sm_forge_phase3
+        is_megastructure_type = ehof_sm_forge_phase4
+
+        is_megastructure_type = fusion_suppressor_0
+        is_megastructure_type = fusion_suppressor_1
+        is_megastructure_type = fusion_suppressor_2
+        is_megastructure_type = fusion_suppressor_3
+        is_megastructure_type = fusion_suppressor_4
+        is_megastructure_type = fusion_suppressor_5
+        is_megastructure_type = fusion_suppressor_6
+        is_megastructure_type = fusion_suppressor_7
+
+        is_megastructure_type = terraform_molten_0
+        is_megastructure_type = terraform_molten_1
+
+        is_megastructure_type = terraform_shattered_0
+        is_megastructure_type = terraform_shattered_1
+        is_megastructure_type = terraform_shattered_2
+        is_megastructure_type = terraform_shattered_3
+        is_megastructure_type = terraform_shattered_4
+
+        is_megastructure_type = nicoll_beam_0
+        is_megastructure_type = nicoll_beam_1
+        is_megastructure_type = nicoll_beam_2
+        is_megastructure_type = nicoll_beam_3
+        is_megastructure_type = nicoll_beam_4
+        is_megastructure_type = nicoll_beam_cooldown
+        is_megastructure_type = nicoll_beam_menu
+        is_megastructure_type = nicoll_beam_ready
+        is_megastructure_type = nicoll_beam_firing
+        is_megastructure_type = nicoll_beam_targetting
+        # is_megastructure_type = nicoll_beam_recharge_after_damage
+        # is_megastructure_type = nicoll_beam_recharge_after_barren
+        # is_megastructure_type = nicoll_beam_recharge_after_melt
+        # is_megastructure_type = nicoll_beam_recharge_after_crack
+        # is_megastructure_type = nicoll_beam_recharge_after_system
+
+        is_megastructure_type = hrae_mc_0
+        is_megastructure_type = hrae_mc_1
+        is_megastructure_type = hrae_mc_2
+        is_megastructure_type = hrae_mc_3
+        is_megastructure_type = hrae_mc_4
+
+        is_megastructure_type = hyperstructural_ass_0
+        is_megastructure_type = hyperstructural_ass_1
+        is_megastructure_type = hyperstructural_ass_2
+        is_megastructure_type = hyperstructural_ass_3
+        is_megastructure_type = hyperstructural_ass_4
+
+        is_megastructure_type = interstellar_habitat_0
+        is_megastructure_type = interstellar_habitat_1
+        is_megastructure_type = interstellar_habitat_2
+        is_megastructure_type = interstellar_habitat_3
+        is_megastructure_type = interstellar_habitat_4
+        is_megastructure_type = interstellar_habitat_5
+
+        is_megastructure_type = kugelblitz_0
+        is_megastructure_type = kugelblitz_1
+        is_megastructure_type = kugelblitz_2
+        is_megastructure_type = kugelblitz_3
+        is_megastructure_type = kugelblitz_restored
+        is_megastructure_type = kugelblitz_ruined
+
+        is_megastructure_type = lunar_disco_ball_0
+        is_megastructure_type = lunar_disco_ball_1
+        is_megastructure_type = lunar_disco_ball_2
+
+        is_megastructure_type = macro_stabilizer_0
+        is_megastructure_type = macro_stabilizer_1
+        is_megastructure_type = macro_stabilizer_2
+        is_megastructure_type = macro_stabilizer_3
+
+        is_megastructure_type = orbital_naval_logistics_office_0
+        is_megastructure_type = orbital_naval_logistics_office_1
+
+        is_megastructure_type = neutronium_gigaforge_0
+        is_megastructure_type = neutronium_gigaforge_1
+        is_megastructure_type = neutronium_gigaforge_2
+        is_megastructure_type = neutronium_gigaforge_3
+        is_megastructure_type = neutronium_gigaforge_restored
+        is_megastructure_type = neutronium_gigaforge_ruined
+
+        is_megastructure_type = nidavellir_forge_0
+        is_megastructure_type = nidavellir_forge_1
+        is_megastructure_type = nidavellir_forge_2
+        is_megastructure_type = nidavellir_forge_3
+        is_megastructure_type = nidavellir_forge_4
+
+        is_megastructure_type = orbital_arcology_0
+        is_megastructure_type = orbital_arcology_1
+        is_megastructure_type = orbital_arcology_1_m
+        is_megastructure_type = orbital_arcology_1_l
+
+        is_megastructure_type = orbital_elysium_0
+
+        is_megastructure_type = penrose_sphere_0
+        is_megastructure_type = penrose_sphere_1
+        is_megastructure_type = penrose_sphere_a2
+        is_megastructure_type = penrose_sphere_a3
+        is_megastructure_type = penrose_sphere_a4
+        #is_megastructure_type = penrose_sphere_a41
+        #is_megastructure_type = penrose_sphere_a42
+        is_megastructure_type = penrose_sphere_b2
+        is_megastructure_type = penrose_sphere_b3
+        is_megastructure_type = penrose_sphere_b4
+
+        is_megastructure_type = planetary_computer_0
+        is_megastructure_type = planetary_computer_1
+        is_megastructure_type = planetary_computer_2
+
+        is_megastructure_type = psychic_beacon_0
+        is_megastructure_type = psychic_beacon_1
+        is_megastructure_type = psychic_beacon_2
+        is_megastructure_type = psychic_beacon_3
+        is_megastructure_type = psychic_beacon_4
+
+        is_megastructure_type = psychic_hypersiphon_0
+        is_megastructure_type = psychic_hypersiphon_1
+        is_megastructure_type = psychic_hypersiphon_2
+        #is_megastructure_type = psychic_hypersiphon_3
+
+        is_megastructure_type = quasi_stellar_obliterator_0
+        is_megastructure_type = quasi_stellar_obliterator_1
+        is_megastructure_type = quasi_stellar_obliterator_2
+        is_megastructure_type = quasi_stellar_obliterator_3
+        is_megastructure_type = quasi_stellar_obliterator_4
+        is_megastructure_type = quasi_stellar_obliterator_5
+        is_megastructure_type = quasi_stellar_obliterator_6
+
+        # is_megastructure_type = particle_accelerator_0
+        # is_megastructure_type = particle_accelerator_1
+        # is_megastructure_type = particle_accelerator_restored
+        # is_megastructure_type = particle_accelerator_ruined
+
+        is_megastructure_type = war_system_0
+        is_megastructure_type = war_system_1
+        is_megastructure_type = war_system_2
+        is_megastructure_type = war_system_3
+        is_megastructure_type = war_system_4
+        is_megastructure_type = war_system_5
+
+        is_megastructure_type = substellar_compressor_0
+        is_megastructure_type = substellar_compressor_1
+        is_megastructure_type = substellar_compressor_2
+        is_megastructure_type = substellar_compressor_4
+        is_megastructure_type = substellar_compressor_5
+        is_megastructure_type = substellar_compressor_6
+        is_megastructure_type = substellar_compressor_7
+
+        is_megastructure_type = yggdrasil_orchid_0
+        is_megastructure_type = yggdrasil_orchid_1
+        is_megastructure_type = yggdrasil_orchid_2
+        is_megastructure_type = yggdrasil_orchid_3
+        is_megastructure_type = yggdrasil_orchid_restored
+        is_megastructure_type = yggdrasil_orchid_ruined
+
+        is_megastructure_type = the_vat_0
+        is_megastructure_type = the_vat_1
+        is_megastructure_type = the_vat_2
+        is_megastructure_type = the_vat_3
+        is_megastructure_type = the_vat_4
+
+        is_megastructure_type = ringworld_titanic_0
+        is_megastructure_type = ringworld_titanic_1
+        is_megastructure_type = ringworld_titanic_2
+        is_megastructure_type = ringworld_t_3x_segment
+
+        is_megastructure_type = ringworld_behemoth_0
+        is_megastructure_type = ringworld_behemoth_1
+        is_megastructure_type = ringworld_behemoth_2
+        is_megastructure_type = ringworld_b_3x_segment
+
+        is_megastructure_type = ringworld_gargantuan_0
+        is_megastructure_type = ringworld_gargantuan_1
+        is_megastructure_type = ringworld_gargantuan_2
+        is_megastructure_type = ringworld_g_3x_segment
+
+        is_megastructure_type = r_square_world_hub
+        is_megastructure_type = r_square_world_hub_garyx
+        is_megastructure_type = r_square_world_hub_powered
+        is_megastructure_type = r_square_world_restored
+        is_megastructure_type = r_square_world_ruined
+
+        is_megastructure_type = planetary_drive_yard_0
+        is_megastructure_type = planetary_drive_yard_1
+        is_megastructure_type = planetary_drive_yard_1_shipyard
+        is_megastructure_type = planetary_drive_yard_1_fortress
+
+        is_megastructure_type = lunar_macroreplicator_0
+        is_megastructure_type = lunar_macroreplicator_1
+        is_megastructure_type = lunar_macroreplicator_2
+        is_megastructure_type = lunar_macroreplicator_make_moon
+
+        is_megastructure_type = planetcraft_printer_0
+        is_megastructure_type = planetcraft_printer_1
+        is_megastructure_type = planetcraft_printer_2
+        is_megastructure_type = planetcraft_printer_3
+        is_megastructure_type = planetcraft_printer_make_planet
+
+        is_megastructure_type = maginot_world_0
+        is_megastructure_type = maginot_world_1
+        is_megastructure_type = maginot_world_2
+        is_megastructure_type = maginot_world_ringworld_0
+        is_megastructure_type = maginot_world_ringworld_1
+        is_megastructure_type = maginot_world_ringworld_2
+
+        is_megastructure_type = frameworld_penrose_0
+        is_megastructure_type = frameworld_penrose_1
+        is_megastructure_type = frameworld_penrose_2
+        is_megastructure_type = frameworld_decompressor_0
+        is_megastructure_type = frameworld_decompressor_1
+        is_megastructure_type = frameworld_decompressor_2
+
+        is_megastructure_type = blokkat_star_fix_0
+        is_megastructure_type = blokkat_star_fix_1
+        is_megastructure_type = blokkat_star_fix_active
+
+        is_megastructure_type = stellar_ring_habitat_0
+        is_megastructure_type = stellar_ring_habitat_1
+        is_megastructure_type = stellar_ring_habitat_2
+        is_megastructure_type = stellar_ring_habitat_3
+
+
+
+
+
+
+
+    }
+}

--- a/events/REVERT_giga_disable_supertensiles_4_4.txt
+++ b/events/REVERT_giga_disable_supertensiles_4_4.txt
@@ -1,0 +1,32 @@
+namespace = giga_disable_supertensiles_4_4
+
+country_event = {
+    id = giga_disable_supertensiles_4_4.1
+    hide_window = yes
+    is_triggered_only = yes
+
+    immediate = {
+        if = {
+            limit = {
+                has_global_flag = @giga_amb_flag
+            }
+            remove_global_flag = @giga_amb_flag
+            remove_flags_buildcap = yes
+            set_global_flag = giga_buildcap_u
+            country_event = { id = giga_disable_supertensiles_4_4.2 }
+        }
+    }
+}
+
+country_event = {
+    id = giga_disable_supertensiles_4_4.2
+    hide_window = no
+    is_triggered_only = yes
+
+    title = giga_disable_supertensiles_4_4.2.name
+    desc = giga_disable_supertensiles_4_4.2.desc
+    picture = GFX_evt_black_hole
+    show_sound = event_dyson_sphere_build_upgrade_panel
+    location = event_target:giga_planet
+    option = { name = giga_disable_supertensiles_4_4.2.2.a }
+}

--- a/events/giga_002_menu.txt
+++ b/events/giga_002_menu.txt
@@ -358,6 +358,15 @@ country_event = {
 	is_triggered_only = yes
 
 	immediate = {
+
+        # REVERT ME SUPERTENSILES 4_4
+        if = {
+            limit = {
+                has_global_flag = @giga_amb_flag
+            }
+            country_event = { id = giga_disable_supertensiles_4_4.1 }
+        }
+
 		every_megastructure = {
 			# Remove unwanted ruined megastructures
 			if = {

--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -14714,3 +14714,7 @@
  giga_pending_rework:0 "Temporarily disabled, to be reworked"
 
  giga_reset:0 "£giga_reset£ Reset"
+
+ giga_disable_supertensiles_4_4.2.name: "SUPERTENSILES DISABLED"
+ giga_disable_supertensiles_4_4.2.desc: "Due to a bug with supertensiles, they have been temporarily forcibly disabled. Your mega build cap has been set to §_Unlimited§!."
+ giga_disable_supertensiles_4_4.2.2.a: "Alright"


### PR DESCRIPTION
SUPERTENSILES ARE DISABLED TEMPORARILY
Hid some megas from the construction screen that nomads couldnt build anyways
Update behemoth egg overwrite
Added overwrite for the `is_megastructure_incompatible_with_nomads` trigger