### PR TITLE
"A Celestial Armada" AP small fix

### DIFF
--- a/common/ascension_perks/giga_ascension_perks.txt
+++ b/common/ascension_perks/giga_ascension_perks.txt
@@ -185,7 +185,8 @@ ap_celestial_printing = {
 				has_global_flag = giga_celestial_printing_moon_disabled
 				has_global_flag = giga_celestial_printing_planet_disabled
 				has_global_flag = systemcraft_disabled
-			} 
+				has_global_flag = giga_planet_bulking_disabled
+			}
 		}
 		is_nomadic = no
 	}


### PR DESCRIPTION
The "A Celestial Armada" AP now properly accounts for Planetary Bulking in its disable trigger

Why is that even locked behind this AP anyway