### PR TITLE
EHOF and carrier fixes

### DIFF
--- a/common/governments/civics/ehof_origin.txt
+++ b/common/governments/civics/ehof_origin.txt
@@ -12,10 +12,7 @@ origin_incohesive = {
 	description = origin_incohesive_effect_desc
 
 	possible = {
-		NOT = {
-			text = "Nomads are currently unable repair the EHOF, so cannot escape the cohesive cluster."
-			is_nomadic = yes
-		}
+		is_nomadic = no
 	}
 
 	# ai_playable = {

--- a/common/megastructures/zz_c_dyson_swarm.txt
+++ b/common/megastructures/zz_c_dyson_swarm.txt
@@ -377,8 +377,7 @@ dyson_swarm_3 = {
 				any_system_planet = {
 					is_colony = yes
 					is_artificial = no
-					exists = owner
-					owner = {
+					owner? = {
 						is_primitive = no
 					}
 				}
@@ -388,8 +387,7 @@ dyson_swarm_3 = {
 			limit = {
 				solar_system = {
 					any_system_planet = {
-						exists = owner
-						owner = {
+						owner? = {
 							is_primitive = yes
 						}
 					}

--- a/common/resolutions/z_giga_resolution_overwrites.txt
+++ b/common/resolutions/z_giga_resolution_overwrites.txt
@@ -42,7 +42,13 @@ resolution_custodian_united_front = {
     }
 
     potential = {
-        has_nemesis = yes
+        OR = {
+            has_nemesis = yes
+            AND = {
+                has_nomads_dlc = yes
+                has_ascension_perk = ap_defender_of_the_galaxy_nomads
+            }
+        }
         is_galactic_custodian = yes
         any_country = { is_crisis_faction = yes }
     }
@@ -122,8 +128,7 @@ resolution_custodian_united_front = {
         modifier = {
             factor = 0
             OR = {
-                has_ascension_perk = ap_become_the_crisis
-                has_ascension_perk = ap_cosmogenesis
+                is_player_crisis = yes
             }
             desc = gal_com_we_have_crisis_perk
         }

--- a/common/scripted_effects/giga_blokkat_effects.txt
+++ b/common/scripted_effects/giga_blokkat_effects.txt
@@ -160,7 +160,7 @@ blokkat_harvest_system = {
 			planet_event = { id = giga_qso.111 }
 		}
 		every_system_planet = {
-			limit = { has_planet_flag = machine_lair }
+			limit = { has_carrier_flag = machine_lair }
 			planet_event = { id = giga_qso.113 }
 		}
 		every_system_planet = {
@@ -348,7 +348,7 @@ blokkat_harvest_system_mothership = {
 			planet_event = { id = giga_qso.111 }
 		}
 		every_system_planet = {
-			limit = { has_planet_flag = machine_lair }
+			limit = { has_carrier_flag = machine_lair }
 			planet_event = { id = giga_qso.113 }
 		}
 		every_system_planet = {
@@ -2142,7 +2142,7 @@ blokkat_harvest_system_player = {
 			planet_event = { id = giga_qso.111 }
 		}
 		every_system_planet = {
-			limit = { has_planet_flag = machine_lair }
+			limit = { has_carrier_flag = machine_lair }
 			planet_event = { id = giga_qso.113 }
 		}
 		every_system_planet = {

--- a/common/scripted_effects/y_giga_low_priority_overwrites.txt
+++ b/common/scripted_effects/y_giga_low_priority_overwrites.txt
@@ -266,18 +266,18 @@ hyperthermia_galaxy_effect = {
     every_system_planet = {
         limit = {
             is_planet_class = pc_ai
-            NOT = { has_planet_flag = machine_lair }
+            NOT = { has_carrier_flag = machine_lair }
         }
         destroy_machine_world = yes
     }
     random_system_planet = {
         limit = {
             is_planet_class = pc_ai
-            has_planet_flag = machine_lair
+            has_carrier_flag = machine_lair
         }
         from.owner = { save_event_target_as = final_machine_world_destroyer }
         stop_crisis_sound = yes
-        planet_event = { id = crisis.2046 }
+        carrier_event = { id = crisis.2046 }
     }
     every_system_planet = {
         limit = {

--- a/common/scripted_effects/zzz_giga_overwrites.txt
+++ b/common/scripted_effects/zzz_giga_overwrites.txt
@@ -96,10 +96,10 @@ spawn_habitat_cracker_effect = {
         }
         random_system_planet = {
             limit = {
-                has_planet_flag = habitat@event_target:target_habitat
+                has_carrier_flag = habitat@event_target:target_habitat
             }
-            remove_planet_flag = habitat@event_target:target_habitat
-            set_planet_flag = habitat_build_site
+            remove_carrier_flag = habitat@event_target:target_habitat
+            set_carrier_flag = habitat_build_site
         }
         every_fleet_in_system = {
             limit = {
@@ -159,7 +159,7 @@ activate_behemoth_superweapon = { #Overwrite to not kill the bloody vester
 			habitable_planet_not_urban = yes
 		}
 		change_pc = pc_nuked
-		set_planet_flag = nuked_planet_anomalies_disabled
+		set_carrier_flag = nuked_planet_anomalies_disabled
 		reroll_deposits = yes
 		tomb_world_modifier_cleanup = yes
 		validate_planet_buildings_and_districts = yes

--- a/common/scripted_triggers/03_giga_low_priority_overwrites.txt
+++ b/common/scripted_triggers/03_giga_low_priority_overwrites.txt
@@ -374,6 +374,10 @@ has_special_star_flag_trigger = {
         has_star_flag = jupitwo_system
         has_star_flag = pouchkinn_system
 		has_star_flag = eawaf_system
+		has_star_flag = everchanging_system
+		has_star_flag = urmazin_system
+		has_star_flag = urmazin_capital
+		has_star_flag = compound_cluster
 	}
 }
 

--- a/common/scripted_triggers/zzz_overwrites.txt
+++ b/common/scripted_triggers/zzz_overwrites.txt
@@ -1394,7 +1394,7 @@ can_destroy_planet_with_PLANET_KILLER_CRACKER = {
 	}
 	custom_tooltip = {
 		fail_text = fotd_cant_collossus
-		NOT = { has_planet_flag = fotd_seperatist_planet@from.owner }
+		NOT = { has_carrier_flag = fotd_seperatist_planet@from.owner }
 		exists = from.owner
 		from.owner = { 
 			NOT = { has_country_flag = fotd_seperatist_country@from.owner }

--- a/events/!_giga_overwritten_events.txt
+++ b/events/!_giga_overwritten_events.txt
@@ -357,7 +357,7 @@ country_event = {
 
 # Change blacklist in embracing the worm event
 namespace = akx
-planet_event = {
+carrier_event = {
 	id = akx.10020
 	title = akx.10020.name
 	desc = akx.10020.desc
@@ -728,7 +728,7 @@ carrier_event = {
 						owner = { has_country_flag = relentless_industrialists_situation_happened }
 					}
 				}
-				planet_event = { id = toxoids.5 days = 15 random = 180 }
+				carrier_event = { id = toxoids.5 days = 15 random = 180 }
 			}
 			else = {
 				change_pc = pc_nuked
@@ -890,7 +890,7 @@ country_event = { # To infinity and beyond the event horizon
 					has_star_flag = terminal_egress
 					has_star_flag = guardians_horror_system
 					any_system_planet = {
-						has_planet_flag = black_hole_horror
+						has_carrier_flag = black_hole_horror
 					}
 					is_capital_system = yes
 					has_star_flag = cosmogenesis_project
@@ -1404,7 +1404,7 @@ carrier_event = {
 
 ### Create the Unemployed
 ### Fired by cybernetics.2025 and cybernetics.2026
-planet_event = {
+carrier_event = {
 	id = cybernetics.2027
 	hide_window = yes
 

--- a/events/giga_011_qso.txt
+++ b/events/giga_011_qso.txt
@@ -2492,7 +2492,7 @@ country_event = {
 				if = {
 					limit = { is_planet_class = pc_ai }
 					if = {
-						limit = { NOT = { has_planet_flag = machine_lair } }
+						limit = { NOT = { has_carrier_flag = machine_lair } }
 						planet_event = { id = giga_qso.111 } # contingency planet
 						every_country = { country_event = { id = giga_qso.110 } } # message
 					}
@@ -2711,7 +2711,7 @@ country_event = { #blast
 			if = {
 				limit = { is_planet_class = pc_ai }
 				if = {
-					limit = { NOT = { has_planet_flag = machine_lair } }
+					limit = { NOT = { has_carrier_flag = machine_lair } }
 					planet_event = { id = giga_qso.111 } # contingency planet
 					every_country = { country_event = { id = giga_qso.110 } } # message
 				}

--- a/events/giga_105_ehof.txt
+++ b/events/giga_105_ehof.txt
@@ -1113,7 +1113,14 @@ country_event = {
 				any_planet_within_border = {
 					solar_system = {
 						is_capital_system = no
-						has_special_star_flag_trigger = no
+						OR = { #people kept bug-reporting that it won't spawn when it doesn't spawn literally nextdoor so here you go, it can spawn nextdoor now
+							has_special_star_flag_trigger = no
+							has_star_flag = neighbor_t1
+							has_star_flag = neighbor_t1_first_colony
+							has_star_flag = neighbor_t2
+							has_star_flag = neighbor_t2_second_colony
+							has_star_flag = empire_cluster
+						}
 					}
 					is_artificial = no
 					is_colonizable = no
@@ -1128,7 +1135,14 @@ country_event = {
 				limit = {
 					solar_system = {
 						is_capital_system = no
-						has_special_star_flag_trigger = no
+						OR = { #people kept bug-reporting that it won't spawn when it doesn't spawn literally nextdoor so here you go, it can spawn nextdoor now
+							has_special_star_flag_trigger = no
+							has_star_flag = neighbor_t1
+							has_star_flag = neighbor_t1_first_colony
+							has_star_flag = neighbor_t2
+							has_star_flag = neighbor_t2_second_colony
+							has_star_flag = empire_cluster
+						}
 					}
 					is_artificial = no
 					is_colonizable = no
@@ -3985,6 +3999,35 @@ ship_event = {
 			}
 		}
 		default_hide_option = yes
+	}
+
+	option = {
+		name = ehof_megastructure.018.b
+		custom_tooltip = ehof_megastructure.018.b.tooltip
+		owner = {
+			add_monthly_resource_mult = {
+				resource = physics_research
+				value = @tier5researchreward
+				min = @tier5researchmin
+				max = @tier5researchmax
+			}
+			add_monthly_resource_mult = {
+				resource = engineering_research
+				value = @tier5researchreward
+				min = @tier5researchmin
+				max = @tier5researchmax
+			}
+		}
+		hidden_effect = {
+			owner = {
+				set_country_flag = explored_ruined_ehof
+			}
+		}
+		allow = {
+			owner = {
+				is_ai = no
+			}
+		}
 	}
 }
 

--- a/localisation/english/giga_ehof_l_english.yml
+++ b/localisation/english/giga_ehof_l_english.yml
@@ -1882,6 +1882,7 @@
  ehof_megastructure.018.desc:0 "A damaged orbital structure is located in the core of the §H[root.solar_system.GetName]§!, one which appears to envelop the central black hole. Our initial survey indicates that the construct appears to be non-functional and abandoned. To determine its purpose, we'll have to explore the construct."
  ehof_megastructure.018.a:0 "Intriguing!"
  ehof_megastructure.018.b:0 "Nah. Staying isolated is much cooler."
+ ehof_megastructure.018.b.tooltip:0 "§RYou will not be able to expand the cluster, or leave it without technologies such as jump drives.§!"
 
  EXPLORE_RUINED_EHOF:0 "Explore the Black Hole Construct"
  EXPLORE_RUINED_EHOF_DESC:0 "The exploration project of the damaged black hole construct inside the §H[root.solar_system.GetName]§! system is ongoing. To determine its purpose, we will have to equip exploration units with gear capable of handling hard vacuum and intense gravity, and send them into the remains of the construct."


### PR DESCRIPTION
Correctly blocked nomads from Away on an Island origin.
The Orange Bolt (EHOF) digsite will spawn more reliably.
Fixed the DLC lock and player crisis checks on the United Front resolution overwrite.
Certain random events can no longer trigger in Urmazin and Compound-related systems.