### PR TITLE
Small, misc fixes

### DIFF
--- a/common/game_rules/giga_rules.txt
+++ b/common/game_rules/giga_rules.txt
@@ -12,7 +12,7 @@ can_orbitable_repair_ships = {
                 is_arkship_starbase = yes
                 has_starbase_module = waystation_repair_bay
                 # ACOT ADDED
-				ia_acot_advanced_starbase = yes
+				is_acot_advanced_starbase = yes
 			}
 			fleet = {
 				is_disabled = no
@@ -398,9 +398,8 @@ can_colonize_with_species = {
 		NOT = { has_trait = trait_self_modified }
 		is_same_species = root
 	}
-	NOR = {
+	NOT = {
 		has_trait = trait_pathogenic_genes
-		has_trait = trait_limited_cybernetic
 	}
 	if = {
 		limit = {

--- a/common/megastructures/zz_c_atmospheric_storm_observatory.txt
+++ b/common/megastructures/zz_c_atmospheric_storm_observatory.txt
@@ -81,8 +81,12 @@ atmosphere_shredder_0 = {
 	tooltip_system_filter = {
 		solar_system = {
 			giga_system_has_atmosphere_shredder = no
+			any_system_planet = {
+				giga_is_gas_giant = yes
+			}
 		}
 		system_has_arc_furnace = no
+		giga_system_has_planetary_seeder_nexus = no
 	}
 
 	potential = {

--- a/common/megastructures/zz_c_macroengineering_test_site.txt
+++ b/common/megastructures/zz_c_macroengineering_test_site.txt
@@ -79,8 +79,12 @@ macro_test_site_0 = {
 	tooltip_system_filter = {
 		solar_system = {
 			giga_system_has_macro_test = no
+			any_system_planet = {
+				is_planet_class = pc_frozen
+			}
 		}
 		system_has_arc_furnace = no
+		giga_system_has_planetary_seeder_nexus = no
 	}
 
 	potential = {

--- a/common/megastructures/zz_c_orbital_arc_furnace.txt
+++ b/common/megastructures/zz_c_orbital_arc_furnace.txt
@@ -57,6 +57,9 @@ orbital_arc_furnace_1 = {
     tooltip_best_systems_header = "MEGASTRUCTURE_ARC_FURNACE_BEST_SYSTEMS_TOOLTIP_HEADER"
     tooltip_system_filter = {
         system_has_arc_furnace = no
+        any_system_planet = {
+            is_planet_class = pc_molten
+        }
     }
 
 	potential = {

--- a/common/megastructures/zz_c_orbital_arc_furnace.txt
+++ b/common/megastructures/zz_c_orbital_arc_furnace.txt
@@ -60,6 +60,9 @@ orbital_arc_furnace_1 = {
         any_system_planet = {
             is_planet_class = pc_molten
         }
+        giga_system_has_atmosphere_shredder = no
+        giga_system_has_artificial_eco = no
+        giga_system_has_macro_test = no
     }
 
 	potential = {

--- a/common/megastructures/zz_c_orbital_artificial_eco.txt
+++ b/common/megastructures/zz_c_orbital_artificial_eco.txt
@@ -82,8 +82,12 @@ orbital_artificial_eco_0 = {
 	tooltip_system_filter = {
 		solar_system = {
 			giga_system_has_artificial_eco = no
+			any_system_planet = {
+				is_planet_class = pc_toxic
+			}
 		}
 		system_has_arc_furnace = no
+		giga_system_has_planetary_seeder_nexus = no
 	}
 
 	potential = {

--- a/common/megastructures/zz_c_planetary_seeder_nexus.txt
+++ b/common/megastructures/zz_c_planetary_seeder_nexus.txt
@@ -81,6 +81,12 @@ planetary_seeder_nexus_0 = {
 	tooltip_best_systems_header = "MEGASTRUCTURE_SCIENCE_KILO_BEST_SYSTEMS_TOOLTIP_HEADER"
 	tooltip_system_filter = {
 		solar_system = {
+			giga_system_has_planetary_seeder_nexus = no
+			any_system_planet = {
+				giga_is_gas_giant = yes
+			}
+			giga_system_has_atmosphere_shredder = no
+			giga_system_has_artificial_eco = no
 			giga_system_has_macro_test = no
 		}
 	}

--- a/common/megastructures/zz_c_planetary_seeder_nexus.txt
+++ b/common/megastructures/zz_c_planetary_seeder_nexus.txt
@@ -106,8 +106,6 @@ planetary_seeder_nexus_0 = {
 	possible = {
         inline_script = megastructures/system_ownership_or_waystation_check
 		custom_tooltip = { fail_text = "requires_no_anomaly" 				NOT = { any_system_planet = { has_anomaly = yes } } }
-		custom_tooltip = { fail_text = "requires_no_arc_furnace" 			system_has_arc_furnace = no }
-		custom_tooltip = { fail_text = "requires_no_planetary_seeder_nexus"			NOT = { any_system_megastructure = { ehof_giga_new_is_artificial_eco = yes } } }
 		custom_tooltip = {
 			fail_text = "requires_not_capped"
 			from = {
@@ -119,6 +117,26 @@ planetary_seeder_nexus_0 = {
 					}
 				}
 			}
+		}
+		custom_tooltip = {
+			fail_text = "requires_no_arc_furnace"
+			system_has_arc_furnace = no
+		}
+		custom_tooltip = {
+			fail_text = "requires_no_planetary_seeder_nexus"
+			giga_system_has_planetary_seeder_nexus = no
+		}
+		custom_tooltip = {
+			fail_text = "requires_no_macro_test_site"
+			giga_system_has_macro_test = no
+		}
+		custom_tooltip = {
+			fail_text = "requires_no_atmosphere_shredder"
+			giga_system_has_atmosphere_shredder = no
+		}
+		custom_tooltip = {
+			fail_text = "requires_no_orb_eco_arc"
+			giga_system_has_artificial_eco = no
 		}
 	}
 

--- a/common/scripted_triggers/giga_megastructure_type_triggers.txt
+++ b/common/scripted_triggers/giga_megastructure_type_triggers.txt
@@ -1347,6 +1347,7 @@ vat_07_chk = {
 }
 
 giga_system_has_atmosphere_shredder = {
+	optimize_memory
 	OR = {
 		any_system_megastructure = {
 			ehof_giga_new_is_atmosphere_shredder = yes
@@ -1355,6 +1356,7 @@ giga_system_has_atmosphere_shredder = {
 }
 
 giga_system_has_artificial_eco = {
+	optimize_memory
 	OR = {
 		any_system_megastructure = {
 			ehof_giga_new_is_artificial_eco = yes
@@ -1363,6 +1365,7 @@ giga_system_has_artificial_eco = {
 }
 
 giga_system_has_macro_test = {
+	optimize_memory
 	OR = {
 		any_system_megastructure = {
 			ehof_giga_new_is_macrotest = yes
@@ -1370,8 +1373,8 @@ giga_system_has_macro_test = {
 	}
 }
 
-
 giga_system_has_planetary_seeder_nexus = {
+	optimize_memory
 	OR = {
 		any_system_megastructure = {
 			ehof_giga_new_is_planetary_seeder_nexus = yes

--- a/localisation/english/giga_l_english.yml
+++ b/localisation/english/giga_l_english.yml
@@ -386,10 +386,10 @@
   requires_owned_system:0 "$TRIGGER_FAIL$System must be owned."
   requires_not_old_update:0 "$TRIGGER_FAIL$DEBUG: This megastructure cannot be dismantled, it is from a prior mod update and does not have necessary flags. if possible upgrading it should fix this."
 
-  requires_no_orb_eco_arc:0 "$TRIGGER_FAIL$Can't build in a system with the $orbital_artificial_eco_3$."
-  requires_no_macro_test_site:0 "$TRIGGER_FAIL$Can't build in a system with the $macro_test_site_3$."
-  requires_no_atmosphere_shredder:0 "$TRIGGER_FAIL$Can't build in a system with the $atmosphere_shredder_3$."
-  requires_no_planetary_seeder_nexus:0 "$TRIGGER_FAIL$Can't build in a system with the $planetary_seeder_nexus_3$."
+  requires_no_orb_eco_arc:0 "$TRIGGER_FAIL$Can't build in a system with the $name_orbital_artificial_eco$."
+  requires_no_macro_test_site:0 "$TRIGGER_FAIL$Can't build in a system with the $name_eng_test_site$."
+  requires_no_atmosphere_shredder:0 "$TRIGGER_FAIL$Can't build in a system with the $name_atmosphere_shredder$."
+  requires_no_planetary_seeder_nexus:0 "$TRIGGER_FAIL$Can't build in a system with the $name_planetary_seeder_nexus$."
 
   cant_fire_without_target:0 "$TRIGGER_FAIL$The $name_ndb$ needs a Warp Gate or a Planetary Target Marker in order to fire."
   cant_explode_two_bombs_at_once:0 "$TRIGGER_FAIL$Can't have two Subspace Distortion Bombs detonating at the same time!"


### PR DESCRIPTION
- Updated can_orbitable_repair_ships overwrite (also fixed typo in placeholder trigger)
- Kilostructure ideal system locators now only show systems actually containing a planet where the structure can be built. 
- Science kilo ideal system locator no longer shows systems containing an Arc Furnace or Planetary Seeder Nexus
- Arc Furnace/Planetary Seeder Nexus ideal system locators no longer show systems containing a science kilostructure
- Improved some loc related to kilostructure placement rules
- Planetary Seeder Nexus can no longer be wastefully built in a system with a science kilo
