### PR TITLE
Reworked ship components to use the potential block. Added SM and QNM components for bio ships. Fixed components appearing for wrong ship sizes (by vanilla logic), apparent mostly in Cosmogenesis ships.

### DIFF
--- a/common/component_sets/giga_component_sets.txt
+++ b/common/component_sets/giga_component_sets.txt
@@ -18,9 +18,11 @@ component_set = { key = "ARMOR_QUBERINE"					icon = "GFX_ship_part_armor_quberin
 component_set = { key = "REACTOR_PLANET"					icon = "GFX_ship_part_reactor_planet"			icon_frame = 1 }
 component_set = { key = "SA_ARMOR"							icon = "GFX_sa_armor"							icon_frame = 1 }
 component_set = { key = "QNM_SHIELD"						icon = "GFX_qnm_shield"							icon_frame = 1 }
+component_set = { key = "BIO_QNM_SHIELD"					icon = "GFX_qnm_shield"							icon_frame = 1 }
 component_set = { key = "COMPOUND_SHIELD"					icon = "GFX_compound_shield"					icon_frame = 1 }
 component_set = { key = "COMPOUND_ARMOR"					icon = "GFX_compound_armor"						icon_frame = 1 }
 component_set = { key = "SENTIENT_ARMOR"					icon = "GFX_sentient_armor"						icon_frame = 1 }
+component_set = { key = "BIO_SENTIENT_ARMOR"				icon = "GFX_sentient_armor"						icon_frame = 1 }
 component_set = { key = "SENTIENT_AUTO_REPAIR"				icon = "GFX_sentient_auto_repair"				icon_frame = 1 }
 component_set = { key = "KATZEN_STELLARITE_ARMOR_01"		icon = "GFX_ship_part_armor_5"					icon_frame = 1 }
 

--- a/common/component_templates/asteroid_artillery_components.txt
+++ b/common/component_templates/asteroid_artillery_components.txt
@@ -6,7 +6,9 @@ utility_component_template = {
 	icon_frame = 1
 	power = 15000
 	component_set = "power_core"
-	size_restriction = { asteroid_artillery }
+	potential = {
+		is_ship_size = asteroid_artillery
+	}
 
 	ftl_inhibitor = yes
 }
@@ -44,7 +46,9 @@ weapon_component_template = {
 	prerequisites = { "tech_titans" }
 	component_set = "PERDITION_BEAM"
 	projectile_gfx = "perdition_beam"
-	size_restriction = { asteroid_artillery }
+	potential = {
+		is_ship_size = asteroid_artillery
+	}
 	resources = {
 		category = ship_components
 		cost = {
@@ -106,7 +110,9 @@ weapon_component_template = {
 	prerequisites = { "tech_archaeo_titan_beam" }
 	component_set = "ARCHAEO_TITAN"
 	projectile_gfx = "perdition_beam"
-	size_restriction = { asteroid_artillery }
+	potential = {
+		is_ship_size = asteroid_artillery
+	}
 	resources = {
 		category = ship_components
 		cost = {

--- a/common/component_templates/blokkat_components.txt
+++ b/common/component_templates/blokkat_components.txt
@@ -29,7 +29,7 @@ utility_component_template = {
 	inline_script = {
 		script = components/blokkat/player_reactors
 		SIZE = corvette
-		POTENTIAL = "ship_uses_corvette_reactors = yes"
+		POTENTIAL = "giga_uses_corvette_reactors = yes"
 	}
 }
 
@@ -38,7 +38,7 @@ utility_component_template = {
 	inline_script = {
 		script = components/blokkat/player_reactors
 		SIZE = destroyer
-		POTENTIAL = "ship_uses_destroyer_reactors = yes"
+		POTENTIAL = "giga_uses_destroyer_reactors = yes"
 	}
 }
 
@@ -47,7 +47,7 @@ utility_component_template = {
 	inline_script = {
 		script = components/blokkat/player_reactors
 		SIZE = cruiser
-		POTENTIAL = "ship_uses_cruiser_reactors = yes"
+		POTENTIAL = "giga_uses_cruiser_reactors = yes"
 	}
 }
 
@@ -56,7 +56,7 @@ utility_component_template = {
 	inline_script = {
 		script = components/blokkat/player_reactors
 		SIZE = battleship
-		POTENTIAL = "ship_uses_battleship_reactors = yes"
+		POTENTIAL = "giga_uses_battleship_reactors = yes"
 	}
 }
 
@@ -65,7 +65,7 @@ utility_component_template = {
 	inline_script = {
 		script = components/blokkat/player_reactors
 		SIZE = titan
-		POTENTIAL = "ship_uses_titan_reactors = yes"
+		POTENTIAL = "giga_uses_titan_reactors = yes"
 	}
 }
 
@@ -74,7 +74,7 @@ utility_component_template = {
 	inline_script = {
 		script = components/blokkat/player_reactors
 		SIZE = juggernaut
-		POTENTIAL = "ship_uses_juggernaut_reactors = yes"
+		POTENTIAL = "giga_uses_juggernaut_reactors = yes"
 	}
 }
 
@@ -83,7 +83,7 @@ utility_component_template = {
 	inline_script = {
 		script = components/blokkat/player_reactors
 		SIZE = "starbase"
-		POTENTIAL = "ship_uses_starbase_components = yes"
+		POTENTIAL = "giga_uses_starbase_reactors = yes"
 	}
 }
 
@@ -92,7 +92,7 @@ utility_component_template = {
 	inline_script = {
 		script = components/blokkat/player_reactors
 		SIZE = platform
-		POTENTIAL = "ship_uses_platform_reactors = yes"
+		POTENTIAL = "giga_uses_platform_reactors = yes"
 	}
 }
 
@@ -118,7 +118,7 @@ utility_component_template = {
 	}
 
 	potential = {
-		ship_uses_ion_cannon_components = yes
+		giga_uses_ion_cannon_reactors = yes
 	}
 
 	prerequisites = { "giga_tech_blokkat_reactor" }
@@ -382,8 +382,10 @@ weapon_component_template = {
 
 	component_set = "KNIFE_BLOKKAT"
 	tags = { weapon_type_kinetic weapon_type_anticompound }
-
-	size_restriction = { giga_blokkat_individual }
+	
+	potential = {
+		is_ship_size = giga_blokkat_individual
+	}
 
 	ai_tags = { weapon_role_anti_armor }	#tags must be pre-registered in common/weapon_tags
 }
@@ -575,7 +577,12 @@ utility_component_template = {
 			energy = 100
 		}
 	}
-	class_restriction = { shipclass_military shipclass_military_special }
+	potential = {
+		OR = {
+			is_ship_class = shipclass_military
+			is_ship_class = shipclass_military_special
+		}
+	}
 	component_set = "combat_computers"
 	ship_behavior = "artillery"
 
@@ -618,7 +625,12 @@ utility_component_template = {
 			energy = 100
 		}
 	}
-	class_restriction = { shipclass_military shipclass_military_special }
+	potential = {
+		OR = {
+			is_ship_class = shipclass_military
+			is_ship_class = shipclass_military_special
+		}
+	}
 	component_set = "combat_computers"
 	ship_behavior = "carrier"
 
@@ -647,7 +659,12 @@ utility_component_template = {
 	icon = "GFX_ship_part_computer_terminator_blokkat"
 	icon_frame = 1
 	power = -100
-	class_restriction = { shipclass_military shipclass_military_special }
+	potential = {
+		OR = {
+			is_ship_class = shipclass_military
+			is_ship_class = shipclass_military_special
+		}
+	}
 	component_set = "combat_computers"
 	ship_behavior = "carrier"
 
@@ -675,7 +692,12 @@ utility_component_template = {
 	icon = "GFX_ship_part_computer_terminator_blokkat"
 	icon_frame = 1
 	power = -100
-	class_restriction = { shipclass_military shipclass_military_special }
+	potential = {
+		OR = {
+			is_ship_class = shipclass_military
+			is_ship_class = shipclass_military_special
+		}
+	}
 	component_set = "combat_computers"
 	ship_behavior = "carrier"
 
@@ -702,10 +724,11 @@ utility_component_template = {
 	size = small
 	icon = "GFX_ship_part_computer_blokkazoi_blokkat"
 	icon_frame = 1
-	class_restriction = { shipclass_military shipclass_military_special }
+	potential = {
+		is_ship_size = giga_blokkat_individual
+	}
 	component_set = "combat_computers"
 	ship_behavior = "giga_blokkazoi"
-	size_restriction = { giga_blokkat_individual }
 
 	ai_weight = {
 		weight = 4
@@ -837,8 +860,11 @@ weapon_component_template = {
 
 	windup = { min = 5 max = 5 }
 	total_fire_time = 20
+	
+	potential = {
+		is_ship_size = giga_blokkat_harvester
+	}
 
-	size_restriction = { giga_blokkat_harvester }
 	component_set = "PLANET_KILLER_BLOKKAT_HARVESTER"
 	#planet_destruction_gfx = "blokkatsim_harvester_gfx"
 }

--- a/common/component_templates/ehof_t1_components.txt
+++ b/common/component_templates/ehof_t1_components.txt
@@ -12,6 +12,9 @@
 ################################
 ##### DEFENSIVE COMPONENTS #####
 ################################
+
+##### Mechanical shields #####
+
 utility_component_template = {
     key = "QNM_SHIELD_SMALL"
     size = small
@@ -19,48 +22,25 @@ utility_component_template = {
     icon_frame = 1
     component_set = "QNM_SHIELD"
     # upgrades_to = "COMPOUND_SHIELD_SMALL"
-    power = @ehof_power_S1
     prerequisites = { "tech_qnm_shields" }
 
-    modifier = {
-        ship_shield_add = @shield_S6 #@ehof_shield_S1
-        ship_shield_regen_add_static = @regen_S7 #@ehof_regen_S1
-    }
-    ship_modifier = {
-        ship_shield_hardening_add = @hardening_T6
-    }
+    potential = {
+		OR = {
+			from = {
+				country_uses_bio_ships = no
+			}
+			is_arkship_ship = yes
+		}
+	}
 
-    resources = {
-        category = ship_components
-        cost = {
-            giga_sr_sentient_metal = @shield_s_t6_cost #@ehof_t1_s_cost
-            giga_sr_negative_mass = 0.4 #@ehof_t1_s_cost_rare
-        }
-        upkeep = {
-            energy = @shield_s_t6_upkeep_energy
-            giga_sr_sentient_metal = @shield_s_t6_upkeep_alloys
-        }
-    }
-
-    ai_weight = {
-        weight = @T6_weight #@ehof_t1_shield_weight
-        modifier = {
-            is_fallen_empire = yes
-            factor = 0
-        }
-        modifier = {
-            factor = 0.0
-            ehof_default_country = yes
-            OR =  {
-                no_resource_for_component = { RESOURCE = giga_sr_sentient_metal }
-                no_resource_for_component = { RESOURCE = giga_sr_negative_mass }
-            }
-        }
-        inline_script = {
-            script = ship_components/weights/roles_stealth
-            MULT = 0
-        }
-    }
+    inline_script = {
+		script = ship_components/mech_ehof_ship_shield
+		SIZE = s
+		UPPERCASE_SIZE = S
+		TIER = 6
+		REGEN = 7
+		EHOF_TIER = 1
+	}
 }
 
 utility_component_template = {
@@ -68,50 +48,27 @@ utility_component_template = {
     size = medium
     icon = "GFX_qnm_shield"
     icon_frame = 1
-    power = @ehof_power_M1
+	component_set = "QNM_SHIELD"
+    # upgrades_to = "COMPOUND_SHIELD_MEDIUM"
     prerequisites = { "tech_qnm_shields" }
 
-    modifier = {
-        ship_shield_add = @shield_M6 #@ehof_shield_M1
-        ship_shield_regen_add_static = @regen_M7 #@ehof_regen_M1
-    }
-    ship_modifier = {
-        ship_shield_hardening_add = @hardening_T6
-    }
+    potential = {
+		OR = {
+			from = {
+				country_uses_bio_ships = no
+			}
+			is_arkship_ship = yes
+		}
+	}
 
-    component_set = "QNM_SHIELD"
-    # upgrades_to = "COMPOUND_SHIELD_MEDIUM"
-    resources = {
-        category = ship_components
-        cost = {
-            giga_sr_sentient_metal = @shield_m_t6_cost #@ehof_t1_m_cost
-            giga_sr_negative_mass = 0.8 #@ehof_t1_m_cost_rare
-        }
-        upkeep = {
-            energy = @shield_m_t6_upkeep_energy
-            giga_sr_sentient_metal = @shield_m_t6_upkeep_alloys
-        }
-    }
-
-    ai_weight = {
-        weight = @T6_weight #@ehof_t1_shield_weight
-        modifier = {
-            is_fallen_empire = yes
-            factor = 0
-        }
-        modifier = {
-            factor = 0.0
-            ehof_default_country = yes
-            OR =  {
-                no_resource_for_component = { RESOURCE = giga_sr_sentient_metal }
-                no_resource_for_component = { RESOURCE = giga_sr_negative_mass }
-            }
-        }
-        inline_script = {
-            script = ship_components/weights/roles_stealth
-            MULT = 0
-        }
-    }
+    inline_script = {
+		script = ship_components/mech_ehof_ship_shield
+		SIZE = m
+		UPPERCASE_SIZE = M
+		TIER = 6
+		REGEN = 7
+		EHOF_TIER = 1
+	}
 }
 
 utility_component_template = {
@@ -119,51 +76,110 @@ utility_component_template = {
     size = large
     icon = "GFX_qnm_shield"
     icon_frame = 1
-    power = @ehof_power_L1
+	component_set = "QNM_SHIELD"
+    # upgrades_to = "COMPOUND_SHIELD_LARGE"
     prerequisites = { "tech_qnm_shields" }
 
-    modifier = {
-        ship_shield_add = @shield_L6 #@ehof_shield_L1
-        ship_shield_regen_add_static = @regen_L7 #@ehof_regen_L1
-    }
-    ship_modifier = {
-        ship_shield_hardening_add = @hardening_T6
-    }
+    potential = {
+		OR = {
+			from = {
+				country_uses_bio_ships = no
+			}
+			is_arkship_ship = yes
+		}
+	}
 
-    component_set = "QNM_SHIELD"
-    # upgrades_to = "COMPOUND_SHIELD_LARGE"
-    resources = {
-        category = ship_components
-        cost = {
-            giga_sr_sentient_metal = @shield_l_t6_cost #@ehof_t1_l_cost
-            giga_sr_negative_mass = 1.6 #@ehof_t1_l_cost_rare
-        }
-        upkeep = {
-            energy = @shield_l_t7_upkeep_energy
-            giga_sr_sentient_metal = @shield_l_t7_upkeep_alloys
-        }
-    }
-
-    ai_weight = {
-        weight = @T6_weight #@ehof_t1_shield_weight
-        modifier = {
-            is_fallen_empire = yes
-            factor = 0
-        }
-        modifier = {
-            factor = 0.0
-            ehof_default_country = yes
-            OR =  {
-                no_resource_for_component = { RESOURCE = giga_sr_sentient_metal }
-                no_resource_for_component = { RESOURCE = giga_sr_negative_mass }
-            }
-        }
-        inline_script = {
-            script = ship_components/weights/roles_stealth
-            MULT = 0
-        }
-    }
+    inline_script = {
+		script = ship_components/mech_ehof_ship_shield
+		SIZE = l
+		UPPERCASE_SIZE = L
+		TIER = 6
+		REGEN = 7
+		EHOF_TIER = 1
+	}
 }
+
+##### Bio shields #####
+
+utility_component_template = {
+    key = "BIO_QNM_SHIELD_SMALL"
+    size = small
+    icon = "GFX_qnm_shield"
+    icon_frame = 1
+    component_set = "BIO_QNM_SHIELD"
+    # upgrades_to = "COMPOUND_SHIELD_SMALL"
+    prerequisites = { "tech_qnm_shields" }
+
+	potential = {
+		is_arkship_ship = no
+		from = {
+			country_uses_bio_ships = yes
+		}
+	}
+
+    inline_script = {
+		script = ship_components/bio_ehof_ship_shield
+		SIZE = s
+		UPPERCASE_SIZE = S
+		TIER = 6
+		REGEN = 7
+		EHOF_TIER = 1
+	}
+}
+
+utility_component_template = {
+    key = "BIO_QNM_SHIELD_MEDIUM"
+    size = medium
+    icon = "GFX_qnm_shield"
+    icon_frame = 1
+	component_set = "BIO_QNM_SHIELD"
+    # upgrades_to = "COMPOUND_SHIELD_MEDIUM"
+    prerequisites = { "tech_qnm_shields" }
+
+	potential = {
+		is_arkship_ship = no
+		from = {
+			country_uses_bio_ships = yes
+		}
+	}
+
+    inline_script = {
+		script = ship_components/bio_ehof_ship_shield
+		SIZE = m
+		UPPERCASE_SIZE = M
+		TIER = 6
+		REGEN = 7
+		EHOF_TIER = 1
+	}
+}
+
+utility_component_template = {
+    key = "BIO_QNM_SHIELD_LARGE"
+    size = large
+    icon = "GFX_qnm_shield"
+    icon_frame = 1
+	component_set = "BIO_QNM_SHIELD"
+    # upgrades_to = "COMPOUND_SHIELD_LARGE"
+    prerequisites = { "tech_qnm_shields" }
+
+	potential = {
+		is_arkship_ship = no
+		from = {
+			country_uses_bio_ships = yes
+		}
+	}
+
+    inline_script = {
+		script = ship_components/bio_ehof_ship_shield
+		SIZE = l
+		UPPERCASE_SIZE = L
+		TIER = 6
+		REGEN = 7
+		EHOF_TIER = 1
+	}
+}
+
+##### Mechanical armor #####
 
 utility_component_template = {
     key = "SENTIENT_ARMOR_SMALL"
@@ -172,45 +188,23 @@ utility_component_template = {
     icon_frame = 1
     component_set = "SENTIENT_ARMOR"
     # upgrades_to = "COMPOUND_ARMOR_SMALL"
-    power = 0
     prerequisites = { "tech_sm_armor" }
 
-    modifier = {
-        ship_armor_add = @armor_S6 #@ehof_armor_1S
-        ship_armor_regen_add_perc = @inf_regen_perc
-        ship_hull_regen_add_perc = @inf_regen_perc
-    }
-    ship_modifier = {
-        ship_armor_hardening_add = @hardening_T6
-    }
+    potential = {
+		OR = {
+			from = {
+				country_uses_bio_ships = no
+			}
+			is_arkship_ship = yes
+		}
+	}
 
-    resources = {
-        category = ship_components
-        cost = {
-            giga_sr_sentient_metal = @armor_s_t6_cost #@ehof_t1_s_cost
-            #giga_sr_negative_mass = @ehof_t1_s_cost_rare
-        }
-        upkeep = {
-            energy = @s_t6_upkeep_energy #@ehof_t1_s_upkeep_energy
-            giga_sr_sentient_metal = @s_t6_upkeep_alloys #@ehof_t1_s_upkeep_alloys
-        }
-    }
-
-    ai_weight = {
-        weight = @T6_weight
-        modifier = {
-            is_fallen_empire = yes
-            factor = 0
-        }
-        modifier = {
-            factor = 0.0
-            ehof_default_country = yes
-            OR =  {
-                no_resource_for_component = { RESOURCE = giga_sr_sentient_metal }
-                no_resource_for_component = { RESOURCE = giga_sr_negative_mass }
-            }
-        }
-    }
+    inline_script = {
+		script = ship_components/mech_ehof_ship_armor
+		SIZE = s
+		UPPERCASE_SIZE = S
+		TIER = 6
+	}
 }
 
 utility_component_template = {
@@ -220,45 +214,23 @@ utility_component_template = {
     icon_frame = 1
     component_set = "SENTIENT_ARMOR"
     # upgrades_to = "COMPOUND_ARMOR_MEDIUM"
-    power = 0
     prerequisites = { "tech_sm_armor" }
 
-    modifier = {
-        ship_armor_add = @armor_M6 #@ehof_armor_1M
-        ship_armor_regen_add_perc = @inf_regen_perc
-        ship_hull_regen_add_perc = @inf_regen_perc
-    }
-    ship_modifier = {
-        ship_armor_hardening_add = @hardening_T6
-    }
+    potential = {
+		OR = {
+			from = {
+				country_uses_bio_ships = no
+			}
+			is_arkship_ship = yes
+		}
+	}
 
-    resources = {
-        category = ship_components
-        cost = {
-            giga_sr_sentient_metal = @armor_m_t6_cost #@ehof_t1_m_cost
-            #giga_sr_negative_mass = @ehof_t1_m_cost_rare
-        }
-        upkeep = {
-            energy = @m_t6_upkeep_energy #@ehof_t1_m_upkeep_energy
-            giga_sr_sentient_metal = @m_t6_upkeep_alloys #@ehof_t1_m_upkeep_alloys
-        }
-    }
-
-    ai_weight = {
-        weight = @T6_weight
-        modifier = {
-            is_fallen_empire = yes
-            factor = 0
-        }
-        modifier = {
-            factor = 0.0
-            ehof_default_country = yes
-            OR =  {
-                no_resource_for_component = { RESOURCE = giga_sr_sentient_metal }
-                no_resource_for_component = { RESOURCE = giga_sr_negative_mass }
-            }
-        }
-    }
+    inline_script = {
+		script = ship_components/mech_ehof_ship_armor
+		SIZE = m
+		UPPERCASE_SIZE = M
+		TIER = 6
+	}
 }
 
 utility_component_template = {
@@ -268,45 +240,94 @@ utility_component_template = {
     icon_frame = 1
     component_set = "SENTIENT_ARMOR"
     # upgrades_to = "COMPOUND_ARMOR_LARGE"
-    power = 0
     prerequisites = { "tech_sm_armor" }
 
-    modifier = {
-        ship_armor_add = @armor_L6 #@ehof_armor_1L
-        ship_armor_regen_add_perc = @inf_regen_perc
-        ship_hull_regen_add_perc = @inf_regen_perc
-    }
-    ship_modifier = {
-        ship_armor_hardening_add = @hardening_T6
-    }
+    potential = {
+		OR = {
+			from = {
+				country_uses_bio_ships = no
+			}
+			is_arkship_ship = yes
+		}
+	}
 
-    resources = {
-        category = ship_components
-        cost = {
-            giga_sr_sentient_metal = @armor_l_t6_cost #@ehof_t1_l_cost
-            #giga_sr_negative_mass = @ehof_t1_l_cost_rare
-        }
-        upkeep = {
-            energy = @l_t6_upkeep_energy #@ehof_t1_l_upkeep_energy
-            giga_sr_sentient_metal = @l_t6_upkeep_alloys #@ehof_t1_l_upkeep_alloys
-        }
-    }
+    inline_script = {
+		script = ship_components/mech_ehof_ship_armor
+		SIZE = l
+		UPPERCASE_SIZE = L
+		TIER = 6
+	}
+}
 
-    ai_weight = {
-        weight = @T6_weight
-        modifier = {
-            is_fallen_empire = yes
-            factor = 0
-        }
-        modifier = {
-            factor = 0.0
-            ehof_default_country = yes
-            OR =  {
-                no_resource_for_component = { RESOURCE = giga_sr_sentient_metal }
-                no_resource_for_component = { RESOURCE = giga_sr_negative_mass }
-            }
-        }
-    }
+##### Bio armor #####
+
+utility_component_template = {
+    key = "BIO_SENTIENT_ARMOR_SMALL"
+    size = small
+    icon = "GFX_sentient_armor"
+    icon_frame = 1
+    component_set = "BIO_SENTIENT_ARMOR"
+    # upgrades_to = "COMPOUND_ARMOR_SMALL"
+    prerequisites = { "tech_sm_armor" }
+
+	potential = {
+		is_arkship_ship = no
+		from = {
+			country_uses_bio_ships = yes
+		}
+	}
+
+    inline_script = {
+		script = ship_components/bio_ehof_ship_armor
+		SIZE = s
+		TIER = 6
+	}
+}
+
+utility_component_template = {
+    key = "BIO_SENTIENT_ARMOR_MEDIUM"
+    size = medium
+    icon = "GFX_sentient_armor"
+    icon_frame = 1
+    component_set = "BIO_SENTIENT_ARMOR"
+    # upgrades_to = "COMPOUND_ARMOR_MEDIUM"
+    prerequisites = { "tech_sm_armor" }
+
+	potential = {
+		is_arkship_ship = no
+		from = {
+			country_uses_bio_ships = yes
+		}
+	}
+
+    inline_script = {
+		script = ship_components/bio_ehof_ship_armor
+		SIZE = m
+		TIER = 6
+	}
+}
+
+utility_component_template = {
+    key = "BIO_SENTIENT_ARMOR_LARGE"
+    size = large
+    icon = "GFX_sentient_armor"
+    icon_frame = 1
+    component_set = "BIO_SENTIENT_ARMOR"
+    # upgrades_to = "COMPOUND_ARMOR_LARGE"
+    prerequisites = { "tech_sm_armor" }
+
+	potential = {
+		is_arkship_ship = no
+		from = {
+			country_uses_bio_ships = yes
+		}
+	}
+
+    inline_script = {
+		script = ship_components/bio_ehof_ship_armor
+		SIZE = l
+		TIER = 6
+	}
 }
 
 
@@ -889,7 +910,7 @@ weapon_component_template = {
     use_ship_main_target = no
     prio_projectile = yes
     potential = {
-        ship_uses_titan_components = yes
+        giga_uses_titan_components = yes
     }
     prerequisites = { "tech_sm_titanic" }
     component_set = "SENTIENT_TITAN"
@@ -968,7 +989,8 @@ weapon_component_template = {
     use_ship_main_target = no
     prio_projectile = yes
     potential = {
-        ship_uses_ion_cannon_components = yes    }
+        giga_uses_ion_cannon_components = yes
+	}
     prerequisites = { "tech_sm_titanic" }
     component_set = "SENTIENT_TITAN"
     projectile_gfx = "adv_kinetic_artillery"
@@ -1852,7 +1874,7 @@ weapon_component_template = {
     component_set = "QNM_BEAM_TITAN"
     projectile_gfx = "perdition_beam"
     potential = {
-        ship_uses_titan_components = yes
+        giga_uses_titan_components = yes
     }
     tags = { weapon_type_anticompound weapon_type_energy }
     # ship_modifier = {
@@ -1930,7 +1952,7 @@ weapon_component_template = {
     component_set = "QNM_BEAM_TITAN"
     projectile_gfx = "perdition_beam"
     potential = {
-        ship_uses_ion_cannon_components = yes
+        giga_uses_ion_cannon_components = yes
     }
     tags = { weapon_type_anticompound weapon_type_energy }
     # ship_modifier = {
@@ -2043,7 +2065,9 @@ utility_component_template = {
     icon_frame = 1
     power = @ehof_drive_power1
     ftl = yes
-    class_restriction = { shipclass_military shipclass_constructor shipclass_colonizer shipclass_science_ship shipclass_transport shipclass_military_special shipclass_starbase }
+    potential = {
+		giga_uses_jump_drives = yes
+	}
     prerequisites = { "tech_qnm_jumpdrive" }
     component_set = "ftl_components"
     # upgrades_to = "COMPOUND_JUMPDRIVE"
@@ -2118,7 +2142,9 @@ utility_component_template = {
     icon = "GFX_sentient_computer_swarm"
     icon_frame = 1
     power = @ehof_computer_power1
-    inline_script = components/size_restriction/giga_swarm
+	potential = {
+		giga_uses_swarm_role = yes
+	}
     prerequisites = { "tech_sm_computers" }
     component_set = "combat_computers"
     ship_behavior = "swarm"
@@ -2159,8 +2185,9 @@ utility_component_template = {
         category = ship_components
         cost = { giga_sr_sentient_metal = @ehof_computer_cost1 }
     }
-    class_restriction = { shipclass_military }
-    inline_script = components/size_restriction/giga_torpedo
+	potential = {
+		giga_uses_torpedo_role = yes
+	}
     component_set = "combat_computers"
     ship_behavior = "torpedo"
     # upgrades_to = "COMPOUND_COMPUTER_TORPEDO"
@@ -2198,8 +2225,9 @@ utility_component_template = {
     icon = "GFX_sentient_computer_picket"
     icon_frame = 1
     power = @ehof_computer_power1
-    class_restriction = { shipclass_military }
-    inline_script = components/size_restriction/giga_picket
+	potential = {
+		giga_uses_picket_role = yes
+	}
     prerequisites = { "tech_sm_computers" }
     component_set = "combat_computers"
     ship_behavior = "picket"
@@ -2235,7 +2263,9 @@ utility_component_template = {
     icon = "GFX_sentient_computer_line"
     icon_frame = 1
     power = @ehof_computer_power1
-    inline_script = components/size_restriction/giga_line
+	potential = {
+		giga_uses_line_role = yes
+	}
     prerequisites = { "tech_sm_computers" }
     component_set = "combat_computers"
     ship_behavior = "line"
@@ -2270,7 +2300,9 @@ utility_component_template = {
     icon = "GFX_sentient_computer_artillery"
     icon_frame = 1
     power = @ehof_computer_power1
-    inline_script = components/size_restriction/giga_artillery
+	potential = {
+		giga_uses_artillery_role = yes
+	}
     prerequisites = { "tech_sm_computers" }
     component_set = "combat_computers"
     ship_behavior = "artillery"
@@ -2305,8 +2337,9 @@ utility_component_template = {
     icon = "GFX_sentient_computer_carrier"
     icon_frame = 1
     power = @ehof_computer_power1
-    inline_script = components/size_restriction/giga_carrier
-    class_restriction = { shipclass_military shipclass_starbase }
+	potential = {
+		giga_uses_carrier_role = yes
+	}
     prerequisites = { "tech_sm_computers" }
     component_set = "combat_computers"
     ship_behavior = "carrier"
@@ -2340,7 +2373,9 @@ utility_component_template = {
     icon = "GFX_sentient_computer_platform"
     icon_frame = 1
     power = @ehof_computer_power1
-    class_restriction = { shipclass_military_station }
+	potential = {
+		giga_uses_platform_computers = yes
+	}
     prerequisites = { "tech_sm_computers" }
     component_set = "combat_computers"
     ship_behavior = "platform"
@@ -2375,8 +2410,9 @@ utility_component_template = {
     icon_frame = 1
     power = 0
     ship_behavior = "colossus"
-    size_restriction = { reshaper colossus }
-    class_restriction = { shipclass_military_special }
+	potential = {
+		giga_uses_colossus_computers = yes
+	}
     prerequisites = { "tech_sm_computers" }
     component_set = "combat_computers"
     ai_weight = {
@@ -2398,8 +2434,9 @@ utility_component_template = {
     component_set = "combat_computers"
     ship_behavior = "platform"
     # upgrades_to = "COMPOUND_COMPUTER_STARBASE"
-    inline_script = components/size_restriction/giga_starbase_computer
-    class_restriction = { shipclass_starbase }
+	potential = {
+		giga_uses_starbase_computers = yes
+	}
     prerequisites = { "tech_sm_computers" }
     ai_weight = {
         weight = @ehof_t1_weight
@@ -2437,8 +2474,9 @@ utility_component_template = {
     power = @ehof_corvette_reactor_power_1
     component_set = "power_core"
     # upgrades_to = "COMPOUND_REACTOR_CORVETTE"
-    inline_script = components/size_restriction/giga_corvette
-
+	potential = {
+		giga_uses_corvette_reactors = yes
+	}
     prerequisites = { "tech_qnm_reactors" }
     ai_weight = {
         weight = @ehof_t1_weight
@@ -2476,7 +2514,9 @@ utility_component_template = {
     power = @ehof_destroyer_reactor_power_1
     component_set = "power_core"
     # upgrades_to = "COMPOUND_REACTOR_DESTROYER"
-    inline_script = components/size_restriction/giga_destroyer
+	potential = {
+		giga_uses_destroyer_reactors = yes
+	}
 
     prerequisites = { "tech_qnm_reactors" }
     ai_weight = {
@@ -2515,7 +2555,9 @@ utility_component_template = {
     power = @ehof_cruiser_reactor_power_1
     component_set = "power_core"
     # upgrades_to = "COMPOUND_REACTOR_CRUISER"
-    inline_script =  components/size_restriction/giga_cruiser
+	potential = {
+		giga_uses_cruiser_reactors = yes
+	}
 
     prerequisites = { "tech_qnm_reactors" }
     ai_weight = {
@@ -2554,7 +2596,9 @@ utility_component_template = {
     power = @ehof_battleship_reactor_power_1
     component_set = "power_core"
     # upgrades_to = "COMPOUND_REACTOR_BATTLESHIP"
-    inline_script = components/size_restriction/giga_battleship
+	potential = {
+		giga_uses_battleship_reactors = yes
+	}
 
     prerequisites = { "tech_qnm_reactors" }
     ai_weight = {
@@ -2593,7 +2637,9 @@ utility_component_template = {
     power = @ehof_titan_reactor_power_1
     component_set = "power_core"
     # upgrades_to = "COMPOUND_REACTOR_TITAN"
-    inline_script = components/size_restriction/giga_titan
+	potential = {
+		giga_uses_titan_reactors = yes
+	}
 
     prerequisites = { "tech_qnm_reactors" }
     ai_weight = {
@@ -2632,7 +2678,9 @@ utility_component_template = {
     power = @ehof_colossus_reactor_power_1
     component_set = "power_core"
     # upgrades_to = "COMPOUND_REACTOR_COLOSSUS"
-    inline_script = components/size_restriction/giga_colossus
+	potential = {
+		giga_uses_colossus_reactors = yes
+	}
 
     prerequisites = { "tech_qnm_reactors" }
     ai_weight = {
@@ -2663,7 +2711,9 @@ utility_component_template = {
     power = @ehof_juggernaut_reactor_power_1
     component_set = "power_core"
     # upgrades_to = "COMPOUND_REACTOR_JUGGERNAUT"
-    inline_script = components/size_restriction/giga_juggernaut
+	potential = {
+		giga_uses_juggernaut_reactors = yes
+	}
 
     prerequisites = { "tech_qnm_reactors" }
     ai_weight = {
@@ -2702,9 +2752,9 @@ utility_component_template = {
     power = @ehof_platform_reactor_power_1
     component_set = "power_core"
     # upgrades_to = "COMPOUND_REACTOR_PLATFORM"
-    inline_script = components/size_restriction/giga_platform
-
-    class_restriction = { shipclass_military_station }
+	potential = {
+		giga_uses_platform_reactors = yes
+	}
     prerequisites = { "tech_qnm_reactors" }
     ai_weight = {
         weight = @ehof_t1_weight
@@ -2742,7 +2792,9 @@ utility_component_template = {
     power = @ehof_battleship_reactor_power_1
     component_set = "power_core"
     #upgrades_to = "COMPOUND_REACTOR_ION"
-    inline_script = components/size_restriction/giga_ion
+	potential = {
+		giga_uses_ion_cannon_reactors = yes
+	}
 
     prerequisites = { "tech_qnm_reactors" }
     ai_weight = {
@@ -2778,8 +2830,9 @@ utility_component_template = {
     power = @ehof_starbase_reactor_power_1
     component_set = "power_core"
     # upgrades_to = "COMPOUND_REACTOR_STARBASE"
-    class_restriction = { shipclass_starbase }
-    inline_script = components/size_restriction/giga_starbase
+	potential = {
+		giga_uses_starbase_reactors = yes
+	}
 
     prerequisites = { "tech_qnm_reactors" }
     ai_weight = {
@@ -2820,7 +2873,9 @@ utility_component_template = {
     }
     component_set = "thruster_components"
     # upgrades_to = "COMPOUND_THRUSTER_CORVETTE"
-    inline_script = components/size_restriction/giga_corvette
+	potential = {
+		giga_uses_corvette_thrusters = yes
+	}
     resources = {
         category = ship_components
         cost = {
@@ -2856,7 +2911,9 @@ utility_component_template = {
     }
     component_set = "thruster_components"
     # upgrades_to = "COMPOUND_THRUSTER_DESTROYER"
-    inline_script = components/size_restriction/giga_destroyer
+	potential = {
+		giga_uses_destroyer_thrusters = yes
+	}
     resources = {
         category = ship_components
         cost = {
@@ -2892,7 +2949,9 @@ utility_component_template = {
     }
     component_set = "thruster_components"
     # upgrades_to = "COMPOUND_THRUSTER_CRUISER"
-    inline_script = components/size_restriction/giga_cruiser
+	potential = {
+		giga_uses_cruiser_thrusters = yes
+	}
     resources = {
         category = ship_components
         cost = {
@@ -2928,7 +2987,9 @@ utility_component_template = {
     }
     component_set = "thruster_components"
     # upgrades_to = "COMPOUND_THRUSTER_BATTLESHIP"
-    inline_script = components/size_restriction/giga_battleship
+	potential = {
+		giga_uses_battleship_thrusters = yes
+	}
     resources = {
         category = ship_components
         cost = {
@@ -2964,7 +3025,9 @@ utility_component_template = {
     }
     component_set = "thruster_components"
     # upgrades_to = "COMPOUND_THRUSTER_TITAN"
-    inline_script = components/size_restriction/giga_titan
+	potential = {
+		giga_uses_titan_thrusters = yes
+	}
     resources = {
         category = ship_components
         cost = {
@@ -2999,7 +3062,9 @@ utility_component_template = {
     }
     component_set = "thruster_components"
     # upgrades_to = "COMPOUND_THRUSTER_COLOSSUS"
-    inline_script = components/size_restriction/giga_colossus
+	potential = {
+		giga_uses_colossus_thrusters = yes
+	}
     resources = {
         category = ship_components
         cost = {

--- a/common/component_templates/ehof_t2_components.txt
+++ b/common/component_templates/ehof_t2_components.txt
@@ -307,8 +307,10 @@ weapon_component_template = {
     icon_frame = 1
     size = small
     type = instant
-    potential = { from = { is_country_type = compound_empire } }
-    size_restriction = { hornet stalker humiliator apex sovereign }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_is_compound_regular_ship = yes
+	}
     component_set = "COMPOUND_HM_BEAM"
     projectile_gfx = "ehof_hazard_matter_beam"
     tags = { weapon_type_energy weapon_type_anticompound }
@@ -361,8 +363,10 @@ weapon_component_template = {
     icon_frame = 1
     size = medium
     type = instant
-    potential = { from = { is_country_type = compound_empire } }
-    size_restriction = { hornet stalker humiliator apex sovereign }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_is_compound_regular_ship = yes
+	}
     component_set = "COMPOUND_HM_BEAM"
     projectile_gfx = "ehof_hazard_matter_beam"
     tags = { weapon_type_energy weapon_type_anticompound }
@@ -415,8 +419,10 @@ weapon_component_template = {
     icon_frame = 1
     size = large
     type = instant
-    potential = { from = { is_country_type = compound_empire } }
-    size_restriction = { hornet stalker humiliator apex sovereign }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_is_compound_regular_ship = yes
+	}
     component_set = "COMPOUND_HM_BEAM"
     projectile_gfx = "ehof_hazard_matter_beam"
     tags = { weapon_type_energy weapon_type_anticompound }
@@ -469,8 +475,10 @@ weapon_component_template = {
     icon_frame = 1
     size = small
     type = instant
-    potential = { from = { is_country_type = compound_empire } }
-    size_restriction = { starbase_ehof_01 starbase_ehof_02 starbase_ehof_03 starbase_ehof_04 starbase_ehof_05 }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_is_compound_starbase = yes
+	}
     component_set = "COMPOUND_HM_BEAM"
     projectile_gfx = "ehof_hazard_matter_beam"
     tags = { weapon_type_energy weapon_type_anticompound }
@@ -497,8 +505,10 @@ weapon_component_template = {
     icon_frame = 1
     size = small
     type = instant
-    potential = { from = { is_country_type = compound_empire } }
-    size_restriction = { hornet stalker humiliator apex sovereign }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_is_compound_regular_ship = yes
+	}
     component_set = "COMPOUND_HM_PLASMA"
     projectile_gfx = "ehof_hazard_matter_accelerator"
     tags = { weapon_type_energy weapon_type_anticompound }
@@ -552,8 +562,10 @@ weapon_component_template = {
     icon_frame = 1
     size = medium
     type = instant
-    potential = { from = { is_country_type = compound_empire } }
-    size_restriction = { hornet stalker humiliator apex sovereign }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_is_compound_regular_ship = yes
+	}
     component_set = "COMPOUND_HM_PLASMA"
     projectile_gfx = "ehof_hazard_matter_accelerator"
     tags = { weapon_type_energy weapon_type_anticompound }
@@ -607,8 +619,10 @@ weapon_component_template = {
     icon_frame = 1
     size = large
     type = instant
-    potential = { from = { is_country_type = compound_empire } }
-    size_restriction = { hornet stalker humiliator apex sovereign }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_is_compound_regular_ship = yes
+	}
     component_set = "COMPOUND_HM_PLASMA"
     projectile_gfx = "ehof_hazard_matter_accelerator"
     tags = { weapon_type_energy weapon_type_anticompound }
@@ -662,8 +676,10 @@ weapon_component_template = {
     icon_frame = 1
     size = medium
     type = instant
-    potential = { from = { is_country_type = compound_empire } }
-    size_restriction = { starbase_ehof_01 starbase_ehof_02 starbase_ehof_03 starbase_ehof_04 starbase_ehof_05 }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_is_compound_starbase = yes
+	}
     component_set = "COMPOUND_HM_PLASMA"
     projectile_gfx = "ehof_hazard_matter_accelerator"
     tags = { weapon_type_energy weapon_type_anticompound }
@@ -690,8 +706,10 @@ weapon_component_template = {
     icon_frame = 1
     size = large
     type = instant
-    potential = { from = { is_country_type = compound_empire } }
-    size_restriction = { hornet stalker humiliator apex sovereign }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_is_compound_regular_ship = yes
+	}
     component_set = "COMPOUND_HM_LAUNCHER"
     projectile_gfx = "ehof_hazard_matter_launcher"
     tags = { weapon_type_energy weapon_type_anticompound }
@@ -747,8 +765,10 @@ weapon_component_template = {
     icon_frame = 1
     size = large
     type = instant
-    potential = { from = { is_country_type = compound_empire } }
-    size_restriction = { starbase_ehof_01 starbase_ehof_02 starbase_ehof_03 starbase_ehof_04 starbase_ehof_05 }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_is_compound_starbase = yes
+	}
     component_set = "COMPOUND_HM_LAUNCHER"
     projectile_gfx = "ehof_hazard_matter_launcher"
     tags = { weapon_type_energy weapon_type_anticompound }
@@ -778,8 +798,10 @@ weapon_component_template = {
     icon_frame = 1
     size = extra_large
     type = instant
-    potential = { from = { is_country_type = compound_empire } }
-    size_restriction = { hornet stalker humiliator apex sovereign }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_is_compound_regular_ship = yes
+	}
     component_set = "COMPOUND_HM_LANCE"
     projectile_gfx = "ehof_hazard_matter_lance"
     tags = { weapon_type_energy weapon_type_anticompound }
@@ -837,8 +859,10 @@ weapon_component_template = {
     icon_frame = 1
     size = extra_large
     type = instant
-    potential = { from = { is_country_type = compound_empire } }
-    size_restriction = { starbase_ehof_01 starbase_ehof_02 starbase_ehof_03 starbase_ehof_04 starbase_ehof_05 }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_is_compound_starbase = yes
+	}
     component_set = "COMPOUND_HM_LANCE"
     projectile_gfx = "ehof_hazard_matter_lance"
     tags = { weapon_type_energy weapon_type_anticompound }
@@ -877,10 +901,12 @@ weapon_component_template = {
     icon_frame = 1
     size = titanic
     type = instant
-    potential = { from = { is_country_type = compound_empire } }
+    potential = {
+		from = { is_country_type = compound_empire }
+		is_ship_size = sovereign
+	}
     component_set = "COMPOUND_HM_ERADICATOR"
     projectile_gfx = "ehof_hazard_matter_eradicator"
-    size_restriction = { sovereign }
     tags = { weapon_type_energy weapon_type_anticompound }
     # ship_modifier = {
     # 	damage_vs_country_type_compound_empire_mult = @ehof_t2_weapon_anti_compound_nm_titanic
@@ -942,8 +968,10 @@ weapon_component_template = {
     type = planet_killer
     component_set = "COMPOUND_HM_RESHAPER"
     planet_destruction_gfx = "reshaper_gfx"
-    potential = { from = { is_country_type = compound_empire } }
-    size_restriction = { reshaper }
+    potential = {
+		from = { is_country_type = compound_empire }
+		is_ship_size = reshaper
+	}
     tags = { weapon_type_energy weapon_type_anticompound }
 
     use_ship_main_target = no
@@ -963,8 +991,10 @@ utility_component_template = {
     icon = "GFX_compound_aura"
     icon_frame = 1
     power = 0
-    potential = { from = { is_country_type = compound_empire } }
-    size_restriction = { sovereign }
+    potential = {
+		from = { is_country_type = compound_empire }
+		is_ship_size = reshaper
+	}
     component_set = "COMPOUND_AURA_COMPONENTS"
 
     hostile_aura = {
@@ -998,8 +1028,13 @@ utility_component_template = {
 #     icon = "GFX_compound_aura"
 #     icon_frame = 1
 #     power = 0
-#     potential = { from = { is_country_type = compound_empire } }
-#     size_restriction = { hornet stalker humiliator apex sovereign architect propagator reshaper }
+#     potential = {
+#		 from = { is_country_type = compound_empire }
+#		 OR = {
+#			giga_is_compound_regular_ship = yes
+#			giga_is_compound_special_ship = yes
+#		 }
+#	  }
 #     component_set = "COMPOUND_IMMUNITY_AURA_SET"
 #
 #     hostile_aura = {
@@ -1022,8 +1057,10 @@ utility_component_template = {
     icon = "GFX_compound_aura"
     icon_frame = 1
     power = 0
-    potential = { from = { is_country_type = compound_empire } }
-    size_restriction = { starbase_ehof_01 starbase_ehof_02 starbase_ehof_03 starbase_ehof_04 starbase_ehof_05 }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_is_compound_starbase = yes
+	}
     component_set = "COMPOUND_COMMUNICATIONS_JAMMER"
 
     hostile_aura = {
@@ -1058,8 +1095,10 @@ utility_component_template = {
     icon_frame = 1
     power = @ehof_drive_power2
     ftl = yes
-    potential = { from = { is_country_type = compound_empire } }
-    class_restriction = { shipclass_military shipclass_constructor shipclass_colonizer shipclass_science_ship shipclass_transport shipclass_military_special shipclass_starbase }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_jump_drives = yes
+	}
     #prerequisites = { "tech_compound_drives" }
     component_set = "ftl_components"
     # ai_weight = {
@@ -1132,9 +1171,10 @@ utility_component_template = {
     icon = "GFX_compound_computer_swarm"
     icon_frame = 1
     power = @ehof_computer_power2
-    size_restriction = { corvette hornet }
-    class_restriction = { shipclass_military }
-    potential = { from = { is_country_type = compound_empire } }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_swarm_role = yes
+	}
     component_set = "combat_computers"
     ship_behavior = "swarm"
     ai_tags = { gunship brawler brawler_stealth }
@@ -1173,11 +1213,12 @@ utility_component_template = {
 #         category = ship_components
 #         cost = { sr_dark_matter = @ehof_computer_cost2 }
 #     }
-#     class_restriction = { shipclass_military }
-#     size_restriction = { frigate crisis_destroyer cruiser offspring_cruiser hornet stalker humiliator }
 #     component_set = "combat_computers"
 #     ship_behavior = "torpedo"
-#     potential = { from = { is_country_type = compound_empire } }
+#     potential = {
+#		 from = { is_country_type = compound_empire }
+#		 giga_uses_torpedo_role = yes
+#	  }
 #     ai_tags = { explosive explosive_stealth }
 #     ai_tag_weight = 0
 #
@@ -1211,9 +1252,10 @@ utility_component_template = {
     icon = "GFX_compound_computer_picket"
     icon_frame = 1
     power = @ehof_computer_power2
-    size_restriction = { hornet stalker humiliator corvette destroyer cruiser }
-    class_restriction = { shipclass_military }
-    potential = { from = { is_country_type = compound_empire } }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_picket_role = yes
+	}
     component_set = "combat_computers"
     ship_behavior = "picket"
     ai_tags = { screen }
@@ -1246,9 +1288,10 @@ utility_component_template = {
     icon = "GFX_compound_computer_line"
     icon_frame = 1
     power = @ehof_computer_power2
-    size_restriction = { stalker humiliator apex destroyer cruiser battleship }
-    class_restriction = { shipclass_military }
-    potential = { from = { is_country_type = compound_empire } }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_line_role = yes
+	}
     component_set = "combat_computers"
     ship_behavior = "line"
     ai_tags = { gunship }
@@ -1281,9 +1324,10 @@ utility_component_template = {
     icon = "GFX_compound_computer_artillery"
     icon_frame = 1
     power = @ehof_computer_power2
-    size_restriction = { stalker humiliator apex sovereign destroyer cruiser battleship titan juggernaut }
-    class_restriction = { shipclass_military shipclass_starbase }
-    potential = { from = { is_country_type = compound_empire } }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_artillery_role = yes
+	}
     component_set = "combat_computers"
     ship_behavior = "artillery"
     ai_tags = { artillery artillery_stealth energy_torpedoes energy_torpedoes_stealth }
@@ -1316,9 +1360,10 @@ utility_component_template = {
 #     icon = "GFX_compound_computer_carrier"
 #     icon_frame = 1
 #     power = @ehof_computer_power2
-#     potential = { from = { is_country_type = compound_empire } }
-#     size_restriction = { humiliator apex sovereign cruiser battleship titan juggernaut }
-#     class_restriction = { shipclass_military shipclass_starbase }
+#     potential = {
+#	 	 from = { is_country_type = compound_empire }
+#	 	 giga_uses_carrier_role = yes
+#	  }
 #     component_set = "combat_computers"
 #     ship_behavior = "carrier"
 #     ai_tags = { carrier }
@@ -1350,8 +1395,10 @@ utility_component_template = {
 #     icon = "GFX_compound_computer_platform"
 #     icon_frame = 1
 #     power = @ehof_computer_power2
-#     class_restriction = { shipclass_military_station }
-#     potential = { from = { is_country_type = compound_empire } }
+#     potential = {
+#		 from = { is_country_type = compound_empire }
+#		 giga_uses_platform_computers = yes
+#	  }
 #     component_set = "combat_computers"
 #     ship_behavior = "platform"
 #     # ai_weight = {
@@ -1384,9 +1431,10 @@ utility_component_template = {
     icon_frame = 1
     power = 0
     ship_behavior = "colossus"
-    potential = { from = { is_country_type = compound_empire } }
-    size_restriction = { reshaper }
-    class_restriction = { shipclass_military_special }
+    potential = {
+		from = { is_country_type = compound_empire }
+		is_ship_size = reshaper
+	}
     component_set = "combat_computers"
 }
 
@@ -1398,20 +1446,10 @@ utility_component_template = {
     power = 0
     component_set = "combat_computers"
     ship_behavior = "platform"
-    size_restriction = {
-        starbase_outpost
-        starbase_starport
-        starbase_starhold
-        starbase_starfortress
-        starbase_citadel
-        starbase_ehof_01
-        starbase_ehof_02
-        starbase_ehof_02
-        starbase_ehof_04
-        starbase_ehof_05
-    }
-    potential = { from = { is_country_type = compound_empire } }
-    class_restriction = { shipclass_starbase }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_starbase_computers = yes
+	}
     # prerequisites = { "tech_compound_computers" }
     # ai_weight = {
     #     weight = @ehof_t2_weight
@@ -1448,8 +1486,10 @@ utility_component_template = {
     icon_frame = 1
     power = @ehof_corvette_reactor_power_1
     component_set = "power_core"
-    potential = { from = { is_country_type = compound_empire } }
-    inline_script = components/size_restriction/giga_corvette
+    potential = { 
+		from = { is_country_type = compound_empire }
+		giga_uses_corvette_reactors = yes
+	}
 
     # prerequisites = { "tech_compound_reactors" }
     # ai_weight = {
@@ -1487,8 +1527,10 @@ utility_component_template = {
     icon_frame = 1
     power = @ehof_destroyer_reactor_power_1
     component_set = "power_core"
-    potential = { from = { is_country_type = compound_empire } }
-    inline_script = components/size_restriction/giga_destroyer
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_destroyer_reactors = yes
+	}
 
     # prerequisites = { "tech_compound_reactors" }
     # ai_weight = {
@@ -1526,8 +1568,10 @@ utility_component_template = {
     icon_frame = 1
     power = @ehof_cruiser_reactor_power_1
     component_set = "power_core"
-    potential = { from = { is_country_type = compound_empire } }
-    inline_script = components/size_restriction/giga_cruiser
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_cruiser_reactors = yes
+	}
 
     # prerequisites = { "tech_compound_reactors" }
     # ai_weight = {
@@ -1565,8 +1609,10 @@ utility_component_template = {
     icon_frame = 1
     power = @ehof_battleship_reactor_power_1
     component_set = "power_core"
-    potential = { from = { is_country_type = compound_empire } }
-    inline_script = components/size_restriction/giga_battleship
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_battleship_reactors = yes
+	}
 
     # prerequisites = { "tech_compound_reactors" }
     # ai_weight = {
@@ -1604,8 +1650,10 @@ utility_component_template = {
     icon_frame = 1
     power = @ehof_titan_reactor_power_1
     component_set = "power_core"
-    potential = { from = { is_country_type = compound_empire } }
-    inline_script = components/size_restriction/giga_titan
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_titan_reactors = yes
+	}
 
     # prerequisites = { "tech_compound_reactors" }
     # ai_weight = {
@@ -1643,8 +1691,10 @@ utility_component_template = {
     icon_frame = 1
     power = @ehof_colossus_reactor_power_2
     component_set = "power_core"
-    potential = { from = { is_country_type = compound_empire } }
-    inline_script = components/size_restriction/giga_colossus
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_colossus_reactors = yes
+	}
 
     # prerequisites = { "tech_compound_reactors" }
     # ai_weight = {
@@ -1674,8 +1724,10 @@ utility_component_template = {
 #     icon_frame = 1
 #     power = @ehof_juggernaut_reactor_power_2
 #     component_set = "power_core"
-#     potential = { from = { is_country_type = compound_empire } }
-#     inline_script = components/size_restriction/giga_juggernaut
+#     potential = {
+#		 from = { is_country_type = compound_empire }
+#		 giga_uses_juggernaut_reactors = yes
+#	  }
 #
 #     #prerequisites = { "tech_compound_reactors" }
 #     # ai_weight = {
@@ -1710,10 +1762,11 @@ utility_component_template = {
 #     icon_frame = 1
 #     power = @ehof_platform_reactor_power_2
 #     component_set = "power_core"
-#     potential = { from = { is_country_type = compound_empire } }
-#     inline_script = components/size_restriction/giga_platform
+#     potential = {
+#		 from = { is_country_type = compound_empire }
+#	 	 giga_uses_platform_reactors = yes
+#  	  }
 #
-#     class_restriction = { shipclass_military_station }
 #     # prerequisites = { "tech_compound_reactors" }
 #     # ai_weight = {
 #     #     weight = @ehof_t2_weight
@@ -1747,8 +1800,10 @@ utility_component_template = {
 #     icon_frame = 1
 #     power = @ehof_ion_reactor_power_2
 #     component_set = "power_core"
-#     potential = { from = { is_country_type = compound_empire } }
-#     inline_script = components/size_restriction/giga_ion
+#     potential = {
+#		 from = { is_country_type = compound_empire }
+#	 	 giga_uses_ion_cannon_reactors = yes
+#  	  }
 #
 #     ai_weight = {
 #         weight = @ehof_t2_weight
@@ -1782,9 +1837,10 @@ utility_component_template = {
     icon_frame = 1
     power = @ehof_starbase_reactor_power_2
     component_set = "power_core"
-    potential = { from = { is_country_type = compound_empire } }
-    class_restriction = { shipclass_starbase }
-    inline_script = components/size_restriction/giga_starbase
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_starbase_reactors = yes
+	}
 
     # prerequisites = { "tech_compound_reactors" }
     # ai_weight = {
@@ -1818,13 +1874,15 @@ utility_component_template = {
     icon = "GFX_compound_thruster"
     icon_frame = 1
     power = @ehof_corvette_thruster_power_2
-    potential = { from = { is_country_type = compound_empire } }
+	potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_corvette_thrusters = yes
+	}
     modifier = {
         ship_base_speed_mult = @ehof_thruster_basespeed_2
         ship_evasion_add = @ehof_corvette_thruster_evasion_2
     }
     component_set = "thruster_components"
-    inline_script = components/size_restriction/giga_corvette
     resources = {
         category = ship_components
         cost = {
@@ -1853,13 +1911,15 @@ utility_component_template = {
     icon = "GFX_compound_thruster"
     icon_frame = 1
     power = @ehof_destroyer_thruster_power_2
-    potential = { from = { is_country_type = compound_empire } }
+    potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_destroyer_thrusters = yes
+	}
     modifier = {
         ship_base_speed_mult = @ehof_thruster_basespeed_2
         ship_evasion_add = @ehof_destroyer_thruster_evasion_2
     }
     component_set = "thruster_components"
-    inline_script = components/size_restriction/giga_destroyer
     resources = {
         category = ship_components
         cost = {
@@ -1888,13 +1948,15 @@ utility_component_template = {
     icon = "GFX_compound_thruster"
     icon_frame = 1
     power = @ehof_cruiser_thruster_power_2
-    potential = { from = { is_country_type = compound_empire } }
+	potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_cruiser_thrusters = yes
+	}
     modifier = {
         ship_base_speed_mult = @ehof_thruster_basespeed_2
         ship_evasion_add = @ehof_cruiser_thruster_evasion_2
     }
     component_set = "thruster_components"
-    inline_script = components/size_restriction/giga_cruiser
     resources = {
         category = ship_components
         cost = {
@@ -1923,13 +1985,15 @@ utility_component_template = {
     icon = "GFX_compound_thruster"
     icon_frame = 1
     power = @ehof_battleship_thruster_power_2
-    potential = { from = { is_country_type = compound_empire } }
+	potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_battleship_thrusters = yes
+	}
     modifier = {
         ship_base_speed_mult = @ehof_thruster_basespeed_2
         ship_evasion_add = @ehof_battleship_thruster_evasion_2
     }
     component_set = "thruster_components"
-    inline_script = components/size_restriction/giga_battleship
     resources = {
         category = ship_components
         cost = {
@@ -1958,13 +2022,15 @@ utility_component_template = {
     icon = "GFX_compound_thruster"
     icon_frame = 1
     power = @ehof_titan_thruster_power_2
-    potential = { from = { is_country_type = compound_empire } }
+	potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_titan_thrusters = yes
+	}
     modifier = {
         ship_base_speed_mult = @ehof_thruster_basespeed_2
         ship_evasion_add = @ehof_titan_thruster_evasion_2
     }
     component_set = "thruster_components"
-    inline_script = components/size_restriction/giga_titan
     resources = {
         category = ship_components
         cost = {
@@ -1993,12 +2059,14 @@ utility_component_template = {
     icon = "GFX_compound_thruster"
     icon_frame = 1
     power = @ehof_colossus_thruster_power_2
-    potential = { from = { is_country_type = compound_empire } }
+	potential = {
+		from = { is_country_type = compound_empire }
+		giga_uses_colossus_thrusters = yes
+	}
     modifier = {
         ship_base_speed_mult = @ehof_thruster_basespeed_2
     }
     component_set = "thruster_components"
-    inline_script = components/size_restriction/giga_colossus
     resources = {
         category = ship_components
         cost = {

--- a/common/component_templates/ehof_t3_components.txt
+++ b/common/component_templates/ehof_t3_components.txt
@@ -7,7 +7,9 @@ utility_component_template = {
     icon = "GFX_sa_armor"
     icon_frame = 1
     power = 0
-    size_restriction = { annihilator annihilator_sk }
+	potential = {
+		giga_is_annihilator = yes
+	}
     component_set = "SA_ARMOR"
 
     modifier = {
@@ -28,7 +30,9 @@ weapon_component_template = {
     power = 0
     size = medium
     type = instant
-    size_restriction = { annihilator annihilator_sk }
+	potential = {
+		giga_is_annihilator = yes
+	}
     component_set = "SA_NM_BOOSTER"
     projectile_gfx = "ehof_negative_mass_booster"
     tags = { weapon_type_anticompound }
@@ -55,7 +59,9 @@ weapon_component_template = {
     power = 0
     size = large
     type = instant
-    size_restriction = { annihilator annihilator_sk }
+	potential = {
+		giga_is_annihilator = yes
+	}
     component_set = "SA_NM_CATAPULT"
     projectile_gfx = "ehof_negative_mass_capult"
     tags = { weapon_type_anticompound }
@@ -82,7 +88,9 @@ weapon_component_template = {
     power = 0
     size = extra_large
     type = instant
-    size_restriction = { annihilator annihilator_sk }
+	potential = {
+		giga_is_annihilator = yes
+	}
     component_set = "SA_NM_EMITTER"
     projectile_gfx = "ehof_negative_mass_emitter"
     tags = { weapon_type_anticompound }
@@ -109,7 +117,9 @@ utility_component_template = {
     icon = "GFX_sa_computer"
     icon_frame = 1
     power = 0
-    size_restriction = { annihilator annihilator_sk }
+	potential = {
+		giga_is_annihilator = yes
+	}
     component_set = "SA_COMBAT_COMPUTERS"
     ai_tags = { artillery artillery_stealth energy_torpedoes energy_torpedoes_stealth }
 
@@ -127,8 +137,9 @@ utility_component_template = {
 #     icon_frame = 1
 #     power = 0
 #     size = small
-#     size_restriction = { annihilator annihilator_sk }
-#     class_restriction = { shipclass_transport }
+# 	  potential = {
+#		 giga_is_annihilator = yes
+#	  }
 #     component_set = "ftl_components"
 #
 #     ftl = yes
@@ -147,7 +158,9 @@ utility_component_template = {
     icon_frame = 1
     power = 0
     size = extra_large
-    size_restriction = { annihilator annihilator_sk }
+	potential = {
+		giga_is_annihilator = yes
+	}
     component_set = "SA_HYPERDRIVE_COMPONENTS"
 
     ftl = yes
@@ -164,7 +177,9 @@ utility_component_template = {
     icon = "GFX_sa_reactor"
     icon_frame = 1
     power = @ehof_colossus_reactor_power_3
-    size_restriction = { annihilator annihilator_sk }
+	potential = {
+		giga_is_annihilator = yes
+	}
     component_set = "SA_REACTOR_COMPONENTS"
 }
 
@@ -174,7 +189,9 @@ utility_component_template = {
     icon_frame = 1
     power = 0
     size = extra_large
-    size_restriction = { annihilator annihilator_sk }
+	potential = {
+		giga_is_annihilator = yes
+	}
     component_set = "SA_SENSOR_COMPONENTS"
 
     sensor_range = 4
@@ -189,7 +206,9 @@ utility_component_template = {
     icon_frame = 1
     power = 0
     component_set = "SA_THRUSTER_COMPONENTS"
-    size_restriction = { annihilator annihilator_sk }
+	potential = {
+		giga_is_annihilator = yes
+	}
 
     modifier = {
         ship_base_speed_mult = @ehof_thruster_basespeed_3

--- a/common/component_templates/giga_computers.txt
+++ b/common/component_templates/giga_computers.txt
@@ -6,7 +6,6 @@ utility_component_template = {
 	icon_frame = 1
 	power = -50
 	ai_weight = { weight = 2 }
-	class_restriction = { shipclass_military }
 	potential = { giga_ship_uses_war_planet_components = yes }
 	ai_tags = { artillery }
 	component_set = "combat_computers"

--- a/common/component_templates/giga_corrona_weapons.txt
+++ b/common/component_templates/giga_corrona_weapons.txt
@@ -9,7 +9,9 @@ weapon_component_template = {
 	component_set = "GIGA_FLUSION_GUN_1"
 	projectile_gfx = "corrona_spell_projectile"
 	tags = { weapon_type_energy }
-	size_restriction = { giga_corrona_planetcraft }
+	potential = {
+		is_ship_size = giga_corrona_planetcraft
+	}
 	ai_tags = { weapon_role_anti_armor }
 	ai_tag_weight = 0
 
@@ -44,7 +46,9 @@ weapon_component_template = {
 	component_set = "GIGA_FLUSION_GUN_1"
 	projectile_gfx = "arc_emitter"
 	tags = { weapon_type_energy }
-	size_restriction = { giga_corrona_planetcraft }
+	potential = {
+		is_ship_size = giga_corrona_planetcraft
+	}
 	ai_tags = { weapon_role_anti_armor }
 	ai_tag_weight = 0
 
@@ -75,7 +79,9 @@ weapon_component_template = {
 	component_set = "GIGA_FLUSION_GUN_1"
 	projectile_gfx = "tachyon_lance"
 	tags = { weapon_type_energy }
-	size_restriction = { giga_corrona_planetcraft }
+	potential = {
+		is_ship_size = giga_corrona_planetcraft
+	}
 	ai_tags = { weapon_role_anti_armor }
 	ai_tag_weight = 0
 
@@ -106,7 +112,9 @@ weapon_component_template = { #anti-armor
 	component_set = "GIGA_FLUSION_GUN_1"
 	projectile_gfx = "corrona_disruptor"
 	tags = { weapon_type_energy }
-	size_restriction = { giga_corrona_planetcraft }
+	potential = {
+		is_ship_size = giga_corrona_planetcraft
+	}
 	ai_tags = { weapon_role_anti_armor }
 	ai_tag_weight = 0
 
@@ -139,7 +147,9 @@ weapon_component_template = {
 	component_set = "GIGA_FLUSION_GUN_1"
 	projectile_gfx = "corrona_dragon_breath"
 	tags = { weapon_type_energy }
-	size_restriction = { giga_corrona_dragon }
+	potential = {
+		is_ship_size = giga_corrona_dragon
+	}
 	ai_tags = { weapon_role_anti_armor }
 	ai_tag_weight = 0
 

--- a/common/component_templates/giga_eawaf_components.txt
+++ b/common/component_templates/giga_eawaf_components.txt
@@ -564,8 +564,9 @@ utility_component_template = {
 	icon_frame = 1
 	power = 0
 	ship_behavior = "giga_eawaf_kamikaze"
-	size_restriction = { giga_eawaf_sirens_kamikaze }
-	class_restriction = { shipclass_military_special }
+	potential = {
+		is_ship_size = giga_eawaf_sirens_kamikaze
+	}
 	component_set = "combat_computers"
 	hidden = yes
 }
@@ -576,7 +577,9 @@ utility_component_template = {
 	icon = "GFX_ship_part_giga_eawaf_psionic_charge"
 	icon_frame = 1
 	power = 0
-	size_restriction = { giga_eawaf_sirens_panopticon }
+	potential = {
+		is_ship_size = giga_eawaf_sirens_panopticon
+	}
 	component_set = "ship_aura_components"
 	hidden = yes
 

--- a/common/component_templates/giga_flusion_weapons.txt
+++ b/common/component_templates/giga_flusion_weapons.txt
@@ -9,7 +9,9 @@ weapon_component_template = {
 	component_set = "GIGA_FLUSION_GUN_1"
 	projectile_gfx = "giga_flusion_gun"
 	tags = { weapon_type_kinetic }
-	size_restriction = { giga_war_moon_flusion }
+	potential = {
+		is_ship_size = giga_war_moon_flusion
+	}
 	ai_tags = { weapon_role_artillery }
 	ai_tag_weight = 0
 
@@ -37,7 +39,10 @@ weapon_component_template = {
 	component_set = "GIGA_FLUSION_AUTOCANNON_1"
 	projectile_gfx = "giga_flusion_autocannon"
 	tags = { weapon_type_kinetic }
-	size_restriction = { giga_war_moon_flusion giga_kaiser_moon_flusion }
+	potential = {
+		is_ship_size = giga_war_moon_flusion
+		is_ship_size = giga_kaiser_moon_flusion
+	}
 	ai_tags = { weapon_role_artillery }
 	ai_tag_weight = 0
 
@@ -161,7 +166,9 @@ weapon_component_template = {
 	component_set = "PANZER_ARTILLERY_01"
 	projectile_gfx = "adv_kinetic_artillery"
 	tags = { weapon_type_kinetic }
-	size_restriction = { giga_katzen_panzer }
+	potential = {
+		is_ship_size = giga_katzen_panzer
+	}
 	ai_tags = { weapon_role_artillery }
 	ai_tag_weight = 0
 
@@ -199,7 +206,9 @@ utility_component_template = {
 	}
 	
 	component_set = "KATZEN_STELLARITE_ARMOR_01"
-	size_restriction = { giga_kaiser_moon_flusion }
+	potential = {
+		is_ship_size = giga_kaiser_moon_flusion
+	}
 }
 
 #SUBMARINES
@@ -213,7 +222,9 @@ weapon_component_template = {
 	component_set = "GIGA_KATZEN_SUBMARINE_MISSILE"
 	projectile_gfx = "flusion_missile"
 	tags = { weapon_type_explosive }
-	size_restriction = { giga_katzen_submarine }
+	potential = {
+		is_ship_size = giga_katzen_submarine
+	}
 	ai_tags = { weapon_role_anti_shield }
 	ai_tag_weight = 0
 
@@ -249,8 +260,9 @@ utility_component_template = {
 	icon_frame = 1
 	power = -10
 	ai_weight = { weight = 2 }
-	class_restriction = { shipclass_military }
-	size_restriction = { giga_katzen_submarine }
+	potential = {
+		is_ship_size = giga_katzen_submarine
+	}
 	component_set = "combat_computers"
 	ship_behavior = "giga_katzen_submarine"
 

--- a/common/component_templates/giga_maginot_components.txt
+++ b/common/component_templates/giga_maginot_components.txt
@@ -11,7 +11,9 @@ utility_component_template = {
 	power = 40000
 	component_set = "power_core"
 	#prerequisites = { giga_tech_maginot_world }
-	size_restriction = { strategic_defence_command_platform }
+	potential = {
+		is_ship_size = strategic_defence_command_platform
+	}
 	# planetside facilities strengthen shields
 	modifier = { ship_shield_mult = 0.10 }
 
@@ -42,7 +44,9 @@ utility_component_template = {
 	power = 120000
 	component_set = "power_core"
 	prerequisites = { giga_tech_maginot_planetcraft_upgrade }
-	size_restriction = { strategic_defence_command_platform }
+	potential = {
+		is_ship_size = strategic_defence_command_platform
+	}
 	# planetside facilities strengthen shields
 	modifier = { ship_shield_mult = 0.20 }
 
@@ -73,7 +77,9 @@ utility_component_template = {
 	power = 1000000
 	component_set = "power_core"
 	prerequisites = { giga_tech_maginot_systemcraft_upgrade }
-	size_restriction = { strategic_defence_command_platform }
+	potential = {
+		is_ship_size = strategic_defence_command_platform
+	}
 	modifier = { ship_shield_mult = 0.20 }
 	
 	ftl_inhibitor = yes
@@ -110,7 +116,9 @@ weapon_component_template = {
 	min_range = 10.0
 
 	tags = { weapon_type_energy artillery }
-	size_restriction = { strategic_defence_command_platform }
+	potential = {
+		is_ship_size = strategic_defence_command_platform
+	}
 
 	#prerequisites = { giga_tech_maginot_world }
 	component_set = "GIGA_MAGINOT_OMEGA_LANCE"
@@ -160,7 +168,9 @@ weapon_component_template = {
 	icon_frame = 1
 
 	tags = { weapon_type_kinetic }
-	size_restriction = { strategic_defence_command_platform }
+	potential = {
+		is_ship_size = strategic_defence_command_platform
+	}
 
 	#prerequisites = { giga_tech_maginot_world }
 	component_set = "GIGA_MAGINOT_KINETIC_BATTERY"
@@ -247,7 +257,9 @@ strike_craft_component_template = {
 	icon = "GFX_ship_part_maginot_defence_drone_swarm"
 	icon_frame = 1
 	component_set = "GIGA_MAGINOT_DEFENCE_DRONE_SWARM"
-	size_restriction = { strategic_defence_command_platform }
+	potential = {
+		is_ship_size = strategic_defence_command_platform
+	}
 
 	tags = { weapon_type_strike_craft }
 	ai_tags = { weapon_role_point_defense carrier }

--- a/common/component_templates/giga_placeholder_components.txt
+++ b/common/component_templates/giga_placeholder_components.txt
@@ -12,8 +12,10 @@ utility_component_template = {
     }
 
     component_set = "combat_computers"
-    size_restriction = { starbase_aet }
-
+	potential = {
+		is_ship_size = starbase_aet
+	}
+	
     ai_weight = {
         weight = 0
     }
@@ -30,7 +32,9 @@ utility_component_template = {
     }
 
     component_set = "power_core"
-    size_restriction = { starbase_aet }
+	potential = {
+		is_ship_size = starbase_aet
+	}
 
     ai_weight = {
         weight = 0

--- a/common/inline_scripts/ship_components/bio_ehof_ship_armor.txt
+++ b/common/inline_scripts/ship_components/bio_ehof_ship_armor.txt
@@ -1,0 +1,52 @@
+power = 0
+
+modifier = {
+	ship_hull_add = @bio_ship_hull_$SIZE$_$TIER$
+	ship_armor_add = @bio_ship_armor_$SIZE$_$TIER$
+	ship_armor_regen_add_perc = @inf_regen_perc
+	ship_hull_regen_add_perc = @inf_regen_perc
+}
+
+custom_tooltip = bio_ship_armor_regen_$SIZE$_$TIER$_tt
+
+ship_modifier = {
+	ship_armor_hardening_add = @hardening_T$TIER$
+}
+
+triggered_ship_modifier = {
+	potential = {
+		has_armor_percentage < @bio_ship_armor_regen_threshold
+	}
+	ship_armor_regen_add_static = @bio_ship_armor_regen_$SIZE$_$TIER$
+}
+
+resources = {
+	category = ship_components
+	cost = {
+		giga_sr_sentient_metal = @armor_$SIZE$_t$TIER$_cost
+	}
+	upkeep = {
+		energy = @$SIZE$_t$TIER$_upkeep_energy
+		giga_sr_sentient_metal = @$SIZE$_t$TIER$_upkeep_alloys
+	}
+}
+
+show_tech_unlock_if = {
+	country_uses_bio_ships = yes
+}
+
+ai_weight = {
+	weight = @T$TIER$_weight
+	modifier = {
+		is_fallen_empire = yes
+		factor = 0
+	}
+	modifier = {
+		factor = 0.0
+		ehof_default_country = yes
+		OR =  {
+			no_resource_for_component = { RESOURCE = giga_sr_sentient_metal }
+			no_resource_for_component = { RESOURCE = giga_sr_negative_mass }
+		}
+	}
+}

--- a/common/inline_scripts/ship_components/bio_ehof_ship_shield.txt
+++ b/common/inline_scripts/ship_components/bio_ehof_ship_shield.txt
@@ -1,0 +1,46 @@
+power = @ehof_power_$UPPERCASE_SIZE$$EHOF_TIER$
+
+modifier = {
+	ship_shield_add = @bio_ship_shield_$UPPERCASE_SIZE$$TIER$
+	ship_shield_regen_add_static = @bio_ship_regen_$UPPERCASE_SIZE$$REGEN$
+}
+
+ship_modifier = {
+	ship_shield_hardening_add = @hardening_T$TIER$
+}
+
+resources = {
+	category = ship_components
+	cost = {
+		giga_sr_sentient_metal = @shield_$SIZE$_t$TIER$_cost
+		giga_sr_negative_mass = @ehof_t$EHOF_TIER$_$SIZE$_cost_rare
+	}
+	upkeep = {
+		energy = @shield_$SIZE$_t$TIER$_upkeep_energy
+		giga_sr_sentient_metal = @shield_$SIZE$_t$TIER$_upkeep_alloys
+	}
+}
+
+show_tech_unlock_if = {
+	country_uses_bio_ships = yes
+}
+
+ai_weight = {
+	weight = @T$TIER$_weight
+	modifier = {
+		is_fallen_empire = yes
+		factor = 0
+	}
+	modifier = {
+		factor = 0.0
+		ehof_default_country = yes
+		OR =  {
+			no_resource_for_component = { RESOURCE = giga_sr_sentient_metal }
+			no_resource_for_component = { RESOURCE = giga_sr_negative_mass }
+		}
+	}
+	inline_script = {
+		script = ship_components/weights/roles_stealth
+		MULT = 0
+	}
+}

--- a/common/inline_scripts/ship_components/mech_ehof_ship_armor.txt
+++ b/common/inline_scripts/ship_components/mech_ehof_ship_armor.txt
@@ -1,0 +1,42 @@
+power = 0
+
+modifier = {
+	ship_armor_add = @armor_$UPPERCASE_SIZE$$TIER$
+	ship_armor_regen_add_perc = @inf_regen_perc
+	ship_hull_regen_add_perc = @inf_regen_perc
+}
+
+ship_modifier = {
+	ship_armor_hardening_add = @hardening_T$TIER$
+}
+
+resources = {
+	category = ship_components
+	cost = {
+		giga_sr_sentient_metal = @armor_$SIZE$_t$TIER$_cost
+	}
+	upkeep = {
+		energy = @$SIZE$_t$TIER$_upkeep_energy
+		giga_sr_sentient_metal = @$SIZE$_t$TIER$_upkeep_alloys
+	}
+}
+
+show_tech_unlock_if = {
+	country_uses_bio_ships = no
+}
+
+ai_weight = {
+	weight = @T$TIER$_weight
+	modifier = {
+		is_fallen_empire = yes
+		factor = 0
+	}
+	modifier = {
+		factor = 0.0
+		ehof_default_country = yes
+		OR =  {
+			no_resource_for_component = { RESOURCE = giga_sr_sentient_metal }
+			no_resource_for_component = { RESOURCE = giga_sr_negative_mass }
+		}
+	}
+}

--- a/common/inline_scripts/ship_components/mech_ehof_ship_shield.txt
+++ b/common/inline_scripts/ship_components/mech_ehof_ship_shield.txt
@@ -1,0 +1,46 @@
+power = @ehof_power_$UPPERCASE_SIZE$$EHOF_TIER$
+
+modifier = {
+	ship_shield_add = @shield_$UPPERCASE_SIZE$$TIER$
+	ship_shield_regen_add_static = @regen_$UPPERCASE_SIZE$$REGEN$
+}
+
+ship_modifier = {
+	ship_shield_hardening_add = @hardening_T$TIER$
+}
+
+resources = {
+	category = ship_components
+	cost = {
+		giga_sr_sentient_metal = @shield_$SIZE$_t$TIER$_cost
+		giga_sr_negative_mass = @ehof_t$EHOF_TIER$_$SIZE$_cost_rare
+	}
+	upkeep = {
+		energy = @shield_$SIZE$_t$TIER$_upkeep_energy
+		giga_sr_sentient_metal = @shield_$SIZE$_t$TIER$_upkeep_alloys
+	}
+}
+
+show_tech_unlock_if = {
+	country_uses_bio_ships = no
+}
+
+ai_weight = {
+	weight = @T$TIER$_weight
+	modifier = {
+		is_fallen_empire = yes
+		factor = 0
+	}
+	modifier = {
+		factor = 0.0
+		ehof_default_country = yes
+		OR =  {
+			no_resource_for_component = { RESOURCE = giga_sr_sentient_metal }
+			no_resource_for_component = { RESOURCE = giga_sr_negative_mass }
+		}
+	}
+	inline_script = {
+		script = ship_components/weights/roles_stealth
+		MULT = 0
+	}
+}

--- a/common/scripted_triggers/giga_scripted_triggers_ships.txt
+++ b/common/scripted_triggers/giga_scripted_triggers_ships.txt
@@ -1,0 +1,383 @@
+####################
+##### REACTORS #####
+####################
+
+giga_uses_corvette_reactors = {
+	OR = {
+		ship_uses_corvette_reactors = yes
+		is_ship_size = hornet
+		is_ship_size = architect
+		is_ship_size = propagator
+	}
+}
+
+giga_uses_destroyer_reactors = {
+	OR = {
+		ship_uses_destroyer_reactors = yes
+		is_ship_size = stalker
+	}
+}
+
+giga_uses_cruiser_reactors = {
+	OR = {
+		ship_uses_cruiser_reactors = yes
+		is_ship_size = humiliator
+		is_ship_size = architect
+		is_ship_size = propagator
+	}
+}
+
+giga_uses_battleship_reactors = {
+	OR = {
+		ship_uses_battleship_reactors = yes
+		is_ship_size = apex
+		
+		# NSC
+		is_ship_size = Battlecruiser
+		is_ship_size = explorationship
+	}
+}
+
+giga_uses_titan_reactors = {
+	OR = {
+		ship_uses_titan_reactors = yes
+		is_ship_size = sovereign
+		
+		# NSC
+		is_ship_size = Carrier
+		is_ship_size = Dreadnought
+	}
+}
+
+giga_uses_juggernaut_reactors = {
+	OR = {
+		ship_uses_juggernaut_reactors = yes
+	}
+}
+
+giga_uses_colossus_reactors = {
+	# Not used in vanilla
+	giga_uses_colossus_components = yes
+}
+
+giga_uses_platform_reactors = {
+	OR = {
+		ship_uses_platform_reactors = yes
+	}
+}
+
+giga_uses_starbase_reactors = {
+	# Not used in vanilla
+	giga_uses_starbase_components = yes
+}
+
+giga_uses_ion_cannon_reactors = {
+	# Not used in vanilla
+	giga_uses_ion_cannon_components = yes
+}
+
+####################
+##### Thrusters ####
+####################
+
+giga_uses_corvette_thrusters = {
+	# Not used in vanilla
+	giga_uses_corvette_components = yes
+}
+
+giga_uses_destroyer_thrusters = {
+	# Not used in vanilla
+	giga_uses_destroyer_components = yes
+}
+
+giga_uses_cruiser_thrusters = {
+	# Not used in vanilla
+	giga_uses_cruiser_components = yes
+}
+
+giga_uses_battleship_thrusters = {
+	OR = {
+		ship_uses_battleship_thrusters = yes
+		is_ship_size = apex
+		
+		# NSC
+		is_ship_size = Battlecruiser
+		is_ship_size = explorationship
+	}
+}
+
+giga_uses_titan_thrusters = {
+	OR = {
+		ship_uses_titan_thrusters = yes
+		is_ship_size = sovereign
+		
+		# NSC
+		is_ship_size = Carrier
+		is_ship_size = Dreadnought
+	}
+}
+
+giga_uses_juggernaut_thrusters = {
+	giga_uses_colossus_thrusters = yes
+}
+
+# Juggernauts also use this
+giga_uses_colossus_thrusters = {
+	OR = {
+		ship_uses_colossus_thrusters = yes
+		is_ship_size = reshaper
+		
+		# NSC
+		is_ship_size = Flagship
+	}
+}
+
+####################
+##### Components ###
+####################
+
+giga_uses_corvette_components = {
+	OR = {
+		ship_uses_corvette_components = yes
+		is_ship_size = hornet
+		is_ship_size = architect
+		is_ship_size = propagator
+	}
+}
+
+giga_uses_destroyer_components = {
+	OR = {
+		ship_uses_destroyer_components = yes
+		is_ship_size = stalker
+	}
+}
+
+giga_uses_cruiser_components = {
+	OR = {
+		ship_uses_cruiser_components = yes
+		is_ship_size = humiliator
+		is_ship_size = architect
+		is_ship_size = propagator
+	}
+}
+
+giga_uses_battleship_components = {
+	OR = {
+		ship_uses_battleship_components = yes
+		is_ship_size = apex
+		
+		# NSC
+		is_ship_size = Battlecruiser
+		is_ship_size = explorationship
+	}
+}
+
+giga_uses_titan_components = {
+	OR = {
+		ship_uses_titan_components = yes
+		is_ship_size = sovereign
+		
+		# NSC
+		is_ship_size = Carrier
+		is_ship_size = Dreadnought
+	}
+}
+
+giga_uses_juggernaut_components = {
+	OR = {
+		ship_uses_juggernaut_components = yes
+		ship_uses_star_eater_components = yes
+	}
+}
+
+giga_uses_colossus_components = {
+	OR = {
+		ship_uses_colossus_components = yes
+		is_ship_size = reshaper
+		
+		# NSC
+		is_ship_size = Flagship
+	}
+}
+
+giga_uses_starbase_components = {
+	OR = {
+		ship_uses_starbase_components = yes
+		is_ship_size = starbase_ehof_01        # compound barricade
+		is_ship_size = starbase_ehof_02        # compound garrison
+		is_ship_size = starbase_ehof_03        # compound bastion
+		is_ship_size = starbase_ehof_04        # compound bulwark
+		is_ship_size = starbase_ehof_05        # compound aegis
+		is_ship_size = starbase_aet			   # aeternum citadel
+		
+		# NSC
+		is_ship_size = starbase_stronghold     # grand citadel
+		is_ship_size = starbase_headquarters   # solar stronghold
+	}
+}
+
+giga_uses_ion_cannon_components = {
+	OR = {
+		ship_uses_ion_cannon_components = yes
+	}
+}
+
+####################
+##### Roles ########
+####################
+
+giga_uses_swarm_role = {
+	OR = {
+		ship_uses_swarm_role = yes
+		is_ship_size = hornet
+		
+		# NSC
+		is_ship_size = StrikeCruiser
+		is_ship_size = Battlecruiser
+		is_ship_size = Carrier
+		is_ship_size = Dreadnought
+		is_ship_size = Flagship
+		is_ship_size = escortcarrier
+		is_ship_size = explorationship
+	}
+}
+
+giga_uses_torpedo_role = {
+	OR = {
+		ship_uses_torpedo_role = yes
+		is_ship_size = hornet
+		is_ship_size = stalker
+		is_ship_size = humiliator
+	}
+}
+
+giga_uses_picket_role = {
+	OR = {
+		ship_uses_picket_role = yes
+		is_ship_size = hornet
+		is_ship_size = stalker
+		is_ship_size = humiliator
+		
+		# NSC
+		is_ship_size = StrikeCruiser
+		is_ship_size = Battlecruiser
+		is_ship_size = Carrier
+		is_ship_size = Dreadnought
+		is_ship_size = Flagship
+		is_ship_size = escortcarrier
+		is_ship_size = explorationship
+	}
+}
+
+giga_uses_line_role = {
+	OR = {
+		ship_uses_line_role = yes
+		is_ship_size = stalker
+		is_ship_size = humiliator
+		is_ship_size = apex
+		
+		# NSC
+		is_ship_size = StrikeCruiser
+		is_ship_size = Battlecruiser
+		is_ship_size = Carrier
+		is_ship_size = Dreadnought
+		is_ship_size = Flagship
+		is_ship_size = escortcarrier
+		is_ship_size = explorationship
+	}
+}
+
+giga_uses_carrier_role = {
+	OR = {
+		ship_uses_carrier_role = yes
+		is_ship_size = humiliator
+		is_ship_size = apex
+		is_ship_size = sovereign
+		
+		# NSC
+		is_ship_size = Carrier
+		is_ship_size = Flagship
+		is_ship_size = escortcarrier
+		is_ship_size = explorationship
+	}
+}
+
+giga_uses_artillery_role = {
+	OR = {
+		ship_uses_artillery_role = yes
+		is_ship_size = stalker
+		is_ship_size = humiliator
+		is_ship_size = apex
+		is_ship_size = sovereign
+		
+		# NSC
+		is_ship_size = StrikeCruiser
+		is_ship_size = Battlecruiser
+		is_ship_size = Carrier
+		is_ship_size = Dreadnought
+		is_ship_size = Flagship
+		is_ship_size = escortcarrier
+		is_ship_size = explorationship
+	}
+}
+
+####################
+##### Computers ####
+####################
+
+giga_uses_colossus_computers = {
+	OR = {
+		ship_uses_colossus_computers = yes
+		is_ship_size = reshaper
+	}
+}
+
+giga_uses_platform_computers = {
+	OR = {
+		ship_uses_platform_computers = yes
+	}
+}
+
+giga_uses_starbase_computers = {
+	# Not used in vanilla
+	giga_uses_starbase_components = yes
+}
+
+####################
+##### Special ######
+####################
+
+giga_uses_jump_drives = {
+	ship_uses_jump_drives = yes
+}
+
+####################
+##### Compund ######
+####################
+
+giga_is_compound_regular_ship = {
+	is_ship_size = hornet
+	is_ship_size = stalker
+	is_ship_size = humiliator
+	is_ship_size = apex
+	is_ship_size = sovereign
+}
+
+giga_is_compound_special_ship = {
+	is_ship_size = architect
+	is_ship_size = propagator
+	is_ship_size = reshaper
+}
+
+giga_is_compound_starbase = {
+	is_ship_size = starbase_ehof_01        # compound barricade
+	is_ship_size = starbase_ehof_02        # compound garrison
+	is_ship_size = starbase_ehof_03        # compound bastion
+	is_ship_size = starbase_ehof_04        # compound bulwark
+	is_ship_size = starbase_ehof_05        # compound aegis
+}
+
+giga_is_annihilator = {
+	is_ship_size = annihilator
+	is_ship_size = annihilator_sk
+}

--- a/localisation/braz_por/giga_ehof_l_braz_por.yml
+++ b/localisation/braz_por/giga_ehof_l_braz_por.yml
@@ -64,11 +64,23 @@
   SENTIENT_ARMOR_MEDIUM:99 "$tech_sm_armor$"
   SENTIENT_ARMOR_LARGE:99 "$tech_sm_armor$"
   
+  BIO_SENTIENT_ARMOR:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_DESC:99 "$tech_sm_armor_desc$."
+  BIO_SENTIENT_ARMOR_SMALL:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_MEDIUM:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_LARGE:99 "$tech_sm_armor$"
+
   QNM_SHIELD:99 "$tech_qnm_shields$"
   QNM_SHIELD_DESC:99 "$tech_qnm_shields_desc$"
   QNM_SHIELD_SMALL:99 "$tech_qnm_shields$"
   QNM_SHIELD_MEDIUM:99 "$tech_qnm_shields$"
   QNM_SHIELD_LARGE:99 "$tech_qnm_shields$"
+
+  BIO_QNM_SHIELD:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_DESC:99 "$tech_qnm_shields_desc$"
+  BIO_QNM_SHIELD_SMALL:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_MEDIUM:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_LARGE:99 "$tech_qnm_shields$"
   
   QNM_REACTOR_CORVETTE:99 "$tech_qnm_reactors$"
   QNM_REACTOR_DESTROYER:99 "$tech_qnm_reactors$"

--- a/localisation/english/giga_ehof_l_english.yml
+++ b/localisation/english/giga_ehof_l_english.yml
@@ -63,12 +63,24 @@
  SENTIENT_ARMOR_SMALL:0 "$tech_sm_armor$"
  SENTIENT_ARMOR_MEDIUM:0 "$tech_sm_armor$"
  SENTIENT_ARMOR_LARGE:0 "$tech_sm_armor$"
+ 
+ BIO_SENTIENT_ARMOR:0 "$tech_sm_armor$"
+ BIO_SENTIENT_ARMOR_DESC:0 "$tech_sm_armor_desc$."
+ BIO_SENTIENT_ARMOR_SMALL:0 "$tech_sm_armor$"
+ BIO_SENTIENT_ARMOR_MEDIUM:0 "$tech_sm_armor$"
+ BIO_SENTIENT_ARMOR_LARGE:0 "$tech_sm_armor$"
 
  QNM_SHIELD:0 "$tech_qnm_shields$"
  QNM_SHIELD_DESC:0 "$tech_qnm_shields_desc$"
  QNM_SHIELD_SMALL:0 "$tech_qnm_shields$"
  QNM_SHIELD_MEDIUM:0 "$tech_qnm_shields$"
  QNM_SHIELD_LARGE:0 "$tech_qnm_shields$"
+
+ BIO_QNM_SHIELD:0 "$tech_qnm_shields$"
+ BIO_QNM_SHIELD_DESC:0 "$tech_qnm_shields_desc$"
+ BIO_QNM_SHIELD_SMALL:0 "$tech_qnm_shields$"
+ BIO_QNM_SHIELD_MEDIUM:0 "$tech_qnm_shields$"
+ BIO_QNM_SHIELD_LARGE:0 "$tech_qnm_shields$"
 
  QNM_REACTOR_CORVETTE:0 "$tech_qnm_reactors$"
  QNM_REACTOR_DESTROYER:0 "$tech_qnm_reactors$"

--- a/localisation/french/giga_ehof_l_french.yml
+++ b/localisation/french/giga_ehof_l_french.yml
@@ -64,11 +64,23 @@
   SENTIENT_ARMOR_MEDIUM:99 "$tech_sm_armor$"
   SENTIENT_ARMOR_LARGE:99 "$tech_sm_armor$"
   
+  BIO_SENTIENT_ARMOR:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_DESC:99 "$tech_sm_armor_desc$."
+  BIO_SENTIENT_ARMOR_SMALL:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_MEDIUM:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_LARGE:99 "$tech_sm_armor$"
+
   QNM_SHIELD:99 "$tech_qnm_shields$"
   QNM_SHIELD_DESC:99 "$tech_qnm_shields_desc$"
   QNM_SHIELD_SMALL:99 "$tech_qnm_shields$"
   QNM_SHIELD_MEDIUM:99 "$tech_qnm_shields$"
   QNM_SHIELD_LARGE:99 "$tech_qnm_shields$"
+
+  BIO_QNM_SHIELD:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_DESC:99 "$tech_qnm_shields_desc$"
+  BIO_QNM_SHIELD_SMALL:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_MEDIUM:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_LARGE:99 "$tech_qnm_shields$"
   
   QNM_REACTOR_CORVETTE:99 "$tech_qnm_reactors$"
   QNM_REACTOR_DESTROYER:99 "$tech_qnm_reactors$"

--- a/localisation/german/giga_ehof_l_german.yml
+++ b/localisation/german/giga_ehof_l_german.yml
@@ -64,11 +64,23 @@
   SENTIENT_ARMOR_MEDIUM:99 "$tech_sm_armor$"
   SENTIENT_ARMOR_LARGE:99 "$tech_sm_armor$"
   
+  BIO_SENTIENT_ARMOR:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_DESC:99 "$tech_sm_armor_desc$."
+  BIO_SENTIENT_ARMOR_SMALL:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_MEDIUM:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_LARGE:99 "$tech_sm_armor$"
+
   QNM_SHIELD:99 "$tech_qnm_shields$"
   QNM_SHIELD_DESC:99 "$tech_qnm_shields_desc$"
   QNM_SHIELD_SMALL:99 "$tech_qnm_shields$"
   QNM_SHIELD_MEDIUM:99 "$tech_qnm_shields$"
   QNM_SHIELD_LARGE:99 "$tech_qnm_shields$"
+
+  BIO_QNM_SHIELD:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_DESC:99 "$tech_qnm_shields_desc$"
+  BIO_QNM_SHIELD_SMALL:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_MEDIUM:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_LARGE:99 "$tech_qnm_shields$"
   
   QNM_REACTOR_CORVETTE:99 "$tech_qnm_reactors$"
   QNM_REACTOR_DESTROYER:99 "$tech_qnm_reactors$"

--- a/localisation/polish/giga_ehof_l_polish.yml
+++ b/localisation/polish/giga_ehof_l_polish.yml
@@ -64,11 +64,23 @@
   SENTIENT_ARMOR_MEDIUM:99 "$tech_sm_armor$"
   SENTIENT_ARMOR_LARGE:99 "$tech_sm_armor$"
   
+  BIO_SENTIENT_ARMOR:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_DESC:99 "$tech_sm_armor_desc$."
+  BIO_SENTIENT_ARMOR_SMALL:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_MEDIUM:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_LARGE:99 "$tech_sm_armor$"
+
   QNM_SHIELD:99 "$tech_qnm_shields$"
   QNM_SHIELD_DESC:99 "$tech_qnm_shields_desc$"
   QNM_SHIELD_SMALL:99 "$tech_qnm_shields$"
   QNM_SHIELD_MEDIUM:99 "$tech_qnm_shields$"
   QNM_SHIELD_LARGE:99 "$tech_qnm_shields$"
+
+  BIO_QNM_SHIELD:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_DESC:99 "$tech_qnm_shields_desc$"
+  BIO_QNM_SHIELD_SMALL:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_MEDIUM:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_LARGE:99 "$tech_qnm_shields$"
   
   QNM_REACTOR_CORVETTE:99 "$tech_qnm_reactors$"
   QNM_REACTOR_DESTROYER:99 "$tech_qnm_reactors$"

--- a/localisation/russian/giga_ehof_l_russian.yml
+++ b/localisation/russian/giga_ehof_l_russian.yml
@@ -64,11 +64,23 @@
   SENTIENT_ARMOR_MEDIUM:99 "$tech_sm_armor$"
   SENTIENT_ARMOR_LARGE:99 "$tech_sm_armor$"
   
+  BIO_SENTIENT_ARMOR:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_DESC:99 "$tech_sm_armor_desc$."
+  BIO_SENTIENT_ARMOR_SMALL:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_MEDIUM:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_LARGE:99 "$tech_sm_armor$"
+
   QNM_SHIELD:99 "$tech_qnm_shields$"
   QNM_SHIELD_DESC:99 "$tech_qnm_shields_desc$"
   QNM_SHIELD_SMALL:99 "$tech_qnm_shields$"
   QNM_SHIELD_MEDIUM:99 "$tech_qnm_shields$"
   QNM_SHIELD_LARGE:99 "$tech_qnm_shields$"
+
+  BIO_QNM_SHIELD:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_DESC:99 "$tech_qnm_shields_desc$"
+  BIO_QNM_SHIELD_SMALL:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_MEDIUM:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_LARGE:99 "$tech_qnm_shields$"
   
   QNM_REACTOR_CORVETTE:99 "$tech_qnm_reactors$"
   QNM_REACTOR_DESTROYER:99 "$tech_qnm_reactors$"

--- a/localisation/simp_chinese/giga_ehof_l_simp_chinese.yml
+++ b/localisation/simp_chinese/giga_ehof_l_simp_chinese.yml
@@ -64,11 +64,23 @@
   SENTIENT_ARMOR_MEDIUM:0 "$tech_sm_armor$"
   SENTIENT_ARMOR_LARGE:0 "$tech_sm_armor$"
   
+  BIO_SENTIENT_ARMOR:0 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_DESC:0 "$tech_sm_armor_desc$。"
+  BIO_SENTIENT_ARMOR_SMALL:0 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_MEDIUM:0 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_LARGE:0 "$tech_sm_armor$"
+
   QNM_SHIELD:0 "$tech_qnm_shields$"
   QNM_SHIELD_DESC:0 "$tech_qnm_shields_desc$"
   QNM_SHIELD_SMALL:0 "$tech_qnm_shields$"
   QNM_SHIELD_MEDIUM:0 "$tech_qnm_shields$"
   QNM_SHIELD_LARGE:0 "$tech_qnm_shields$"
+
+  BIO_QNM_SHIELD:0 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_DESC:0 "$tech_qnm_shields_desc$"
+  BIO_QNM_SHIELD_SMALL:0 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_MEDIUM:0 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_LARGE:0 "$tech_qnm_shields$"
   
   QNM_REACTOR_CORVETTE:0 "$tech_qnm_reactors$"
   QNM_REACTOR_DESTROYER:0 "$tech_qnm_reactors$"

--- a/localisation/spanish/giga_ehof_l_spanish.yml
+++ b/localisation/spanish/giga_ehof_l_spanish.yml
@@ -64,11 +64,23 @@
   SENTIENT_ARMOR_MEDIUM:99 "$tech_sm_armor$"
   SENTIENT_ARMOR_LARGE:99 "$tech_sm_armor$"
   
+  BIO_SENTIENT_ARMOR:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_DESC:99 "$tech_sm_armor_desc$."
+  BIO_SENTIENT_ARMOR_SMALL:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_MEDIUM:99 "$tech_sm_armor$"
+  BIO_SENTIENT_ARMOR_LARGE:99 "$tech_sm_armor$"
+
   QNM_SHIELD:99 "$tech_qnm_shields$"
   QNM_SHIELD_DESC:99 "$tech_qnm_shields_desc$"
   QNM_SHIELD_SMALL:99 "$tech_qnm_shields$"
   QNM_SHIELD_MEDIUM:99 "$tech_qnm_shields$"
   QNM_SHIELD_LARGE:99 "$tech_qnm_shields$"
+
+  BIO_QNM_SHIELD:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_DESC:99 "$tech_qnm_shields_desc$"
+  BIO_QNM_SHIELD_SMALL:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_MEDIUM:99 "$tech_qnm_shields$"
+  BIO_QNM_SHIELD_LARGE:99 "$tech_qnm_shields$"
   
   QNM_REACTOR_CORVETTE:99 "$tech_qnm_reactors$"
   QNM_REACTOR_DESTROYER:99 "$tech_qnm_reactors$"


### PR DESCRIPTION
1. Added scripted triggers for ship sizes and separate for reactors, thrusters, computers, etc. At their core they use the vanilla scripted triggers for ship components but are and can be extended further for Gigastructural and other compatible (currently only NSC) ship sizes.
2. Move away from deprecated size_ and class_restriction parameters and use the potential block.
3. Removed compatibility for Aerial Realistic Ships. No sense in keeping it if the mod has been dead for 4 years.
4. Added bio ship variants for sentient metal (SM) armor and quasi-negative mass (QNM) shield. The stats are taken from vanilla values for the appropriate tiers.
5. Due to the nature of the changes, bio ships also get access to all other components that they were previously denied to them due to their ship sizes not being in the size restriction inline scripts. Armor and shields were the primary differences between bio and mechanical ships. Other components could be made variants of for bio ships but didn't seem necessary at this moment.
6. Consolidated most of the logic of the different size SM armor and QNM shields to inline scripts in inline_scripts/ship_components:
- bio_ehof_ship_armor
- bio_ehof_ship_shield
- mech_ehof_ship_armor
- mech_ehof_ship_shield
This reduces code duplication.
7. Changed @ehof_t1_(s|m|l)_cost_rare values to reflect values actually in use.
@ehof_t1_s_cost_rare        = 0.690
@ehof_t1_m_cost_rare        = 1.380
@ehof_t1_l_cost_rare        = 2.760
to
@ehof_t1_s_cost_rare        = 0.4
@ehof_t1_m_cost_rare        = 0.8
@ehof_t1_l_cost_rare        = 1.6

Fixes:
- Cosmogenesis ships having either no or duplicate components.
- Bioships having no access to EHOF components.

Advantages:
-  Automatic parity with vanilla changes to ship components availability.

Tested:
- EHOF tier 1 parts
- Asteroid artillery
- Planetcrafts
- Systemcrafts

Have not tested:
- Any crisis parts
The crisis changes are similar, if not lesser, to the parts I've tested. So extrapolating from that, I believe them to be functional also.

<img width="591" height="475" alt="image" src="https://github.com/user-attachments/assets/e34263c1-00a4-4595-868d-438d799f3c07" />