### PR TITLE
Nomad Asteroid Industry

### DIFF
--- a/common/buildings/giga_asteroid_industry_buildings.txt
+++ b/common/buildings/giga_asteroid_industry_buildings.txt
@@ -21,37 +21,89 @@ building_giga_asteroid_factory_alloys = {
         cap_modifier = building_giga_asteroid_factory_alloys_country_max
         unlock = "always = yes"
         modifiers = "
-            triggered_planet_modifier = {
-                potential = {
-                    exists = owner
-                    owner = {
-                        is_catalytic_empire = no
-                    }
-                    solar_system = {
-                        any_system_megastructure = {
-                            is_megastructure_type = asteroid_manufactory_alloys
-                        }
-                    }
-                }
-                planet_metallurgists_minerals_upkeep_add = -1
-                planet_metallurgists_energy_upkeep_add = 0.5
-            }
+	        triggered_planet_modifier = {
+	        	potential = {
+	        		owner? = {
+	        		    is_catalytic_empire = no
+	        			if = {
+	        				limit = { is_nomadic = yes  }
+	        				solar_system = {
+	        					any_starbase_in_system = {
+	        						is_waystation_starbase = yes
+	        						owner? = {
+	        							is_same_value = root.owner
+	        						}
+	        						any_starbase_in_network = {
+	        							has_starbase_size >= starbase_waystation_1
+	        							owner? = {
+	        								is_same_value = root.owner
+	        							}
+	        							solar_system = {
+	        								any_system_megastructure = {
+	        									is_megastructure_type = asteroid_manufactory_alloys
+	        								}
+	        							}
+	        						}
+	        					}
+	        				}
+	        			}
+	        			else_if = {
+	        				limit = { is_nomadic = no }
+	        				prev = {
+	        					solar_system = {
+	        						any_system_megastructure = {
+	        							is_megastructure_type = asteroid_manufactory_alloys
+	        						}
+	        					}
+	        				}
+	        			}
+	        		}
+	        	}
+	        	planet_metallurgists_minerals_upkeep_add = -1
+	        	planet_metallurgists_energy_upkeep_add = 0.5
+	        }
 
-            triggered_planet_modifier = {
-                potential = {
-                    exists = owner
-                    owner = {
-                        is_catalytic_empire = yes
-                    }
-                    solar_system = {
-                        any_system_megastructure = {
-                            is_megastructure_type = asteroid_manufactory_alloys
-                        }
-                    }
-                }
-                planet_metallurgists_food_upkeep_add = -1.5
-                planet_metallurgists_energy_upkeep_add = 0.5
-            }
+	        triggered_planet_modifier = {
+	        	potential = {
+	        		owner? = {
+	        		    is_catalytic_empire = yes
+	        			if = {
+	        				limit = { is_nomadic = yes  }
+	        				solar_system = {
+	        					any_starbase_in_system = {
+	        						is_waystation_starbase = yes
+	        						owner? = {
+	        							is_same_value = root.owner
+	        						}
+	        						any_starbase_in_network = {
+	        							has_starbase_size >= starbase_waystation_1
+	        							owner? = {
+	        								is_same_value = root.owner
+	        							}
+	        							solar_system = {
+	        								any_system_megastructure = {
+	        									is_megastructure_type = asteroid_manufactory_alloys
+	        								}
+	        							}
+	        						}
+	        					}
+	        				}
+	        			}
+	        			else_if = {
+	        				limit = { is_nomadic = no }
+	        				prev = {
+	        					solar_system = {
+	        						any_system_megastructure = {
+	        							is_megastructure_type = asteroid_manufactory_alloys
+	        						}
+	        					}
+	        				}
+	        			}
+	        		}
+	        	}
+	        	planet_metallurgists_food_upkeep_add = -1.5
+	        	planet_metallurgists_energy_upkeep_add = 0.5
+	        }
 
             inline_script = {
                 script = planet/alloys/giga_foundry_job_swap
@@ -106,43 +158,96 @@ building_giga_asteroid_factory_consumer_goods = {
         unlock = "country_uses_consumer_goods = yes"
         modifiers = "
             triggered_planet_modifier = {
-                potential = {
-                    industrial_jobs_are_catalytic_trigger = no
-                    solar_system = {
-                        any_system_megastructure = {
-                            is_megastructure_type = asteroid_manufactory_consumer_goods
-                        }
-                    }
-                }
+	        	potential = {
+	        	    industrial_jobs_are_catalytic_trigger = no
+	        		owner? = {
+	        			if = {
+	        				limit = { is_nomadic = yes }
+	        				solar_system = {
+	        					any_starbase_in_system = {
+	        						is_waystation_starbase = yes
+	        						owner? = {
+	        							is_same_value = root.owner
+	        						}
+	        						any_starbase_in_network = {
+	        							has_starbase_size >= starbase_waystation_1
+	        							owner? = {
+	        								is_same_value = root.owner
+	        							}
+	        							solar_system = {
+	        								any_system_megastructure = {
+	        									is_megastructure_type = asteroid_manufactory_consumer_goods
+	        								}
+	        							}
+	        						}
+	        					}
+	        				}
+	        			}
+
+	        			else_if = {
+	        			    limit = { is_nomadic = no }
+	        				prev = {
+	        					solar_system = {
+	        						any_system_megastructure = {
+	        							is_megastructure_type = asteroid_manufactory_consumer_goods
+	        						}
+	        					}
+	        				}
+	        			}
+	        		}
+	        	}
                 planet_artisans_minerals_upkeep_add = -1
                 planet_artisans_energy_upkeep_add = 0.5
-            }
+	        }
 
-            inline_script = {
-                script = planet/consumer_goods/giga_artisan_job_swap
-                jobs = @asteroid_industry_job_count
-            }
             triggered_planet_modifier = {
                 potential = {
-                    industrial_jobs_are_catalytic_trigger = yes
-                    exists = planet
-                    planet = {
-                        artisan_is_pearl_diver_trigger = no
+                    if = {
+                        industrial_jobs_are_catalytic_trigger = yes
+                        limit = { owner? = { is_nomadic = yes } }
+                        planet? = {
+                            artisan_is_pearl_diver_trigger = no
+                        }
+	        		    solar_system = {
+	        		    	any_starbase_in_system = {
+	        		    		is_waystation_starbase = yes
+	        		    		owner? = {
+	        		    			is_same_value = root.owner
+	        		    		}
+	        		    		any_starbase_in_network = {
+	        		    			has_starbase_size >= starbase_waystation_1
+	        		    			owner? = {
+	        		    				is_same_value = root.owner
+	        		    			}
+	        		    			solar_system = {
+	        		    				any_system_megastructure = {
+	        		    					is_megastructure_type = asteroid_manufactory_alloys
+	        		    				}
+	        		    			}
+	        		    		}
+	        		    	}
+	        		    }
                     }
-                    solar_system = {
-                        any_system_megastructure = {
-                            is_megastructure_type = asteroid_manufactory_consumer_goods
+                    else_if = {
+                        industrial_jobs_are_catalytic_trigger = yes
+			            planet? = {
+			            	artisan_is_pearl_diver_trigger = no
+			            }
+			            solar_system = {
+				            any_system_megastructure = {
+				        	    is_megastructure_type = asteroid_manufactory_consumer_goods
+				            }
                         }
                     }
                 }
                 planet_artisans_food_upkeep_add = -1.5
                 planet_artisans_energy_upkeep_add = 0.5
-           }
+            }
+
             triggered_planet_modifier = {
                 potential = {
                     industrial_jobs_are_catalytic_trigger = yes
-                    exists = planet
-                    planet = {
+                    planet? = {
                         artisan_is_pearl_diver_trigger = yes
                     }
                     solar_system = {
@@ -155,6 +260,11 @@ building_giga_asteroid_factory_consumer_goods = {
                 planet_artisans_food_upkeep_add = -1
                 planet_artisans_energy_upkeep_add = 0.5
             }
+
+           inline_script = {
+               script = planet/consumer_goods/giga_artisan_job_swap
+               jobs = @asteroid_industry_job_count
+           }
         "
     }
 
@@ -204,11 +314,41 @@ building_giga_asteroid_factory_energy = {
         modifiers = "
             triggered_planet_modifier = {
                 potential = {
-                    solar_system = {
-                        any_system_megastructure = {
-                            is_megastructure_type = asteroid_manufactory_energy
-                        }
-                    }
+                    owner? = {
+	        			if = {
+	        				limit = { is_nomadic = yes }
+	        				solar_system = {
+	        					any_starbase_in_system = {
+	        						is_waystation_starbase = yes
+	        						owner? = {
+	        							is_same_value = root.owner
+	        						}
+	        						any_starbase_in_network = {
+	        							has_starbase_size >= starbase_waystation_1
+	        							owner? = {
+	        								is_same_value = root.owner
+	        							}
+	        							solar_system = {
+	        								any_system_megastructure = {
+	        									is_megastructure_type = asteroid_manufactory_energy
+	        								}
+	        							}
+	        						}
+	        					}
+	        				}
+	        			}
+
+	        			else_if = {
+	        			    limit = { is_nomadic = no }
+	        				prev = {
+	        					solar_system = {
+	        						any_system_megastructure = {
+	        							is_megastructure_type = asteroid_manufactory_energy
+	        						}
+	        					}
+	        				}
+	        			}
+	        		}
                 }
                 planet_buildings_energy_upkeep_mult = -0.1
                 planet_districts_energy_upkeep_mult = -0.1
@@ -267,11 +407,41 @@ building_giga_asteroid_factory_food = {
         modifiers = "
             triggered_planet_modifier = {
                 potential = {
-                    solar_system = {
-                        any_system_megastructure = {
-                            is_megastructure_type = asteroid_manufactory_food
-                        }
-                    }
+                    owner? = {
+	        			if = {
+	        				limit = { is_nomadic = yes }
+	        				solar_system = {
+	        					any_starbase_in_system = {
+	        						is_waystation_starbase = yes
+	        						owner? = {
+	        							is_same_value = root.owner
+	        						}
+	        						any_starbase_in_network = {
+	        							has_starbase_size >= starbase_waystation_1
+	        							owner? = {
+	        								is_same_value = root.owner
+	        							}
+	        							solar_system = {
+	        								any_system_megastructure = {
+	        									is_megastructure_type = asteroid_manufactory_food
+	        								}
+	        							}
+	        						}
+	        					}
+	        				}
+	        			}
+
+	        			else_if = {
+	        			    limit = { is_nomadic = no }
+	        				prev = {
+	        					solar_system = {
+	        						any_system_megastructure = {
+	        							is_megastructure_type = asteroid_manufactory_food
+	        						}
+	        					}
+	        				}
+	        			}
+	        		}
                 }
                 planet_farmers_produces_mult = 0.05
             }
@@ -285,20 +455,80 @@ building_giga_asteroid_factory_food = {
                     not = {
                         industrial_jobs_are_catalytic_trigger = yes
                         planet = { has_building = building_giga_asteroid_factory_consumer_goods }
-                        solar_system = {
-                            any_system_megastructure = {
-                                is_megastructure_type = asteroid_manufactory_consumer_goods
-                            }
-                        }
+                        owner? = {
+	        		    	if = {
+	        		    		limit = { is_nomadic = yes }
+	        		    		solar_system = {
+	        		    			any_starbase_in_system = {
+	        		    				is_waystation_starbase = yes
+	        		    				owner? = {
+	        		    					is_same_value = root.owner
+	        		    				}
+	        		    				any_starbase_in_network = {
+	        		    					has_starbase_size >= starbase_waystation_1
+	        		    					owner? = {
+	        		    						is_same_value = root.owner
+	        		    					}
+	        		    					solar_system = {
+	        		    						any_system_megastructure = {
+	        		    							is_megastructure_type = asteroid_manufactory_food
+	        		    						}
+	        		    					}
+	        		    				}
+	        		    			}
+	        		    		}
+	        		    	}
+
+	        		    	else_if = {
+	        		    	    limit = { is_nomadic = yes }
+	        		    		prev = {
+	        		    			solar_system = {
+	        		    				any_system_megastructure = {
+	        		    					is_megastructure_type = asteroid_manufactory_food
+	        		    				}
+	        		    			}
+	        		    		}
+	        		    	}
+	        		    }
                     }
-                    solar_system = {
-                        any_system_megastructure = {
-                            is_megastructure_type = asteroid_manufactory_food
-                        }
-                    }
+                    owner? = {
+	        	        if = {
+	        		 	 	limit = { is_nomadic = yes }
+	        		 	 	solar_system = {
+	        		 	 		any_starbase_in_system = {
+	        		 	 			is_waystation_starbase = yes
+	        		 	 			owner? = {
+	        		 	 				is_same_value = root.owner
+	        		 	 			}
+	        		 	 			any_starbase_in_network = {
+	        		 	 				has_starbase_size >= starbase_waystation_1
+	        		 	 				owner? = {
+	        		 	 					is_same_value = root.owner
+	        		 	 				}
+	        		 	 				solar_system = {
+	        		 	 					any_system_megastructure = {
+	        		 	 						is_megastructure_type = asteroid_manufactory_food
+	        		 	 					}
+	        		 	 				}
+	        		 	 			}
+	        		 	 		}
+	        		 	 	}
+	        		    }
+	        		 	else_if = {
+	        		 	     limit = { is_nomadic = yes }
+	        		 	 	 prev = {
+	        		 	 	 	 solar_system = {
+	        		 	 	 	 	 any_system_megastructure = {
+	        		 	 	 	 	    is_megastructure_type = asteroid_manufactory_food
+	        		 	 	 	 	 }
+	        		 	 	 	 }
+	        		 	 	 }
+	        		 	}
+	        		}
                 }
                 planet_artisans_food_upkeep_mult = -0.1
             }
+
             triggered_planet_modifier = {
                 potential = {
                     exists = owner
@@ -307,16 +537,74 @@ building_giga_asteroid_factory_food = {
                         artisan_is_pearl_diver_trigger = yes
                     }
                     planet = { has_building = building_giga_asteroid_factory_consumer_goods }
-                    solar_system = {
-                        any_system_megastructure = {
-                            is_megastructure_type = asteroid_manufactory_consumer_goods
-                        }
-                    }
-                    solar_system = {
-                        any_system_megastructure = {
-                            is_megastructure_type = asteroid_manufactory_food
-                        }
-                    }
+                    owner? = {
+	        	        if = {
+	        		 	 	limit = { is_nomadic = yes }
+	        		 	 	solar_system = {
+	        		 	 		any_starbase_in_system = {
+	        		 	 			is_waystation_starbase = yes
+	        		 	 			owner? = {
+	        		 	 				is_same_value = root.owner
+	        		 	 			}
+	        		 	 			any_starbase_in_network = {
+	        		 	 				has_starbase_size >= starbase_waystation_1
+	        		 	 				owner? = {
+	        		 	 					is_same_value = root.owner
+	        		 	 				}
+	        		 	 				solar_system = {
+	        		 	 					any_system_megastructure = {
+	        		 	 						is_megastructure_type = asteroid_manufactory_consumer_goods
+	        		 	 					}
+	        		 	 				}
+	        		 	 			}
+	        		 	 		}
+	        		 	 	}
+	        		    }
+	        		 	else_if = {
+	        		 	     limit = { is_nomadic = yes }
+	        		 	 	 prev = {
+	        		 	 	 	 solar_system = {
+	        		 	 	 	 	 any_system_megastructure = {
+	        		 	 	 	 	    is_megastructure_type = asteroid_manufactory_consumer_goods
+	        		 	 	 	 	 }
+	        		 	 	 	 }
+	        		 	 	 }
+	        		 	}
+	        		}
+                    owner? = {
+	        	        if = {
+	        		 	 	limit = { is_nomadic = yes }
+	        		 	 	solar_system = {
+	        		 	 		any_starbase_in_system = {
+	        		 	 			is_waystation_starbase = yes
+	        		 	 			owner? = {
+	        		 	 				is_same_value = root.owner
+	        		 	 			}
+	        		 	 			any_starbase_in_network = {
+	        		 	 				has_starbase_size >= starbase_waystation_1
+	        		 	 				owner? = {
+	        		 	 					is_same_value = root.owner
+	        		 	 				}
+	        		 	 				solar_system = {
+	        		 	 					any_system_megastructure = {
+	        		 	 						is_megastructure_type = asteroid_manufactory_food
+	        		 	 					}
+	        		 	 				}
+	        		 	 			}
+	        		 	 		}
+	        		 	 	}
+	        		    }
+	        		 	else_if = {
+	        		 	     limit = { is_nomadic = yes }
+	        		 	 	 prev = {
+	        		 	 	 	 solar_system = {
+	        		 	 	 	 	 any_system_megastructure = {
+	        		 	 	 	 	    is_megastructure_type = asteroid_manufactory_food
+	        		 	 	 	 	 }
+	        		 	 	 	 }
+	        		 	 	 }
+	        		 	}
+	        		}
                 }
                 planet_artisans_food_upkeep_mult = -0.05
             }
@@ -399,11 +687,41 @@ building_giga_asteroid_factory_supertensiles = {
         modifiers = "
             triggered_planet_modifier = {
                 potential = {
-                    solar_system = {
-                        any_system_megastructure = {
-                            is_megastructure_type = asteroid_manufactory_supertensiles
-                        }
-                    }
+                    owner? = {
+	        			if = {
+	        				limit = { is_nomadic = yes }
+	        				solar_system = {
+	        					any_starbase_in_system = {
+	        						is_waystation_starbase = yes
+	        						owner? = {
+	        							is_same_value = root.owner
+	        						}
+	        						any_starbase_in_network = {
+	        							has_starbase_size >= starbase_waystation_1
+	        							owner? = {
+	        								is_same_value = root.owner
+	        							}
+	        							solar_system = {
+	        								any_system_megastructure = {
+	        									is_megastructure_type = asteroid_manufactory_supertensiles
+	        								}
+	        							}
+	        						}
+	        					}
+	        				}
+	        			}
+
+	        			else_if = {
+	        			    limit = { is_nomadic = no }
+	        				prev = {
+	        					solar_system = {
+	        						any_system_megastructure = {
+	        							is_megastructure_type = asteroid_manufactory_supertensiles
+	        						}
+	        					}
+	        				}
+	        			}
+	        		}
                 }
                 planet_giga_megaengineering_overseers_unity_upkeep_add = -1
                 planet_giga_megaengineering_overseers_energy_upkeep_add = 0.5

--- a/common/buildings/giga_asteroid_industry_buildings.txt
+++ b/common/buildings/giga_asteroid_industry_buildings.txt
@@ -25,38 +25,10 @@ building_giga_asteroid_factory_alloys = {
 	        	potential = {
 	        		owner? = {
 	        		    is_catalytic_empire = no
-	        			if = {
-	        				limit = { is_nomadic = yes  }
-	        				solar_system = {
-	        					any_starbase_in_system = {
-	        						is_waystation_starbase = yes
-	        						owner? = {
-	        							is_same_value = root.owner
-	        						}
-	        						any_starbase_in_network = {
-	        							has_starbase_size >= starbase_waystation_1
-	        							owner? = {
-	        								is_same_value = root.owner
-	        							}
-	        							solar_system = {
-	        								any_system_megastructure = {
-	        									is_megastructure_type = asteroid_manufactory_alloys
-	        								}
-	        							}
-	        						}
-	        					}
-	        				}
-	        			}
-	        			else_if = {
-	        				limit = { is_nomadic = no }
-	        				prev = {
-	        					solar_system = {
-	        						any_system_megastructure = {
-	        							is_megastructure_type = asteroid_manufactory_alloys
-	        						}
-	        					}
-	        				}
-	        			}
+                        inline_script = {
+                           script = buildings/asteroid_industry/nomads_or_normal
+                           type = alloys
+                        }
 	        		}
 	        	}
 	        	planet_metallurgists_minerals_upkeep_add = -1
@@ -67,38 +39,10 @@ building_giga_asteroid_factory_alloys = {
 	        	potential = {
 	        		owner? = {
 	        		    is_catalytic_empire = yes
-	        			if = {
-	        				limit = { is_nomadic = yes  }
-	        				solar_system = {
-	        					any_starbase_in_system = {
-	        						is_waystation_starbase = yes
-	        						owner? = {
-	        							is_same_value = root.owner
-	        						}
-	        						any_starbase_in_network = {
-	        							has_starbase_size >= starbase_waystation_1
-	        							owner? = {
-	        								is_same_value = root.owner
-	        							}
-	        							solar_system = {
-	        								any_system_megastructure = {
-	        									is_megastructure_type = asteroid_manufactory_alloys
-	        								}
-	        							}
-	        						}
-	        					}
-	        				}
-	        			}
-	        			else_if = {
-	        				limit = { is_nomadic = no }
-	        				prev = {
-	        					solar_system = {
-	        						any_system_megastructure = {
-	        							is_megastructure_type = asteroid_manufactory_alloys
-	        						}
-	        					}
-	        				}
-	        			}
+	        			inline_script = {
+                           script = buildings/asteroid_industry/nomads_or_normal
+                           type = alloys
+                        }
 	        		}
 	        	}
 	        	planet_metallurgists_food_upkeep_add = -1.5
@@ -161,39 +105,10 @@ building_giga_asteroid_factory_consumer_goods = {
 	        	potential = {
 	        	    industrial_jobs_are_catalytic_trigger = no
 	        		owner? = {
-	        			if = {
-	        				limit = { is_nomadic = yes }
-	        				solar_system = {
-	        					any_starbase_in_system = {
-	        						is_waystation_starbase = yes
-	        						owner? = {
-	        							is_same_value = root.owner
-	        						}
-	        						any_starbase_in_network = {
-	        							has_starbase_size >= starbase_waystation_1
-	        							owner? = {
-	        								is_same_value = root.owner
-	        							}
-	        							solar_system = {
-	        								any_system_megastructure = {
-	        									is_megastructure_type = asteroid_manufactory_consumer_goods
-	        								}
-	        							}
-	        						}
-	        					}
-	        				}
-	        			}
-
-	        			else_if = {
-	        			    limit = { is_nomadic = no }
-	        				prev = {
-	        					solar_system = {
-	        						any_system_megastructure = {
-	        							is_megastructure_type = asteroid_manufactory_consumer_goods
-	        						}
-	        					}
-	        				}
-	        			}
+                        inline_script = {
+                           script = buildings/asteroid_industry/nomads_or_normal
+                           type = consumer_goods
+                        }
 	        		}
 	        	}
                 planet_artisans_minerals_upkeep_add = -1
@@ -202,42 +117,13 @@ building_giga_asteroid_factory_consumer_goods = {
 
             triggered_planet_modifier = {
                 potential = {
-                    if = {
-                        industrial_jobs_are_catalytic_trigger = yes
-                        limit = { owner? = { is_nomadic = yes } }
-                        planet? = {
-                            artisan_is_pearl_diver_trigger = no
-                        }
-	        		    solar_system = {
-	        		    	any_starbase_in_system = {
-	        		    		is_waystation_starbase = yes
-	        		    		owner? = {
-	        		    			is_same_value = root.owner
-	        		    		}
-	        		    		any_starbase_in_network = {
-	        		    			has_starbase_size >= starbase_waystation_1
-	        		    			owner? = {
-	        		    				is_same_value = root.owner
-	        		    			}
-	        		    			solar_system = {
-	        		    				any_system_megastructure = {
-	        		    					is_megastructure_type = asteroid_manufactory_alloys
-	        		    				}
-	        		    			}
-	        		    		}
-	        		    	}
-	        		    }
+                    industrial_jobs_are_catalytic_trigger = yes
+                    planet? = {
+                        artisan_is_pearl_diver_trigger = no
                     }
-                    else_if = {
-                        industrial_jobs_are_catalytic_trigger = yes
-			            planet? = {
-			            	artisan_is_pearl_diver_trigger = no
-			            }
-			            solar_system = {
-				            any_system_megastructure = {
-				        	    is_megastructure_type = asteroid_manufactory_consumer_goods
-				            }
-                        }
+                    inline_script = {
+                        script = buildings/asteroid_industry/nomads_or_normal
+                        type = consumer_goods
                     }
                 }
                 planet_artisans_food_upkeep_add = -1.5
@@ -250,10 +136,9 @@ building_giga_asteroid_factory_consumer_goods = {
                     planet? = {
                         artisan_is_pearl_diver_trigger = yes
                     }
-                    solar_system = {
-                        any_system_megastructure = {
-                            is_megastructure_type = asteroid_manufactory_consumer_goods
-                        }
+                    inline_script = {
+                        script = buildings/asteroid_industry/nomads_or_normal
+                        type = consumer_goods
                     }
                 }
                 planet_artisans_minerals_upkeep_add = -0.5
@@ -315,39 +200,10 @@ building_giga_asteroid_factory_energy = {
             triggered_planet_modifier = {
                 potential = {
                     owner? = {
-	        			if = {
-	        				limit = { is_nomadic = yes }
-	        				solar_system = {
-	        					any_starbase_in_system = {
-	        						is_waystation_starbase = yes
-	        						owner? = {
-	        							is_same_value = root.owner
-	        						}
-	        						any_starbase_in_network = {
-	        							has_starbase_size >= starbase_waystation_1
-	        							owner? = {
-	        								is_same_value = root.owner
-	        							}
-	        							solar_system = {
-	        								any_system_megastructure = {
-	        									is_megastructure_type = asteroid_manufactory_energy
-	        								}
-	        							}
-	        						}
-	        					}
-	        				}
-	        			}
-
-	        			else_if = {
-	        			    limit = { is_nomadic = no }
-	        				prev = {
-	        					solar_system = {
-	        						any_system_megastructure = {
-	        							is_megastructure_type = asteroid_manufactory_energy
-	        						}
-	        					}
-	        				}
-	        			}
+	        			inline_script = {
+                            script = buildings/asteroid_industry/nomads_or_normal
+                            type = energy
+                        }
 	        		}
                 }
                 planet_buildings_energy_upkeep_mult = -0.1
@@ -408,39 +264,10 @@ building_giga_asteroid_factory_food = {
             triggered_planet_modifier = {
                 potential = {
                     owner? = {
-	        			if = {
-	        				limit = { is_nomadic = yes }
-	        				solar_system = {
-	        					any_starbase_in_system = {
-	        						is_waystation_starbase = yes
-	        						owner? = {
-	        							is_same_value = root.owner
-	        						}
-	        						any_starbase_in_network = {
-	        							has_starbase_size >= starbase_waystation_1
-	        							owner? = {
-	        								is_same_value = root.owner
-	        							}
-	        							solar_system = {
-	        								any_system_megastructure = {
-	        									is_megastructure_type = asteroid_manufactory_food
-	        								}
-	        							}
-	        						}
-	        					}
-	        				}
-	        			}
-
-	        			else_if = {
-	        			    limit = { is_nomadic = no }
-	        				prev = {
-	        					solar_system = {
-	        						any_system_megastructure = {
-	        							is_megastructure_type = asteroid_manufactory_food
-	        						}
-	        					}
-	        				}
-	        			}
+	        			inline_script = {
+                            script = buildings/asteroid_industry/nomads_or_normal
+                            type = food
+                        }
 	        		}
                 }
                 planet_farmers_produces_mult = 0.05
@@ -448,163 +275,42 @@ building_giga_asteroid_factory_food = {
 
             triggered_planet_modifier = {
                 potential = {
-                    exists = owner
-                    planet = {
+                    colony? = {
                         artisan_is_pearl_diver_trigger = yes
-                    }
-                    not = {
-                        industrial_jobs_are_catalytic_trigger = yes
-                        planet = { has_building = building_giga_asteroid_factory_consumer_goods }
-                        owner? = {
-	        		    	if = {
-	        		    		limit = { is_nomadic = yes }
-	        		    		solar_system = {
-	        		    			any_starbase_in_system = {
-	        		    				is_waystation_starbase = yes
-	        		    				owner? = {
-	        		    					is_same_value = root.owner
-	        		    				}
-	        		    				any_starbase_in_network = {
-	        		    					has_starbase_size >= starbase_waystation_1
-	        		    					owner? = {
-	        		    						is_same_value = root.owner
-	        		    					}
-	        		    					solar_system = {
-	        		    						any_system_megastructure = {
-	        		    							is_megastructure_type = asteroid_manufactory_food
-	        		    						}
-	        		    					}
-	        		    				}
-	        		    			}
-	        		    		}
-	        		    	}
-
-	        		    	else_if = {
-	        		    	    limit = { is_nomadic = yes }
-	        		    		prev = {
-	        		    			solar_system = {
-	        		    				any_system_megastructure = {
-	        		    					is_megastructure_type = asteroid_manufactory_food
-	        		    				}
-	        		    			}
-	        		    		}
-	        		    	}
-	        		    }
+                        industrial_jobs_are_catalytic_trigger = no
+                        has_building = building_giga_asteroid_factory_consumer_goods
                     }
                     owner? = {
-	        	        if = {
-	        		 	 	limit = { is_nomadic = yes }
-	        		 	 	solar_system = {
-	        		 	 		any_starbase_in_system = {
-	        		 	 			is_waystation_starbase = yes
-	        		 	 			owner? = {
-	        		 	 				is_same_value = root.owner
-	        		 	 			}
-	        		 	 			any_starbase_in_network = {
-	        		 	 				has_starbase_size >= starbase_waystation_1
-	        		 	 				owner? = {
-	        		 	 					is_same_value = root.owner
-	        		 	 				}
-	        		 	 				solar_system = {
-	        		 	 					any_system_megastructure = {
-	        		 	 						is_megastructure_type = asteroid_manufactory_food
-	        		 	 					}
-	        		 	 				}
-	        		 	 			}
-	        		 	 		}
-	        		 	 	}
-	        		    }
-	        		 	else_if = {
-	        		 	     limit = { is_nomadic = yes }
-	        		 	 	 prev = {
-	        		 	 	 	 solar_system = {
-	        		 	 	 	 	 any_system_megastructure = {
-	        		 	 	 	 	    is_megastructure_type = asteroid_manufactory_food
-	        		 	 	 	 	 }
-	        		 	 	 	 }
-	        		 	 	 }
-	        		 	}
-	        		}
+                        inline_script = {
+                            script = buildings/asteroid_industry/nomads_or_normal
+                            type = consumer_goods
+                        }
+                        inline_script = {
+                            script = buildings/asteroid_industry/nomads_or_normal
+                            type = food
+                        }
+                    }
                 }
                 planet_artisans_food_upkeep_mult = -0.1
             }
 
             triggered_planet_modifier = {
                 potential = {
-                    exists = owner
-                    industrial_jobs_are_catalytic_trigger = yes
-                    planet = {
+                    colony? = {
                         artisan_is_pearl_diver_trigger = yes
+                        industrial_jobs_are_catalytic_trigger = yes
+                        has_building = building_giga_asteroid_factory_consumer_goods
                     }
-                    planet = { has_building = building_giga_asteroid_factory_consumer_goods }
                     owner? = {
-	        	        if = {
-	        		 	 	limit = { is_nomadic = yes }
-	        		 	 	solar_system = {
-	        		 	 		any_starbase_in_system = {
-	        		 	 			is_waystation_starbase = yes
-	        		 	 			owner? = {
-	        		 	 				is_same_value = root.owner
-	        		 	 			}
-	        		 	 			any_starbase_in_network = {
-	        		 	 				has_starbase_size >= starbase_waystation_1
-	        		 	 				owner? = {
-	        		 	 					is_same_value = root.owner
-	        		 	 				}
-	        		 	 				solar_system = {
-	        		 	 					any_system_megastructure = {
-	        		 	 						is_megastructure_type = asteroid_manufactory_consumer_goods
-	        		 	 					}
-	        		 	 				}
-	        		 	 			}
-	        		 	 		}
-	        		 	 	}
-	        		    }
-	        		 	else_if = {
-	        		 	     limit = { is_nomadic = yes }
-	        		 	 	 prev = {
-	        		 	 	 	 solar_system = {
-	        		 	 	 	 	 any_system_megastructure = {
-	        		 	 	 	 	    is_megastructure_type = asteroid_manufactory_consumer_goods
-	        		 	 	 	 	 }
-	        		 	 	 	 }
-	        		 	 	 }
-	        		 	}
-	        		}
-                    owner? = {
-	        	        if = {
-	        		 	 	limit = { is_nomadic = yes }
-	        		 	 	solar_system = {
-	        		 	 		any_starbase_in_system = {
-	        		 	 			is_waystation_starbase = yes
-	        		 	 			owner? = {
-	        		 	 				is_same_value = root.owner
-	        		 	 			}
-	        		 	 			any_starbase_in_network = {
-	        		 	 				has_starbase_size >= starbase_waystation_1
-	        		 	 				owner? = {
-	        		 	 					is_same_value = root.owner
-	        		 	 				}
-	        		 	 				solar_system = {
-	        		 	 					any_system_megastructure = {
-	        		 	 						is_megastructure_type = asteroid_manufactory_food
-	        		 	 					}
-	        		 	 				}
-	        		 	 			}
-	        		 	 		}
-	        		 	 	}
-	        		    }
-	        		 	else_if = {
-	        		 	     limit = { is_nomadic = yes }
-	        		 	 	 prev = {
-	        		 	 	 	 solar_system = {
-	        		 	 	 	 	 any_system_megastructure = {
-	        		 	 	 	 	    is_megastructure_type = asteroid_manufactory_food
-	        		 	 	 	 	 }
-	        		 	 	 	 }
-	        		 	 	 }
-	        		 	}
-	        		}
+                        inline_script = {
+                            script = buildings/asteroid_industry/nomads_or_normal
+                            type = consumer_goods
+                        }
+                        inline_script = {
+                            script = buildings/asteroid_industry/nomads_or_normal
+                            type = food
+                        }
+                    }
                 }
                 planet_artisans_food_upkeep_mult = -0.05
             }
@@ -688,39 +394,10 @@ building_giga_asteroid_factory_supertensiles = {
             triggered_planet_modifier = {
                 potential = {
                     owner? = {
-	        			if = {
-	        				limit = { is_nomadic = yes }
-	        				solar_system = {
-	        					any_starbase_in_system = {
-	        						is_waystation_starbase = yes
-	        						owner? = {
-	        							is_same_value = root.owner
-	        						}
-	        						any_starbase_in_network = {
-	        							has_starbase_size >= starbase_waystation_1
-	        							owner? = {
-	        								is_same_value = root.owner
-	        							}
-	        							solar_system = {
-	        								any_system_megastructure = {
-	        									is_megastructure_type = asteroid_manufactory_supertensiles
-	        								}
-	        							}
-	        						}
-	        					}
-	        				}
-	        			}
-
-	        			else_if = {
-	        			    limit = { is_nomadic = no }
-	        				prev = {
-	        					solar_system = {
-	        						any_system_megastructure = {
-	        							is_megastructure_type = asteroid_manufactory_supertensiles
-	        						}
-	        					}
-	        				}
-	        			}
+	        			inline_script = {
+                            script = buildings/asteroid_industry/nomads_or_normal
+                            type = supertensiles
+                        }
 	        		}
                 }
                 planet_giga_megaengineering_overseers_unity_upkeep_add = -1

--- a/common/buildings/giga_asteroid_industry_buildings.txt
+++ b/common/buildings/giga_asteroid_industry_buildings.txt
@@ -117,13 +117,13 @@ building_giga_asteroid_factory_consumer_goods = {
 
             triggered_planet_modifier = {
                 potential = {
-                    industrial_jobs_are_catalytic_trigger = yes
-                    planet? = {
+                    colony? = {
+                        industrial_jobs_are_catalytic_trigger = yes
                         artisan_is_pearl_diver_trigger = no
-                    }
-                    inline_script = {
-                        script = buildings/asteroid_industry/nomads_or_normal
-                        type = consumer_goods
+                        inline_script = {
+                            script = buildings/asteroid_industry/nomads_or_normal
+                            type = consumer_goods
+                        }
                     }
                 }
                 planet_artisans_food_upkeep_add = -1.5
@@ -131,14 +131,14 @@ building_giga_asteroid_factory_consumer_goods = {
             }
 
             triggered_planet_modifier = {
-                potential = {
-                    industrial_jobs_are_catalytic_trigger = yes
-                    planet? = {
+                 potential = {
+                    colony? = {
+                        industrial_jobs_are_catalytic_trigger = yes
                         artisan_is_pearl_diver_trigger = yes
-                    }
-                    inline_script = {
-                        script = buildings/asteroid_industry/nomads_or_normal
-                        type = consumer_goods
+                        inline_script = {
+                            script = buildings/asteroid_industry/nomads_or_normal
+                            type = consumer_goods
+                        }
                     }
                 }
                 planet_artisans_minerals_upkeep_add = -0.5

--- a/common/buildings/giga_asteroid_industry_buildings.txt
+++ b/common/buildings/giga_asteroid_industry_buildings.txt
@@ -120,11 +120,13 @@ building_giga_asteroid_factory_consumer_goods = {
                     colony? = {
                         industrial_jobs_are_catalytic_trigger = yes
                         artisan_is_pearl_diver_trigger = no
-                        inline_script = {
+                    }
+                    owner? = {
+	        			inline_script = {
                             script = buildings/asteroid_industry/nomads_or_normal
                             type = consumer_goods
                         }
-                    }
+	        		}
                 }
                 planet_artisans_food_upkeep_add = -1.5
                 planet_artisans_energy_upkeep_add = 0.5
@@ -135,11 +137,13 @@ building_giga_asteroid_factory_consumer_goods = {
                     colony? = {
                         industrial_jobs_are_catalytic_trigger = yes
                         artisan_is_pearl_diver_trigger = yes
-                        inline_script = {
+                    }
+                    owner? = {
+	        			inline_script = {
                             script = buildings/asteroid_industry/nomads_or_normal
                             type = consumer_goods
                         }
-                    }
+	        		}
                 }
                 planet_artisans_minerals_upkeep_add = -0.5
                 planet_artisans_food_upkeep_add = -1

--- a/common/inline_scripts/buildings/asteroid_industry/nomads_or_normal.txt
+++ b/common/inline_scripts/buildings/asteroid_industry/nomads_or_normal.txt
@@ -1,0 +1,32 @@
+if = {
+    limit = { is_nomadic = yes }
+    solar_system = {
+        any_starbase_in_system = {
+            is_waystation_starbase = yes
+            owner? = {
+                is_same_value = root.owner
+            }
+            any_starbase_in_network = {
+                has_starbase_size >= starbase_waystation_1
+                owner? = {
+                    is_same_value = root.owner
+                }
+                solar_system = {
+                    any_system_megastructure = {
+                        is_megastructure_type = asteroid_manufactory_$type$
+                    }
+                }
+            }
+        }
+    }
+}
+else_if = {
+    limit = { is_nomadic = no }
+    prev = {
+        solar_system = {
+            any_system_megastructure = {
+                is_megastructure_type = asteroid_manufactory_$type$
+            }
+        }
+    }
+}

--- a/common/inline_scripts/megastructures/asteroid_industry/asteroid_industry_construction.txt
+++ b/common/inline_scripts/megastructures/asteroid_industry/asteroid_industry_construction.txt
@@ -40,7 +40,7 @@ potential = {
 }
 
 possible = {
-    custom_tooltip = { fail_text = "requires_inside_border"		is_inside_border = from }
+    inline_script = megastructures/system_ownership_or_waystation_check
     custom_tooltip = {
         fail_text = "requires_not_capped"
         from = {

--- a/common/scripted_triggers/giga_scripted_triggers.txt
+++ b/common/scripted_triggers/giga_scripted_triggers.txt
@@ -1084,8 +1084,7 @@ giga_has_consumer_goods_civic_or_individualist = {
 # extra conditions for whether the angler job swaps should happen
 giga_angler_jobs_trigger = {
     hidden_trigger = {
-        exists = owner
-        owner = {
+        owner? = {
             is_anglers_empire = yes
         }
     }

--- a/common/scripted_triggers/zzz_overwrites.txt
+++ b/common/scripted_triggers/zzz_overwrites.txt
@@ -2272,28 +2272,26 @@ has_orbital_mining_deposit = {
 # farmers to anglers, artisans to pearl divers, via the asteroid industry food building when angler
 farmer_is_angler_trigger = {
     OR = {
-        num_zones = {
-            type = zone_anglers
-            value > 0
-        }
-        num_zones = {
-            type = zone_agrarian_anglers
-            value > 0
-        }
+		# Vanilla Trigger
+		AND = {
+			hidden_trigger = {
+				owner? = { is_anglers_empire = yes }
+			}
+			is_wet = yes
+		}
         # asteroid industry food building
         giga_angler_jobs_trigger = yes
     }
 }
 artisan_is_pearl_diver_trigger = {
     OR = {
-        num_zones = {
-            type = zone_anglers
-            value > 0
-        }
-        num_zones = {
-            type = zone_agrarian_anglers
-            value > 0
-        }
+		# Vanilla Trigger
+		AND = {
+			hidden_trigger = {
+				owner? = { is_anglers_empire = yes }
+			}
+			is_wet = yes
+		}
         # asteroid industry food building
         giga_angler_jobs_trigger = yes
     }

--- a/common/technology/giga_02_society.txt
+++ b/common/technology/giga_02_society.txt
@@ -348,7 +348,14 @@ giga_tech_asteroid_manufactory = {
 	area = society
 	tier = 3
 	category = { new_worlds }
-	prerequisites = { tech_starbase_3 tech_space_mining_2 }
+	prerequisites = {
+		OR = {
+			tech_waystation_2
+			tech_starbase_3
+		}
+		tech_space_mining_2
+	}
+
 	weight = @tier3weight2
 
 	potential = {


### PR DESCRIPTION
- Nomads can now build the Asteroid Industry kilostructures, benefiting from the same-system bonus that regular empires get if both the arkship hosting the Asteroid Industry building and it's associated kilostructure exist on the same wayline